### PR TITLE
fix: components that are not focusable are not being removed from the tab order

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/DwcFocusableMixin.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/DwcFocusableMixin.java
@@ -174,7 +174,11 @@ public final class DwcFocusableMixin<T extends DwcComponent<T>>
       setEnabled(enabled);
     }
 
-    if (this.wasFocused != null) {
+    if (!focusable) {
+      setFocusable(focusable);
+    }
+
+    if (focusable && this.wasFocused != null) {
       this.focus();
     }
   }


### PR DESCRIPTION
Fixes #697 