### PR TITLE
fix: `isReadOnly` does accurately reflect read-only status

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/DwcComponent.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/DwcComponent.java
@@ -896,7 +896,7 @@ public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
   protected boolean isComponentReadOnly() {
     if (control instanceof Editable) {
       try {
-        return ((Editable) control).isEditable();
+        return !((Editable) control).isEditable();
       } catch (BBjException e) {
         throw new WebforjRuntimeException(e);
       }

--- a/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
@@ -158,7 +158,7 @@ class DwcComponentTest {
     @Test
     @DisplayName("Setting/getting readonly when control is not null")
     void settingGettingReadOnlyWhenControlIsNotNull() throws BBjException {
-      when(control.isEditable()).thenReturn(true);
+      when(control.isEditable()).thenReturn(false);
       component.setReadOnly(true);
 
       assertTrue(component.isReadOnly());


### PR DESCRIPTION
fixes #677