### PR TITLE
feat: add helper text support to components list and optioninput components

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/list/DwcList.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/DwcList.java
@@ -12,6 +12,7 @@ import com.webforj.component.event.EventSinkListenerRegistry;
 import com.webforj.component.list.event.ListSelectEvent;
 import com.webforj.component.list.sink.ListSelectEventSink;
 import com.webforj.concern.HasExpanse;
+import com.webforj.concern.HasHelperText;
 import com.webforj.concern.HasHorizontalAlignment;
 import com.webforj.concern.HasLabel;
 import com.webforj.dispatcher.EventListener;
@@ -47,7 +48,7 @@ import java.util.Optional;
  */
 public abstract class DwcList<T extends DwcValidatableComponent<T, V>, V>
     extends DwcValidatableComponent<T, V> implements Iterable<ListItem>, HasLabel<T>,
-    HasExpanse<T, Expanse>, HasHorizontalAlignment<T>, SelectableList<T> {
+    HasExpanse<T, Expanse>, HasHorizontalAlignment<T>, SelectableList<T>, HasHelperText<T> {
   private static final String DUPLICATION_ITEM_MESSAGE = "Item is already in the list";
   private static final String ITEM_MISSING_MESSAGE = "Item is not in the list";
   private static final String INVALID_INDEX_MESSAGE = "Invalid item index '%d'";
@@ -61,6 +62,7 @@ public abstract class DwcList<T extends DwcValidatableComponent<T, V>, V>
           ListSelectEvent.class);
 
   private String label = "";
+  private String helperText = "";
 
   protected DwcList() {
     super();
@@ -625,6 +627,24 @@ public abstract class DwcList<T extends DwcValidatableComponent<T, V>, V>
   @ExcludeFromJacocoGeneratedReport
   public Alignment getHorizontalAlignment() {
     return getComponentHorizontalAlignment();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T setHelperText(String helperText) {
+    this.helperText = helperText;
+    setUnrestrictedProperty("helperText", this.helperText);
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getHelperText() {
+    return this.helperText;
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/optioninput/DwcOptionInput.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optioninput/DwcOptionInput.java
@@ -16,6 +16,7 @@ import com.webforj.component.event.sink.ToggleEventSink;
 import com.webforj.component.event.sink.UncheckEventSink;
 import com.webforj.concern.HasExpanse;
 import com.webforj.concern.HasFocusStatus;
+import com.webforj.concern.HasHelperText;
 import com.webforj.concern.HasTextPosition;
 import com.webforj.data.event.ValueChangeEvent;
 import com.webforj.dispatcher.EventListener;
@@ -42,7 +43,7 @@ import com.webforj.exceptions.WebforjRuntimeException;
  */
 public abstract class DwcOptionInput<T extends DwcValidatableComponent<T, Boolean> & HasTextPosition<T>>
     extends DwcValidatableComponent<T, Boolean>
-    implements HasTextPosition<T>, HasExpanse<T, Expanse>, HasFocusStatus {
+    implements HasTextPosition<T>, HasExpanse<T, Expanse>, HasFocusStatus, HasHelperText<T> {
 
   private final EventSinkListenerRegistry<CheckEvent> checkEventSinkListenerRegistry =
       new EventSinkListenerRegistry<>(new CheckEventSink(this, getEventDispatcher()),
@@ -57,6 +58,7 @@ public abstract class DwcOptionInput<T extends DwcValidatableComponent<T, Boolea
   private HasTextPosition.Position textPosition = HasTextPosition.Position.RIGHT;
   private boolean checked = false;
   private boolean registeredToggleValueChangeListener = false;
+  private String helperText = "";
 
   /**
    * Creates a new AbstractOptionInput component.
@@ -192,6 +194,24 @@ public abstract class DwcOptionInput<T extends DwcValidatableComponent<T, Boolea
   @ExcludeFromJacocoGeneratedReport
   public boolean hasFocus() {
     return componentHasFocus();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T setHelperText(String helperText) {
+    this.helperText = helperText;
+    setUnrestrictedProperty("helperText", this.helperText);
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getHelperText() {
+    return this.helperText;
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/concern/HasHelperText.java
+++ b/webforj-foundation/src/main/java/com/webforj/concern/HasHelperText.java
@@ -1,0 +1,48 @@
+package com.webforj.concern;
+
+import com.webforj.component.Component;
+import com.webforj.component.ComponentUtil;
+
+/**
+ * An interface that allows components to set and retrieve helper text in a way that makes sense for
+ * the specific component.
+ *
+ * @param <T> the type of the component that implements this interface.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.10
+ */
+public interface HasHelperText<T extends Component> {
+
+  /**
+   * Retrieves the helper text of the component.
+   *
+   * @return the helper text of the component.
+   */
+  public default String getHelperText() {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasHelperText) {
+      return ((HasHelperText<?>) component).getHelperText();
+    }
+
+    throw new UnsupportedOperationException("The component does not support helper text");
+  }
+
+  /**
+   * Sets the helper text of the component.
+   *
+   * @param helperText the helper text to set for the component.
+   * @return the component itself after configuring the helper text.
+   */
+  public default T setHelperText(String helperText) {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasHelperText) {
+      ((HasHelperText<?>) component).setHelperText(helperText);
+      return (T) this;
+    }
+
+    throw new UnsupportedOperationException("The component does not support helper text");
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/component/list/DwcListTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/DwcListTest.java
@@ -21,6 +21,7 @@ import com.webforj.component.list.event.ListSelectEvent;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.exceptions.WebforjRuntimeException;
+import java.sql.Ref;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -403,5 +404,15 @@ class DwcListTest {
 
     r.remove();
     assertEquals(0, component.getEventListeners(ListSelectEvent.class).size());
+  }
+
+  @Test
+  void shouldSetGetHelperText() throws IllegalAccessException {
+    ReflectionUtils.nullifyControl(component);
+
+    component.setHelperText("helper text");
+    assertEquals("helper text", component.getHelperText());
+
+    assertEquals("helper text", component.getProperty("helperText"));
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/component/optioninput/DwcOptionInputTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/optioninput/DwcOptionInputTest.java
@@ -43,26 +43,6 @@ class DwcOptionInputTest {
   @InjectMocks
   DwcOptionInputMock component;
 
-  @Test
-  @DisplayName("adding supported events")
-  void addingSupportedEvents() {
-    EventListener<CheckEvent> checkListener = event -> {
-    };
-    EventListener<UncheckEvent> uncheckListener = event -> {
-    };
-    EventListener<ToggleEvent> toggleListener = event -> {
-    };
-
-    component.onCheck(checkListener);
-    component.onUncheck(uncheckListener);
-    component.onToggle(toggleListener);
-
-
-    assertEquals(1, component.getEventListeners(CheckEvent.class).size());
-    assertEquals(1, component.getEventListeners(UncheckEvent.class).size());
-    assertEquals(1, component.getEventListeners(ToggleEvent.class).size());
-  }
-
   @Nested
   @DisplayName("Checked API")
   class CheckedApi {
@@ -194,5 +174,15 @@ class DwcOptionInputTest {
       });
       assertEquals(1, component.getEventListeners(ToggleEvent.class).size());
     }
+  }
+
+  @Test
+  void shouldSetGetHelperText() throws IllegalAccessException {
+    ReflectionUtils.nullifyControl(component);
+
+    component.setHelperText("helper text");
+    assertEquals("helper text", component.getHelperText());
+
+    assertEquals("helper text", component.getProperty("helperText"));
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
@@ -23,7 +23,7 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
     HasValue<ConcernComponentMock, Double>, HasClientValidation<ConcernComponentMock>,
     HasClientValidationStyle<ConcernComponentMock>, HasClientAutoValidation<ConcernComponentMock>,
     HasClientAutoValidationOnLoad<ConcernComponentMock>, HasRequired<ConcernComponentMock>,
-    HasPattern<ConcernComponentMock> {
+    HasPattern<ConcernComponentMock>, HasHelperText<ConcernComponentMock> {
 
   private Map<String, String> attributes = new HashMap<>();
   private Map<String, Object> properties = new HashMap<>();
@@ -52,6 +52,7 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
   private boolean autoValidateOnLoad = false;
   private boolean required = false;
   private String pattern = null;
+  private String helperText;
 
   @Override
   public String getAttribute(String attribute) {
@@ -381,6 +382,17 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
   @Override
   public String getPattern() {
     return this.pattern;
+  }
+
+  @Override
+  public ConcernComponentMock setHelperText(String helperText) {
+    this.helperText = helperText;
+    return this;
+  }
+
+  @Override
+  public String getHelperText() {
+    return this.helperText;
   }
 
   @Override

--- a/webforj-foundation/src/test/java/com/webforj/concern/HasHelperTextTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/HasHelperTextTest.java
@@ -1,0 +1,28 @@
+package com.webforj.concern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.webforj.component.Composite;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HasHelperTextTest {
+
+  private CompositeMock component;
+
+  @BeforeEach
+  void setup() {
+    component = new CompositeMock();
+  }
+
+  @Test
+  void shouldSetGetText() {
+    assertSame(component.setHelperText("Hello, World!"), component);
+    assertEquals("Hello, World!", component.getHelperText());
+  }
+
+  class CompositeMock extends Composite<ConcernComponentMock>
+      implements HasHelperText<CompositeMock> {
+  }
+}


### PR DESCRIPTION
All List and Option Input components support optional helper text that appears beneath the input, providing relevant information or a description of the input or option.

For instance: 

```java
  ChoiceBox choice = new ChoiceBox("Department");
  choice.insert("Electronics", "Health and Beauty", "Fashion", "Kitchen", "Furniture",
      "Pet Supplies", "Toys and Games");
  choice.selectIndex(0);
  choice.setHelperText("What is your department?");
```