### PR TITLE
fix: MavenBinaryInstaller Setting loose POSIX file permissions is sec…

### DIFF
--- a/webforj-plugins/webforj-install-bbj-plugin/pom.xml
+++ b/webforj-plugins/webforj-install-bbj-plugin/pom.xml
@@ -35,6 +35,10 @@
       <version>2.15.1</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.basis.lib</groupId>
       <artifactId>BBjAdminAPI</artifactId>
       <version>24.00-SNAPSHOT</version>

--- a/webforj-plugins/webforj-install-bbj-plugin/src/main/java/com/webforj/installer/MavenBinaryInstaller.java
+++ b/webforj-plugins/webforj-install-bbj-plugin/src/main/java/com/webforj/installer/MavenBinaryInstaller.java
@@ -101,11 +101,7 @@ public class MavenBinaryInstaller {
       perms.remove(PosixFilePermission.OTHERS_WRITE); // Compliant
       perms.add(PosixFilePermission.OTHERS_EXECUTE); // Compliant
 
-      Path binDirectory = Path.of(directory, BINDIR, "bin");
-
-      Files.setPosixFilePermissions(binDirectory.resolve("mvn.cmd"), perms);
-      Files.setPosixFilePermissions(binDirectory.resolve("mvn"), perms);
-
+      Files.setPosixFilePermissions(Path.of(directory, BINDIR, "bin", "mvn"), perms);
     }
 
 

--- a/webforj-plugins/webforj-install-bbj-plugin/src/main/java/com/webforj/installer/WebforjInstaller.java
+++ b/webforj-plugins/webforj-install-bbj-plugin/src/main/java/com/webforj/installer/WebforjInstaller.java
@@ -1,28 +1,41 @@
 package com.webforj.installer;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 import com.basis.api.admin.BBjAdminAppDeploymentApplication;
 import com.basis.api.admin.BBjAdminAppDeploymentConfiguration;
 import com.basis.api.admin.BBjAdminBase;
 import com.basis.api.admin.BBjAdminFactory;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.maven.shared.invoker.*;
-
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
 
 
 /**

--- a/webforj-plugins/webforj-install-bbj-plugin/src/main/resources/log4j2.xml
+++ b/webforj-plugins/webforj-install-bbj-plugin/src/main/resources/log4j2.xml
@@ -20,7 +20,7 @@
     >
       <PatternLayout pattern="${LOG_PATTERN}"/>
       <Policies>
-        <SizeBasedTriggeringPolicy size="500KB"/>
+        <SizeBasedTriggeringPolicy size="1024KB"/>
       </Policies>
 
       <DefaultRolloverStrategy max="5"/>

--- a/webforj-plugins/webforj-install-bbj-plugin/src/main/resources/log4j2.xml
+++ b/webforj-plugins/webforj-install-bbj-plugin/src/main/resources/log4j2.xml
@@ -20,7 +20,7 @@
     >
       <PatternLayout pattern="${LOG_PATTERN}"/>
       <Policies>
-        <SizeBasedTriggeringPolicy size="1024KB"/>
+        <SizeBasedTriggeringPolicy size="500KB"/>
       </Policies>
 
       <DefaultRolloverStrategy max="5"/>


### PR DESCRIPTION
…urity-sensitive java:S2612 #532

- added commons-lang3 dependency to webforj-install-bbj-plugin pom.xml
- using SystemUtils to test for MAC or Linux systems, avoiding setting posix permissions on windows.
- Using PosixFilePermission constants to set the permissions for mvn and mvn.cmd to rwxr-xr-x
- clean up imports.