### PR TITLE
feat: support HTML event registration via the page instance

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/element/annotation/ElementAnnotationProcessor.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/annotation/ElementAnnotationProcessor.java
@@ -70,30 +70,6 @@ public final class ElementAnnotationProcessor {
    * @return The event options
    */
   public static ElementEventOptions processEventOptions(Class<?> clazz) {
-    EventOptions annotation = clazz.getAnnotation(EventOptions.class);
-    ElementEventOptions options = new ElementEventOptions();
-
-    if (annotation != null) {
-      // Set code and filter
-      options.setCode(annotation.code());
-      options.setFilter(annotation.filter());
-
-      // Add the data
-      for (EventOptions.EventData dataItem : annotation.data()) {
-        options.addData(dataItem.key(), dataItem.exp());
-      }
-
-      // Set debounce
-      if (annotation.debounce().value() >= 0) {
-        options.setDebounce(annotation.debounce().value(), annotation.debounce().phase());
-      }
-
-      // Set throttle
-      if (annotation.throttle() >= 0) {
-        options.setThrottle(annotation.throttle());
-      }
-    }
-
-    return options;
+    return EventOptionsAnnotationProcessor.processEventOptions(clazz, new ElementEventOptions());
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/element/annotation/EventOptionsAnnotationProcessor.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/annotation/EventOptionsAnnotationProcessor.java
@@ -1,0 +1,55 @@
+package com.webforj.component.element.annotation;
+
+import com.webforj.component.element.event.ElementEventOptions;
+
+/**
+ * Annotation processor for event options annotations.
+ *
+ * @see EventOptions
+ * @see ElementAnnotationProcessor
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public final class EventOptionsAnnotationProcessor {
+
+  // private constructor to hide the implicit public one
+  private EventOptionsAnnotationProcessor() {}
+
+  /**
+   * A generic method to process event options with a specified instance.
+   *
+   * @param <T> the type of ElementEventOptions or its subclass
+   * @param clazz the class to get the event options from
+   * @param optionsInstance an instance of T where T extends ElementEventOptions
+   *
+   * @return The initialized options instance of type T
+   */
+  public static <T extends ElementEventOptions> T processEventOptions(Class<?> clazz,
+      T optionsInstance) {
+    EventOptions annotation = clazz.getAnnotation(EventOptions.class);
+
+    if (annotation != null) {
+      // Set code and filter
+      optionsInstance.setCode(annotation.code());
+      optionsInstance.setFilter(annotation.filter());
+
+      // Add the data
+      for (EventOptions.EventData dataItem : annotation.data()) {
+        optionsInstance.addData(dataItem.key(), dataItem.exp());
+      }
+
+      // Set debounce
+      if (annotation.debounce().value() >= 0) {
+        optionsInstance.setDebounce(annotation.debounce().value(), annotation.debounce().phase());
+      }
+
+      // Set throttle
+      if (annotation.throttle() >= 0) {
+        optionsInstance.setThrottle(annotation.throttle());
+      }
+    }
+
+    return optionsInstance;
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/component/element/event/ElementEventOptions.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/event/ElementEventOptions.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * @author Hyyan Abo Fakher
  * @since 23.06
  */
-public final class ElementEventOptions {
+public class ElementEventOptions {
 
   private final Map<String, String> data;
   private String code;
@@ -307,18 +307,18 @@ public final class ElementEventOptions {
   }
 
   /**
-   * Merges the current ElementEventOptions instance with other passed instances. This method
-   * updates the current instance's properties with those from the passed instances. For each
-   * setting (items, code, and filter), the last non-empty value encountered will take precedence.
+   * Merges the current EventOptions instance with other passed instances. This method updates the
+   * current instance's properties with those from the passed instances. For each setting (items,
+   * code, and filter), the last non-empty value encountered will take precedence.
    *
    * <p>
    * If any of the objects in the argument list is null, it is safely ignored during the merging
    * process.
    * </p>
    *
-   * @param options Varargs parameter that accepts multiple ElementEventOptions objects. It can be
-   *        passed as separate arguments or as an array of ElementEventOptions.
-   * @return The current ElementEventOptions instance after merging with the passed instances.
+   * @param options Varargs parameter that accepts multiple EventOptions objects. It can be passed
+   *        as separate arguments or as an array of EventOptions.
+   * @return The current EventOptions instance after merging with the passed instances.
    */
   public ElementEventOptions mergeWith(ElementEventOptions... options) {
     if (options == null) {

--- a/webforj-foundation/src/main/java/com/webforj/component/event/EventSinkListenerRegistry.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/event/EventSinkListenerRegistry.java
@@ -7,6 +7,7 @@ import com.webforj.dispatcher.EventDispatcher;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import java.util.ArrayList;
+import java.util.EventObject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +22,7 @@ import java.util.Map;
  * @author Hyyan Abo Fakher
  * @since 24.11
  */
-public class EventSinkListenerRegistry<E extends ComponentEvent<?>, T> {
+public class EventSinkListenerRegistry<E extends EventObject, T> {
   private final DwcEventSink<T> sink;
   private final Class<? super E> event;
   private final List<DwcListenerRegistration> registrations = new ArrayList<>();

--- a/webforj-foundation/src/main/java/com/webforj/event/page/PageEvent.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/page/PageEvent.java
@@ -1,0 +1,94 @@
+package com.webforj.event.page;
+
+import com.webforj.Page;
+import java.util.Collections;
+import java.util.EventObject;
+import java.util.Map;
+
+/**
+ * Represents an event associated with the {@link Page}.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public final class PageEvent extends EventObject {
+  private final transient Map<String, Object> payload;
+  private final transient PageEventOptions options;
+  private final String type;
+  private final int id;
+
+  /**
+   * Creates a new PageEvent instance.
+   *
+   * @param page The page associated with the event.
+   * @param payload A map containing additional data associated with the event.
+   * @param type The type of the event.
+   * @param options The event options.
+   */
+  public PageEvent(Page page, Map<String, Object> payload, String type, int id,
+      PageEventOptions options) {
+    super(page);
+    this.payload = payload;
+    this.type = type;
+    this.id = id;
+    this.options = options;
+  }
+
+  /**
+   * Get the event id.
+   *
+   * @return The event id.
+   */
+  public int getId() {
+    return id;
+  }
+
+  /**
+   * Get the type of the event.
+   *
+   * @return The event type as a string.
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Get the event options.
+   *
+   * @return The event options.
+   */
+  public PageEventOptions getOptions() {
+    return options;
+  }
+
+  /**
+   * Gets the event map sent by the page.
+   *
+   * <p>
+   * The event map is a serializable map from the original client event sent by the page.
+   * </p>
+   *
+   * @return the event map
+   */
+  public Map<String, Object> getData() {
+    return Collections.unmodifiableMap(payload);
+  }
+
+  /**
+   * Alias for {@link #getData()} method.
+   *
+   * @return the event map
+   */
+  public Map<String, Object> getEventMap() {
+    return getData();
+  }
+
+  /**
+   * Gets the page instance associated with the event.
+   *
+   * @return The page instance.
+   */
+  public Page getPage() {
+    return (Page) super.getSource();
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/event/page/PageEventOptions.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/page/PageEventOptions.java
@@ -1,0 +1,120 @@
+package com.webforj.event.page;
+
+import com.webforj.component.element.event.DebouncePhase;
+import com.webforj.component.element.event.ElementEventOptions;
+import java.util.Map;
+
+/**
+ * Represents event options for a page event.
+ *
+ * <p>
+ * This class provides a way to configure and customize event options for the page. Event options
+ * can include items, code to be evaluated on the client-side before an event is fired, and a filter
+ * expression to determine whether an event should be fired or not.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public final class PageEventOptions extends ElementEventOptions {
+
+  /**
+   * Creates a new instance of the event options.
+   *
+   * @param data The event data.
+   * @param code The event code.
+   * @param filter The event filter.
+   */
+  public PageEventOptions(Map<String, String> data, String code, String filter) {
+    super(data, code, filter);
+  }
+
+  /**
+   * Creates a new instance of the event options.
+   *
+   * @param items The event items.
+   * @param code The event code.
+   */
+  public PageEventOptions(Map<String, String> items, String code) {
+    this(items, code, null);
+  }
+
+  /**
+   * Creates a new instance of the event options.
+   *
+   * @param items The event items.
+   */
+  public PageEventOptions(Map<String, String> items) {
+    this(items, null, null);
+  }
+
+  /**
+   * Creates a new instance of the event options with default values.
+   */
+  public PageEventOptions() {
+    this(null, null, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PageEventOptions addData(String name, String expression) {
+    super.addData(name, expression);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PageEventOptions setCode(String expression) {
+    super.setCode(expression);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PageEventOptions setFilter(String expression) {
+    super.setFilter(expression);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PageEventOptions setDebounce(int timeout, DebouncePhase phase) {
+    super.setDebounce(timeout, phase);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PageEventOptions setDebounce(int timeout) {
+    super.setDebounce(timeout);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PageEventOptions setThrottle(int timeout) {
+    super.setThrottle(timeout);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PageEventOptions mergeWith(ElementEventOptions... options) {
+    super.mergeWith(options);
+    return this;
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/sink/page/PageEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/sink/page/PageEventSink.java
@@ -1,0 +1,212 @@
+package com.webforj.sink.page;
+
+
+import com.basis.bbj.proxies.BBjWebManager;
+import com.basis.bbj.proxies.event.BBjEvent;
+import com.basis.bbj.proxies.event.BBjWebEvent;
+import com.basis.bbj.proxies.event.BBjWebEventOptions;
+import com.basis.startup.type.BBjException;
+import com.basis.startup.type.CustomObject;
+import com.webforj.Environment;
+import com.webforj.Page;
+import com.webforj.bridge.WebforjBBjBridge;
+import com.webforj.component.element.event.DebouncePhase;
+import com.webforj.component.event.sink.DwcEventSink;
+import com.webforj.dispatcher.EventDispatcher;
+import com.webforj.event.page.PageEvent;
+import com.webforj.event.page.PageEventOptions;
+import com.webforj.exceptions.WebforjRuntimeException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * The {@code PageEventSink} implements the required logic for setting and removing the callback on
+ * the {@code BBjWebManager}. It will delegates the BBj event to the corresponding event listener to
+ * the Java component.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public class PageEventSink implements DwcEventSink<Page> {
+  private final Page page;
+  private EventDispatcher dispatcher;
+  private final String type;
+  private Map<Integer, PageEventOptions> callbackOptionsMap = new HashMap<>();
+
+  /**
+   * Constructs a new instance of {@link PageEventSink}.
+   *
+   * @param page The associated Page component.
+   * @param type The event type.
+   * @param dispatcher The event dispatcher.
+   */
+  public PageEventSink(Page page, String type, EventDispatcher dispatcher) {
+    this.page = page;
+    this.dispatcher = dispatcher;
+    this.type = type;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String setCallback(Object options) {
+    if (isConnected()) {
+      try {
+        WebforjBBjBridge bridge = getEnvironment().getWebforjHelper();
+        CustomObject handler = bridge.getEventProxy(this, "handleEvent");
+        return doSetCallback(getBbjWebManager(), options, handler, "onEvent");
+      } catch (BBjException e) {
+        throw new WebforjRuntimeException("Failed to set BBjWebManager callback.", e);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void removeCallback(String id) {
+    if (isConnected()) {
+      try {
+        doRemoveCallback(getBbjWebManager(), id);
+      } catch (BBjException e) {
+        throw new WebforjRuntimeException("Failed to remove BBjWebManager callback.", e);
+      }
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public final EventDispatcher getEventDispatcher() {
+    return this.dispatcher;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public final boolean isConnected() {
+    return this.page != null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isMultipleCallbacks() {
+    return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Page getComponent() {
+    return this.page;
+  }
+
+  /**
+   * Handles the BBj event and dispatches a new {@link PageEvent}.
+   *
+   * @param bbjEvent The BBj event to handle.
+   */
+  public void handleEvent(BBjEvent bbjEvent) {
+    BBjWebEvent bbjWebEvent = (BBjWebEvent) bbjEvent;
+    PageEvent event;
+    try {
+      int id = bbjWebEvent.getCallbackID();
+      PageEventOptions options = callbackOptionsMap.get(id);
+
+      event = new PageEvent(getComponent(), bbjWebEvent.getEventMap(), type, id, options);
+      getEventDispatcher().dispatchEvent(event);
+    } catch (BBjException e) {
+      throw new WebforjRuntimeException("Failed to dispatch PageEvent '" + type + "'", e);
+    }
+  }
+
+  /**
+   * Do set a callback on the underlying BBj web manager.
+   *
+   * @param manager The BBjWebManager instance
+   * @param options The options object
+   * @param handler The BBj CustomObject instance
+   * @param callback The callback method name as defined in the handler
+   *
+   * @return the callback id.
+   * @throws BBjException if the callback cannot be set.
+   */
+  protected String doSetCallback(BBjWebManager manager, Object options, CustomObject handler,
+      String callback) throws BBjException {
+
+    // create a control options and map it from the passed PageEventOptions
+    BBjWebEventOptions managerOptions = manager.newEventOptions();
+    PageEventOptions pageOptions = (PageEventOptions) options;
+
+    // Set the code and filter
+    managerOptions.setCode(pageOptions.getCode());
+    managerOptions.setFilter(pageOptions.getFilter());
+
+    // Add the items
+    for (Entry<String, String> entry : pageOptions.getDataMap().entrySet()) {
+      managerOptions.addItem(entry.getKey(), entry.getValue());
+    }
+
+    // Set the debounce/throttle options
+    if (pageOptions.isDebounce()) {
+      DebouncePhase phase = pageOptions.getDebouncePhase();
+      boolean leading = phase.equals(DebouncePhase.LEADING) || phase.equals(DebouncePhase.BOTH);
+      boolean trailing = phase.equals(DebouncePhase.TRAILING) || phase.equals(DebouncePhase.BOTH);
+
+      managerOptions.setDebounce(pageOptions.getDebounceTimeout(), leading, trailing);
+    } else if (pageOptions.isThrottle()) {
+      managerOptions.setThrottle(pageOptions.getThrottleTimeout());
+    } else {
+      managerOptions.setImmediate();
+    }
+
+    int id = manager.setCallback(type, handler, callback, managerOptions);
+    callbackOptionsMap.put(id, pageOptions);
+
+    return String.valueOf(id);
+  }
+
+  /**
+   * Do remove a callback from underlying BBj web manager.
+   *
+   * @param manager The BBjWebManager instance
+   * @param callbackId The callback id.
+   *
+   * @throws BBjException if the callback cannot be removed.
+   */
+  protected void doRemoveCallback(BBjWebManager manager, String callbackId) throws BBjException {
+    int theId = Integer.parseInt(callbackId);
+    callbackOptionsMap.remove(theId);
+
+    // Remove the callback only if there are no more callbacks registered
+    manager.clearCallback(type, theId);
+  }
+
+  /**
+   * Gets the BBjWebManager instance.
+   *
+   * @return the BBjWebManager instance.
+   */
+  protected BBjWebManager getBbjWebManager() {
+    try {
+      return getEnvironment().getBBjAPI().getWebManager();
+    } catch (BBjException e) {
+      throw new WebforjRuntimeException("Failed to get BBjWebManager instance.", e);
+    }
+  }
+
+  Environment getEnvironment() {
+    return Environment.getCurrent();
+  }
+}
+

--- a/webforj-foundation/src/main/java/com/webforj/sink/page/PageEventSinkRegistry.java
+++ b/webforj-foundation/src/main/java/com/webforj/sink/page/PageEventSinkRegistry.java
@@ -1,0 +1,25 @@
+package com.webforj.sink.page;
+
+import com.webforj.Page;
+import com.webforj.component.event.EventSinkListenerRegistry;
+import com.webforj.event.page.PageEvent;
+
+/**
+ * {@code PageEventSinkRegistry} is used to manage the event listeners (add/remove) for a web
+ * manager sink and the corresponding event.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public class PageEventSinkRegistry extends EventSinkListenerRegistry<PageEvent, Page> {
+
+  /**
+   * Creates a new PageEventSinkRegistry.
+   *
+   * @param sink The corresponding sink to the event
+   * @param event The corresponding event to the sink
+   */
+  public PageEventSinkRegistry(PageEventSink sink, Class<? super PageEvent> event) {
+    super(sink, event);
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/sink/page/PageEventSinkTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/sink/page/PageEventSinkTest.java
@@ -1,0 +1,169 @@
+package com.webforj.sink.page;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.basis.bbj.proxies.BBjAPI;
+import com.basis.bbj.proxies.BBjWebManager;
+import com.basis.bbj.proxies.event.BBjWebEvent;
+import com.basis.bbj.proxies.event.BBjWebEventOptions;
+import com.basis.startup.type.BBjException;
+import com.basis.startup.type.CustomObject;
+import com.webforj.Environment;
+import com.webforj.Page;
+import com.webforj.bridge.WebforjBBjBridge;
+import com.webforj.dispatcher.EventDispatcher;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.event.page.PageEvent;
+import com.webforj.event.page.PageEventOptions;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.mockito.stubbing.Answer;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PageEventSinkTest {
+  EventDispatcher dispatcher;
+  Page page;
+  Environment environment;
+  BBjAPI api;
+  BBjWebManager webManager;
+  WebforjBBjBridge bridge;
+  PageEventSink sink;
+
+  @BeforeEach
+  void setUp() throws BBjException {
+    dispatcher = new EventDispatcher();
+    environment = mock(Environment.class);
+    api = mock(BBjAPI.class);
+    webManager = mock(BBjWebManager.class);
+
+    when(environment.getBBjAPI()).thenReturn(api);
+    when(environment.getWebforjHelper()).thenReturn(mock(WebforjBBjBridge.class));
+    when(api.getWebManager()).thenReturn(webManager);
+
+    page = spy(Page.class);
+    sink = spy(new PageEventSink(page, "click", dispatcher));
+  }
+
+  @Test
+  void shouldSetCallback() throws BBjException {
+    try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
+      mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
+
+      BBjWebEventOptions optionsMock = mock(BBjWebEventOptions.class);
+      when(webManager.newEventOptions()).thenReturn(optionsMock);
+
+      sink.setCallback(new PageEventOptions());
+      verify(sink.getBbjWebManager(), times(1)).setCallback("click", null, "onEvent", optionsMock);
+    }
+  }
+
+  @Test
+  void shouldRemoveCallback() throws BBjException {
+    try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
+      mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
+
+      sink.removeCallback("5");
+      verify(webManager, times(1)).clearCallback("click", 5);
+    }
+  }
+
+  @Test
+  void shouldProcessPayload() throws BBjException {
+    try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
+      mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
+      when(environment.getWebforjHelper()).thenReturn(mock(WebforjBBjBridge.class));
+
+      BBjWebEventOptions optionsMock = mock(BBjWebEventOptions.class);
+      when(webManager.newEventOptions()).thenReturn(optionsMock);
+
+      BBjWebEvent event = Mockito.mock(BBjWebEvent.class);
+      PageEvent[] dispatchedEvent = new PageEvent[1];
+
+      String eventType = "click";
+      EventListener<PageEvent> listener = e -> {
+        dispatchedEvent[0] = e;
+      };
+
+      PageEventSinkRegistry registry = new PageEventSinkRegistry(sink, PageEvent.class);
+      registry.addEventListener(listener, new PageEventOptions());
+
+      sink.handleEvent(event);
+
+      assertEquals(eventType, dispatchedEvent[0].getType());
+    }
+  }
+
+  @Test
+  void setRemoveCallbackBehaviour() throws BBjException {
+    try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
+      mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
+
+      Map<String, String> items = new HashMap<>() {
+        {
+          put("x", "event.x");
+          put("y", "event.y");
+        }
+      };
+      String code = "component.dispatchEvent(new CustomEvent('custom-event'))";
+      String filter = "event.target.isSameNode(component)";
+
+      when(webManager.setCallback(anyString(), any(CustomObject.class), anyString(),
+          any(BBjWebEventOptions.class))).thenAnswer(new Answer<Integer>() {
+            @Override
+            public Integer answer(InvocationOnMock invocation) throws Throwable {
+              return new Random().nextInt();
+            }
+          });
+      BBjWebEventOptions managerOptions = mock(BBjWebEventOptions.class);
+      when(managerOptions.getCode()).thenReturn(code);
+      when(managerOptions.getFilter()).thenReturn(filter);
+      when(managerOptions.getItemMap()).thenReturn(items);
+      when(webManager.newEventOptions()).thenReturn(managerOptions);
+
+      PageEventOptions pageOptions = new PageEventOptions(items, code, filter);
+      pageOptions.setDebounce(100);
+
+      String eventType = "click";
+
+      // add the callback
+      String firstCallbackId =
+          sink.doSetCallback(webManager, pageOptions, mock(CustomObject.class), "onEvent");
+      String secondCallbackId =
+          sink.doSetCallback(webManager, pageOptions, mock(CustomObject.class), "onEvent");
+
+      assertNotEquals(firstCallbackId, secondCallbackId);
+      verify(webManager, times(2)).setCallback(eq(eventType), any(CustomObject.class), anyString(),
+          eq(managerOptions));
+
+      verify(webManager, times(2)).newEventOptions();
+
+      // remove the callback
+      sink.doRemoveCallback(webManager, firstCallbackId);
+      verify(webManager, times(1)).clearCallback(eventType, Integer.parseInt(firstCallbackId));
+
+      sink.doRemoveCallback(webManager, secondCallbackId);
+      verify(webManager, times(1)).clearCallback(eventType, Integer.parseInt(secondCallbackId));
+    }
+  }
+}


### PR DESCRIPTION
The PR adds support for registering HTML events directly through the page instance without needing an element or a bridge.

```java
PageEventOptions pageEventOptions = new PageEventOptions();
pageEventOptions.addData("clientX", "event.clientX");
pageEventOptions.addData("clientY", "event.clientY");
ListenerRegistration<PageEvent> r1 = Page.getCurrent().addEventListener("click", e -> {
  int x = (int) e.getData().get("clientX");
  int y = (int) e.getData().get("clientY");

  console().log("x: " + x + ", y: " + y);
}, pageEventOptions);
```