### PR TITLE
feat: allow terminal write methods to accept a complete callback

### DIFF
--- a/webforj-components/webforj-terminal/src/main/java/com/webforj/component/terminal/Terminal.java
+++ b/webforj-components/webforj-terminal/src/main/java/com/webforj/component/terminal/Terminal.java
@@ -180,17 +180,18 @@ public class Terminal extends ElementComposite implements HasSize<Terminal> {
     return this;
   }
 
-  // /**
-  // * Writes data to the terminal.
-  // *
-  // * @param data the data to write
-  // * @param callback callback that fires when the data was processed by the parser
-  // *
-  // * @return the component itself
-  // */
-  // public Terminal write(Object data, Consumer<Object> callback) {
-  // return doWrite(JS_METHOD_WRITE, data, callback);
-  // }
+  /**
+   * Writes data to the terminal.
+   *
+   * @param data the data to write
+   * @param callback callback that fires when the data was processed by the parser
+   *
+   * @return the component itself
+   */
+  public Terminal write(Object data, Consumer<Object> callback) {
+    getOriginalElement().callJsFunctionAsync(JS_METHOD_WRITE, data).thenAccept(callback);
+    return this;
+  }
 
   /**
    * Writes data to the terminal.
@@ -199,20 +200,22 @@ public class Terminal extends ElementComposite implements HasSize<Terminal> {
    * @return the component itself
    */
   public Terminal write(Object data) {
-    return doWrite(JS_METHOD_WRITE, data, null);
+    getOriginalElement().callJsFunctionVoidAsync(JS_METHOD_WRITE, data);
+    return this;
   }
 
-  // /**
-  // * Writes data to the terminal followed by a new line.
-  // *
-  // * @param data the data to write
-  // * @param callback callback that fires when the data was processed by the parser
-  // *
-  // * @return the component itself
-  // */
-  // public Terminal writeln(Object data, Consumer<Object> callback) {
-  // return doWrite(JS_METHOD_WRITELN, data, callback);
-  // }
+  /**
+   * Writes data to the terminal followed by a new line.
+   *
+   * @param data the data to write
+   * @param callback callback that fires when the data was processed by the parser
+   *
+   * @return the component itself
+   */
+  public Terminal writeln(Object data, Consumer<Object> callback) {
+    getOriginalElement().callJsFunctionAsync(JS_METHOD_WRITELN, data).thenAccept(callback);
+    return this;
+  }
 
   /**
    * Writes data to the terminal followed by a new line.
@@ -221,7 +224,8 @@ public class Terminal extends ElementComposite implements HasSize<Terminal> {
    * @return the component itself
    */
   public Terminal writeln(Object data) {
-    return doWrite(JS_METHOD_WRITELN, data, null);
+    getOriginalElement().callJsFunctionVoidAsync(JS_METHOD_WRITELN, data);
+    return this;
   }
 
   /**
@@ -402,34 +406,5 @@ public class Terminal extends ElementComposite implements HasSize<Terminal> {
   Element getOriginalElement() {
     return getElement();
   }
-
-  Terminal doWrite(String type, Object data, Consumer<Object> callback) {
-    // boolean hasCallback = callback != null;
-
-    // Gson gson = new Gson();
-    // String dataStr = gson.toJson(data);
-    // String base64Data = Base64.getEncoder().encodeToString(dataStr.getBytes());
-    // String script = String.format("""
-    // (async () => {
-    // await customElements.whenDefined('dwc-terminal');
-    // const type = '%s';
-    // const hasCallback = %s;
-    // const data = JSON.parse(atob('%s'));
-    // if (hasCallback) {
-    // return await component[type](data);
-    // } else {
-    // component[type](data);
-    // }
-    // })();
-    // """, type, Boolean.toString(hasCallback), base64Data);
-
-    // getElement().executeJsAsync(script).thenAccept(obj -> {
-    // if (hasCallback) {
-    // callback.accept(data);
-    // }
-    // });
-
-    getElement().whenDefined().thenAccept(component -> component.callJsFunction(type, data));
-    return this;
-  }
 }
+

--- a/webforj-components/webforj-terminal/src/test/java/com/webforj/component/terminal/TerminalTest.java
+++ b/webforj-components/webforj-terminal/src/test/java/com/webforj/component/terminal/TerminalTest.java
@@ -68,6 +68,58 @@ class TerminalTest {
     }
 
     @Test
+    void shouldWriteVoid() {
+      Terminal mock = spy(Terminal.class);
+      Element element = mock(Element.class);
+      when(mock.getOriginalElement()).thenReturn(element);
+
+      String text = "Hello";
+      mock.write(text);
+      verify(element).callJsFunctionVoidAsync(Terminal.JS_METHOD_WRITE, text);
+    }
+
+    @Test
+    void shouldWrite() {
+      Terminal mock = spy(Terminal.class);
+      Element element = mock(Element.class);
+      when(mock.getOriginalElement()).thenReturn(element);
+
+      String text = "Hello";
+      when(element.callJsFunctionAsync(Terminal.JS_METHOD_WRITE, text))
+          .thenReturn(PendingResult.completedWith("Hello"));
+
+      mock.write(text, data -> {
+      });
+      verify(element).callJsFunctionAsync(Terminal.JS_METHOD_WRITE, text);
+    }
+
+    @Test
+    void shouldWritelnVoid() {
+      Terminal mock = spy(Terminal.class);
+      Element element = mock(Element.class);
+      when(mock.getOriginalElement()).thenReturn(element);
+
+      String text = "Hello";
+      mock.writeln(text);
+      verify(element).callJsFunctionVoidAsync(Terminal.JS_METHOD_WRITELN, text);
+    }
+
+    @Test
+    void shouldWriteln() {
+      Terminal mock = spy(Terminal.class);
+      Element element = mock(Element.class);
+      when(mock.getOriginalElement()).thenReturn(element);
+
+      String text = "Hello";
+      when(element.callJsFunctionAsync(Terminal.JS_METHOD_WRITELN, text))
+          .thenReturn(PendingResult.completedWith("Hello"));
+
+      mock.writeln(text, data -> {
+      });
+      verify(element).callJsFunctionAsync(Terminal.JS_METHOD_WRITELN, text);
+    }
+
+    @Test
     void shouldClear() {
       Terminal mock = spy(Terminal.class);
       Element element = mock(Element.class);


### PR DESCRIPTION
The PR introduces new method signatures for `write` and `writeln`, allowing them to accept a callback that is invoked once the parser has finished writing the data.

```java
term.write("", data -> term.writeln("Load test completed"));

term.writeln("", data -> term.write("$ "));
```