### PR TITLE
fix: BBjWindowAdapter now needs additional call to create()

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/bridge/BBjWindowAdapter.java
+++ b/webforj-foundation/src/main/java/com/webforj/bridge/BBjWindowAdapter.java
@@ -13,5 +13,6 @@ public class BBjWindowAdapter extends Window {
 
   public BBjWindowAdapter(BBjWindow w) {
     setBbjWindow(w);
+    create(this);
   }
 }


### PR DESCRIPTION
this fixing the interop with BBj which was broken for a while.