### PR TITLE
feat: add page unload event listener to Page class

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/event/page/PageUnloadEvent.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/page/PageUnloadEvent.java
@@ -1,0 +1,38 @@
+package com.webforj.event.page;
+
+import com.webforj.Page;
+import java.util.EventObject;
+
+/**
+ * An event that indicates that a page is unloaded by the browser.
+ *
+ * <p>
+ * This event is fired when the browser unloads a page which can happen in different scenarios such
+ * as when the user navigates to another page, closes the browser, refreshes the page, etc.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.10
+ */
+public class PageUnloadEvent extends EventObject {
+  transient Page page;
+
+  /**
+   * Construct a new PageUnloadEvent.
+   *
+   * @param source the page that is being unloaded
+   */
+  public PageUnloadEvent(Page source) {
+    super(source);
+    this.page = source;
+  }
+
+  /**
+   * Get the page that is being unloaded.
+   *
+   * @return the page that is being unloaded
+   */
+  public Page getPage() {
+    return page;
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/event/page/PageUnloadEventHandler.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/page/PageUnloadEventHandler.java
@@ -1,0 +1,36 @@
+package com.webforj.event.page;
+
+import com.basis.bbj.proxies.event.BBjEvent;
+import com.webforj.Page;
+import com.webforj.dispatcher.EventDispatcher;
+
+/**
+ * Handler for the Page {@code BBjUnloadEvent} event.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.10
+ */
+public final class PageUnloadEventHandler {
+  EventDispatcher dispatcher;
+  Page page;
+
+  /**
+   * Construct a new PageUnloadEventHandler.
+   *
+   * @param page the page that is being unloaded
+   * @param dispatcher the event dispatcher
+   */
+  public PageUnloadEventHandler(Page page, EventDispatcher dispatcher) {
+    this.page = page;
+    this.dispatcher = dispatcher;
+  }
+
+  /**
+   * Handle the event.
+   *
+   * @param ev the event
+   */
+  public void handleEvent(BBjEvent ev) {
+    dispatcher.dispatchEvent(new PageUnloadEvent(page));
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/PageTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/PageTest.java
@@ -21,8 +21,12 @@ import com.basis.bbj.proxies.BBjClientFileSystem;
 import com.basis.bbj.proxies.BBjSysGui;
 import com.basis.bbj.proxies.BBjThinClient;
 import com.basis.bbj.proxies.BBjWebManager;
+import com.basis.bbj.proxyif.SysGuiEventConstants;
 import com.basis.startup.type.BBjException;
 import com.webforj.bridge.WebforjBBjBridge;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+import com.webforj.event.page.PageUnloadEvent;
 import com.webforj.exceptions.WebforjRuntimeException;
 import java.io.File;
 import java.io.InputStream;
@@ -220,6 +224,29 @@ class PageTest {
     void shouldOpenUrl() throws BBjException {
       page.open("http://example.com");
       verify(thinClient).browse("http://example.com", "_blank", "");
+    }
+  }
+
+  @Nested
+  class UnloadListener {
+
+    @Test
+    void shouldAddUnloadListener() throws BBjException {
+      EventListener<PageUnloadEvent> listener = mock(EventListener.class);
+      ListenerRegistration<PageUnloadEvent> registration = page.onUnload(listener);
+      assertNotNull(registration);
+
+      verify(webManager, times(1)).setCallback(eq(SysGuiEventConstants.ON_BROWSER_CLOSE), any(),
+          eq("onEvent"));
+    }
+
+    @Test
+    void addUnloadListenerShouldThrowException() throws BBjException {
+      doThrow(BBjException.class).when(webManager)
+          .setCallback(eq(SysGuiEventConstants.ON_BROWSER_CLOSE), any(), eq("onEvent"));
+      EventListener<PageUnloadEvent> listener = mock(EventListener.class);
+
+      assertThrows(WebforjRuntimeException.class, () -> page.onUnload(listener));
     }
   }
 }


### PR DESCRIPTION
closes #664 

```java
public class SampleApp extends App {

  @Override
  public void run() throws WebforjException {
    Page.getCurrent().onUnload((event) -> {
      System.out.println("Page is unloading, webforj is shutting down");
    });
  }
}
```