### PR TITLE
feat: propose slot interfaces

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/concern/HasDynamicSlots.java
+++ b/dwcj-engine/src/main/java/org/dwcj/concern/HasDynamicSlots.java
@@ -1,0 +1,39 @@
+package org.dwcj.concern;
+
+import org.dwcj.component.Component;
+
+/**
+ * This interface defines methods that shall be implemented by components that offer dynamic slots.
+ * Such UI components could be Tab Control, Carousel, Accordion and similar, where the developer can
+ * add (and remove) slots at runtime.
+ *
+ * @param <T> the component it implements
+ */
+public interface HasDynamicSlots<T extends Component> extends HasSlots {
+
+
+  /**
+   * Adds a slot to the component.
+   *
+   * @param slotName a name representing the dynamic slot to add
+   * @return the component itself
+   */
+  T createSlot(String slotName);
+
+  /**
+   * Deletes one of the slots that had been created dynamically.
+   *
+   * @param slotName - the slot to be deleted
+   * @return - the component itself
+   */
+  T removeSlot(String slotName);
+
+  /**
+   * Method that returns the current slot count. (TBD The count can also be determined outside by
+   * retrieving the slot list and counting the items. This method proposes developer convenience)
+   *
+   * @return the number of slots the component supports
+   */
+  int getNumSlots();
+
+}

--- a/dwcj-engine/src/main/java/org/dwcj/concern/HasSlots.java
+++ b/dwcj-engine/src/main/java/org/dwcj/concern/HasSlots.java
@@ -1,0 +1,49 @@
+package org.dwcj.concern;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.dwcj.component.Component;
+
+/**
+ * Interface defining methods to be implemented by components that have multiple slots Slots can be
+ * filled with components.
+ *
+ * @param <T> the components implementing this interface.
+ * @see HasDynamicSlots for components that support dynamic slot creation and removal at runtime
+ */
+public interface HasSlots<T extends Component> {
+
+  /**
+   * This method returns the list of defined slots. An empty string in the list represents the
+   * default slot (if such exists). If a component supports dynamic slots, the list is dynamic.
+   *
+   * @return a list of the defined slots.
+   */
+  default List<String> getSlots() {
+    // in the trivial case, we have one default slot
+    List<String> al = new ArrayList<>();
+    al.add("");
+    return al;
+  }
+
+  /**
+   * Adds a component into a named slot.
+   *
+   * @param slot The slot to which the component should be added.
+   * @param c The component to add into the slow
+   * @return the component itself
+   */
+  T add(String slot, Component c);
+
+  /**
+   * Adds a component into the default slot. This method coincides with the add method of Panel and
+   * Frame on purpose.
+   *
+   * @param c the component to add
+   * @return this component itself
+   */
+  default T add(Component c) {
+    return add("", c);
+  }
+
+}


### PR DESCRIPTION
I'd like to discuss introducing an interface along the lines of this draft, so we can rely on coherent method names in developer tools. While the WebComponent class currently deals with slots, we in reality have slots in many more places:

Frame and Panel each have a default "slot" = the area holding the components you put on the screen
A Button has a Prefix and a Suffix that can hold Icons, and potentially even the main text is in reality a "Slot"
A TabControl, Carousel, Accordion may offer a dynamic set of slots, created at runtime
So while anything based on a WebComponent already supports slots (like the Shoelace Card sample), we have no strict way to reliably define method names for adding stuff to slots or for creating and removing slots in components that allow that at runtime.
HasSlots - an Interface for controls that bring a predetermined set of slots, like a card
HasDynamicSlots - adds the methods suggested for adding and removing slots at runtime

Points to discuss (in addition to the idea itself):

Use String to represent slots (for simplicity), or do we need a separate Slot class representing a slot?
How about avoiding duplication of purpose - addTab and addSlot in case of a Tab control for instance. Is this a problem?
Are there clean, viable alternatives to using Interfaces similar to this proposal?