### PR TITLE
refactor: mark `consoleLog` and `consoleError` methods deprecated

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/App.java
+++ b/webforj-foundation/src/main/java/com/webforj/App.java
@@ -296,10 +296,12 @@ public abstract class App {
   }
 
   /**
-   * Log a String to the browser console (console.out)
+   * Log a String to the browser console (console.log)
    *
    * @param output The message to log
+   * @deprecated since 24.10, for removal in 25.00. Use {@link BrowserConsole#log(String)} instead
    */
+  @Deprecated(since = "24.10", forRemoval = true)
   public static void consoleLog(String output) {
     try {
 
@@ -309,6 +311,13 @@ public abstract class App {
     }
   }
 
+  /**
+   * Log a String to the browser console (console.error)
+   *
+   * @param output The message to log
+   * @deprecated since 24.10, for removal in 25.00. Use {@link BrowserConsole#error(String)} instead
+   */
+  @Deprecated(since = "24.10", forRemoval = true)
   public static void consoleError(String output) {
     try {
 


### PR DESCRIPTION
see #494 , #624

| Deprecated Method                  | Deprecated Since | Scheduled for Removal | Use Instead                   |
|------------------------------------|------------------|-----------------------|-------------------------------|
| `public static void consoleLog(String output)` | 24.10            | 25.00                 | `BrowserConsole.log(String)`   |
| `public static void consoleError(String output)` | 24.10            | 25.00                 | `BrowserConsole.error(String)` |
