### PR TITLE
feat: Add webforJ Interval similar to Swing Timer

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/Interval.java
+++ b/webforj-foundation/src/main/java/com/webforj/Interval.java
@@ -1,0 +1,211 @@
+package com.webforj;
+
+import com.basis.bbj.proxies.BBjAPI;
+import com.basis.bbj.proxies.event.BBjEvent;
+import com.basis.startup.type.BBjException;
+import com.basis.startup.type.CustomObject;
+import com.basis.util.common.BasisNumber;
+import com.webforj.dispatcher.EventDispatcher;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+import com.webforj.exceptions.WebforjRuntimeException;
+import java.util.EventObject;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Represents a timer that triggers an event with a fixed time delay between each triggering.
+ *
+ * <p>
+ * The Interval class provides a straightforward way to trigger events after a specified delay. It
+ * can be started, stopped, and restarted as needed. Additionally, the Interval can support multiple
+ * listeners for the elapsed event. Optimized for the webforJ framework, it offers better
+ * performance compared to the standard Java timer or the Swing timer.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.02
+ */
+public final class Interval {
+  private String key = "";
+  private float delay = 0;
+  private EventDispatcher dispatcher = new EventDispatcher();
+  private boolean running = false;
+
+  /**
+   * Create a new instance of the interval.
+   *
+   * @param delay Specifies the timeout value in seconds. Fractional seconds are allowed to
+   *        millisecond resolution, but a very small timeout value will cause a flood of events
+   *        faster than the program can respond to them.
+   * @param listener the listener to be added to the interval
+   */
+  public Interval(float delay, EventListener<ElapsedEvent> listener) {
+    setDelay(delay);
+
+    if (listener != null) {
+      addElapsedListener(listener);
+    }
+  }
+
+  /**
+   * Sets the delay of the interval.
+   *
+   * <p>
+   * Specifies the timeout value in seconds. Fractional seconds are allowed to millisecond
+   * resolution, but a very small timeout value will cause a flood of events faster than the program
+   * can respond to them.
+   * </p>
+   *
+   * <p>
+   * The delay must be greater than or equal to 0. If the timer is running, the delay will be
+   * updated after the timer is stopped and restarted.
+   * </p>
+   *
+   * @param delay the delay of the interval
+   */
+  public void setDelay(float delay) {
+    if (delay < 0) {
+      throw new IllegalArgumentException("The delay must be greater than or equal to 0");
+    }
+
+    this.delay = delay;
+  }
+
+  /**
+   * Gets the delay of the interval.
+   *
+   * @return the delay of the interval
+   */
+  public float getDelay() {
+    return delay;
+  }
+
+  /**
+   * Start the interval.
+   *
+   * <p>
+   * If the interval is already running, this method will do nothing.
+   * </p>
+   */
+  public void start() {
+    if (isRunning()) {
+      return;
+    }
+
+    key = UUID.randomUUID().toString();
+    BBjAPI api = getEnvironment().getBBjAPI();
+
+    try {
+      CustomObject handler = getEnvironment().getWebforjHelper().getEventProxy(this, "handleEvent");
+      api.createTimer(key, BasisNumber.createBasisNumber(getDelay()), handler, "onEvent");
+      running = true;
+    } catch (NumberFormatException | BBjException e) {
+      throw new WebforjRuntimeException("Failed to create the timer with the key '" + key + "'", e);
+    }
+  }
+
+  /**
+   * Stop the interval.
+   *
+   * <p>
+   * If the interval is not running, this method will do nothing.
+   * </p>
+   */
+  public void stop() {
+    if (!isRunning()) {
+      return;
+    }
+
+    BBjAPI api = getEnvironment().getBBjAPI();
+    try {
+      api.removeTimer(key);
+      running = false;
+    } catch (BBjException e) {
+      throw new WebforjRuntimeException("Failed to remove the timer with the key '" + key + "'", e);
+    }
+  }
+
+  /**
+   * Restart the interval.
+   */
+  public void restart() {
+    stop();
+    start();
+  }
+
+  /**
+   * Check if the interval is running.
+   *
+   * @return true if the interval is running, false otherwise
+   */
+  public boolean isRunning() {
+    return running;
+  }
+
+  /**
+   * Adds a listener to the interval.
+   *
+   * @param listener the listener
+   * @return A listener registration for removing the event listener
+   */
+  public ListenerRegistration<ElapsedEvent> addElapsedListener(
+      EventListener<ElapsedEvent> listener) {
+    return dispatcher.addListener(ElapsedEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addElapsedListener(EventListener)}.
+   *
+   * @param listener the listener
+   * @return A listener registration for removing the event listener
+   */
+  public ListenerRegistration<ElapsedEvent> onElapsed(EventListener<ElapsedEvent> listener) {
+    return addElapsedListener(listener);
+  }
+
+  /**
+   * Gets the list of elapsed listeners.
+   *
+   * @return the list of elapsed listeners
+   */
+  public List<EventListener<ElapsedEvent>> getElapsedListeners() {
+    return dispatcher.getListeners(ElapsedEvent.class);
+  }
+
+  public void handleEvent(BBjEvent ev) {
+    dispatcher.dispatchEvent(new ElapsedEvent(this));
+  }
+
+  Environment getEnvironment() {
+    return Environment.getCurrent();
+  }
+
+  /**
+   * Represents a time up event.
+   *
+   * @author Hyyan
+   * @since 24.02
+   */
+  public class ElapsedEvent extends EventObject {
+
+    /**
+     * Create a new instance of the event.
+     *
+     * @param source the source of the event
+     */
+    public ElapsedEvent(Object source) {
+      super(source);
+    }
+
+    /**
+     * Get the interval that triggered the event.
+     *
+     * @return the interval instance
+     */
+    public Interval getInterval() {
+      return (Interval) getSource();
+    }
+  }
+}
+

--- a/webforj-foundation/src/main/java/com/webforj/Interval.java
+++ b/webforj-foundation/src/main/java/com/webforj/Interval.java
@@ -33,7 +33,7 @@ public final class Interval {
   private boolean running = false;
 
   /**
-   * Create a new instance of the interval.
+   * Creates a new instance of the interval.
    *
    * @param delay Specifies the timeout value in seconds. Fractional seconds are allowed to
    *        millisecond resolution, but a very small timeout value will cause a flood of events
@@ -82,7 +82,7 @@ public final class Interval {
   }
 
   /**
-   * Start the interval.
+   * Starts the interval.
    *
    * <p>
    * If the interval is already running, this method will do nothing.
@@ -106,7 +106,7 @@ public final class Interval {
   }
 
   /**
-   * Stop the interval.
+   * Stops the interval.
    *
    * <p>
    * If the interval is not running, this method will do nothing.
@@ -127,7 +127,7 @@ public final class Interval {
   }
 
   /**
-   * Restart the interval.
+   * Restarts the interval.
    */
   public void restart() {
     stop();
@@ -135,7 +135,7 @@ public final class Interval {
   }
 
   /**
-   * Check if the interval is running.
+   * Checks if the interval is running.
    *
    * @return true if the interval is running, false otherwise
    */
@@ -190,7 +190,7 @@ public final class Interval {
   public class ElapsedEvent extends EventObject {
 
     /**
-     * Create a new instance of the event.
+     * Creates a new instance of the event.
      *
      * @param source the source of the event
      */
@@ -199,7 +199,7 @@ public final class Interval {
     }
 
     /**
-     * Get the interval that triggered the event.
+     * Gets the interval that triggered the event.
      *
      * @return the interval instance
      */

--- a/webforj-foundation/src/test/java/com/webforj/IntervalTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/IntervalTest.java
@@ -1,0 +1,100 @@
+package com.webforj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.basis.bbj.proxies.BBjAPI;
+import com.basis.startup.type.BBjException;
+import com.basis.util.common.BasisNumber;
+import com.webforj.bridge.WebforjBBjBridge;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IntervalTest {
+  Interval interval;
+  Environment environment;
+  BBjAPI api;
+  WebforjBBjBridge bridge;
+  EventListener<Interval.ElapsedEvent> listener;
+
+  @BeforeEach
+  void setUp() throws BBjException {
+    environment = mock(Environment.class);
+    api = mock(BBjAPI.class);
+    bridge = mock(WebforjBBjBridge.class);
+    listener = mock(EventListener.class);
+
+    when(environment.getBBjAPI()).thenReturn(api);
+    when(environment.getWebforjHelper()).thenReturn(bridge);
+
+    interval = spy(new Interval(1.0f, listener));
+    doReturn(environment).when(interval).getEnvironment();
+  }
+
+  @Test
+  void shouldSetDelay() {
+    interval.setDelay(2.0f);
+    assertEquals(2.0f, interval.getDelay());
+
+    assertThrows(IllegalArgumentException.class, () -> interval.setDelay(-1.0f));
+  }
+
+  @Test
+  void shouldStartInterval() throws BBjException {
+    interval.start();
+    assertTrue(interval.isRunning());
+    verify(api, times(1)).createTimer(anyString(), any(BasisNumber.class), any(), eq("onEvent"));
+  }
+
+  @Test
+  void shouldNotStartWhenAlreadyRunning() throws BBjException {
+    interval.start();
+    interval.start();
+    verify(api, times(1)).createTimer(anyString(), any(BasisNumber.class), any(), eq("onEvent"));
+  }
+
+  @Test
+  void shouldStopInterval() throws BBjException {
+    interval.start();
+    interval.stop();
+    assertFalse(interval.isRunning());
+    verify(api, times(1)).removeTimer(anyString());
+  }
+
+  @Test
+  void shouldNotStopWhenNotRunning() throws BBjException {
+    interval.stop();
+    verify(api, times(0)).removeTimer(anyString());
+  }
+
+  @Test
+  void shouldRestartInterval() throws BBjException {
+    interval.start();
+    interval.restart();
+    verify(api, times(1)).removeTimer(anyString());
+    verify(api, times(2)).createTimer(anyString(), any(BasisNumber.class), any(), eq("onEvent"));
+  }
+
+  @Test
+  void shouldAddElapsedListener() {
+    ListenerRegistration<Interval.ElapsedEvent> registration =
+        interval.addElapsedListener(listener);
+    assertNotNull(registration);
+    assertEquals(2, interval.getElapsedListeners().size());
+  }
+}
+


### PR DESCRIPTION
webforJ Timer implementation based on BBj timers

```java
  Interval interval = new Interval(0.1f, new EventListener<Interval.ElapsedEvent>() {
    private int progress = 0;

    @Override
    public void onEvent(Interval.ElapsedEvent event) {
      progress++;
      bar.setValue(progress);

      if (progress >= bar.getMax()) {
        event.getInterval().stop();
      }
    }
  });

  interval.start();
```