### PR TITLE
feat: add mixins for element event listeners

### DIFF
--- a/webforj-components/webforj-html-elements/src/main/java/com/webforj/component/html/HtmlComponent.java
+++ b/webforj-components/webforj-html-elements/src/main/java/com/webforj/component/html/HtmlComponent.java
@@ -4,9 +4,9 @@ import com.webforj.component.Component;
 import com.webforj.component.element.Element;
 import com.webforj.component.element.ElementComposite;
 import com.webforj.component.element.annotation.EventName;
+import com.webforj.component.element.concern.HasElementClickListener;
 import com.webforj.component.element.event.ElementEventOptions;
 import com.webforj.component.event.ComponentEvent;
-import com.webforj.component.html.event.HtmlClickEvent;
 import com.webforj.concern.HasAttribute;
 import com.webforj.concern.HasClassName;
 import com.webforj.concern.HasHtml;
@@ -27,7 +27,7 @@ import com.webforj.exceptions.WebforjRuntimeException;
  */
 public abstract class HtmlComponent<T extends HtmlComponent<T>> extends ElementComposite
     implements HasStyle<T>, HasAttribute<T>, HasProperty<T>, HasClassName<T>, HasText<T>,
-    HasHtml<T>, HasVisibility<T>, HasSize<T> {
+    HasHtml<T>, HasVisibility<T>, HasSize<T>, HasElementClickListener<T> {
 
   /**
    * Alias for {@link #getBoundComponent()}.
@@ -80,68 +80,5 @@ public abstract class HtmlComponent<T extends HtmlComponent<T>> extends ElementC
   public <E extends ComponentEvent<?>> ListenerRegistration<E> addEventListener(
       Class<? super E> eventClass, EventListener<E> listener) {
     return super.addEventListener(eventClass, listener);
-  }
-
-  /**
-   * Adds a click listener to this component.
-   *
-   * @param listener the listener to add
-   * @param options the options
-   *
-   * @return A listener registration for removing the event listener
-   */
-  public ListenerRegistration<HtmlClickEvent<T>> addClickListener(
-      EventListener<HtmlClickEvent<T>> listener, ElementEventOptions options) {
-    return addEventListener(HtmlClickEvent.class, listener, options);
-  }
-
-  /**
-   * Adds a click listener to this component.
-   *
-   * @param listener the listener to add
-   *
-   * @return A listener registration for removing the event listener
-   */
-  public ListenerRegistration<HtmlClickEvent<T>> addClickListener(
-      EventListener<HtmlClickEvent<T>> listener) {
-    return addEventListener(HtmlClickEvent.class, listener);
-  }
-
-  /**
-   * Adds an onClick listener to this component.
-   *
-   * @param listener the listener to add
-   * @param options the options
-   *
-   * @return A listener registration for removing the event listener
-   */
-  public ListenerRegistration<HtmlClickEvent<T>> onClick(EventListener<HtmlClickEvent<T>> listener,
-      ElementEventOptions options) {
-    return addClickListener(listener, options);
-  }
-
-  /**
-   * Adds an onClick listener to this component.
-   *
-   * @param listener the listener to add
-   *
-   * @return A listener registration for removing the event listener
-   */
-  public ListenerRegistration<HtmlClickEvent<T>> onClick(
-      EventListener<HtmlClickEvent<T>> listener) {
-    return addClickListener(listener);
-  }
-
-  /**
-   * Returns an instance of the current class, casted to its generic type. This method is primarily
-   * used for method chaining in subclasses of HtmlComponent.
-   *
-   * @return An instance of the current class, casted to its generic type.
-   */
-  protected final T getSelf() {
-    @SuppressWarnings("unchecked")
-    T self = (T) this;
-
-    return self;
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/element/ElementCompositeUtil.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/ElementCompositeUtil.java
@@ -1,0 +1,43 @@
+package com.webforj.component.element;
+
+import com.webforj.component.element.event.ElementEventOptions;
+import com.webforj.component.event.ComponentEvent;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+
+/**
+ * Utility methods for {@link ElementComposite}.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public class ElementCompositeUtil {
+
+  private ElementCompositeUtil() {}
+
+  /**
+   * Adds an event listener to the element composite.
+   *
+   * @param <E> the event type
+   *
+   * @param elementComposite the element composite
+   * @param eventClass the event class
+   * @param listener the listener
+   * @param options the options
+   *
+   * @return A listener registration for removing the event listener
+   */
+  public static <E extends ComponentEvent<?>> ListenerRegistration<E> addEventListener(
+      Object elementComposite, Class<? super E> eventClass, EventListener<E> listener,
+      ElementEventOptions options) {
+    return toComposite(elementComposite).addEventListener(eventClass, listener, options);
+  }
+
+  private static ElementComposite toComposite(Object object) {
+    try {
+      return (ElementComposite) object;
+    } catch (ClassCastException e) {
+      throw new IllegalStateException("This component is not an ElementComposite");
+    }
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/component/element/concern/HasElementClickListener.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/concern/HasElementClickListener.java
@@ -1,0 +1,72 @@
+package com.webforj.component.element.concern;
+
+import com.webforj.component.element.ElementComposite;
+import com.webforj.component.element.ElementCompositeUtil;
+import com.webforj.component.element.event.ElementClickEvent;
+import com.webforj.component.element.event.ElementEventOptions;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+
+/**
+ * A mixin interface for element components that have click listeners.
+ *
+ * @param <T> the component type
+ *
+ * @see ElementClickEvent
+ * @see ElementComposite
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public interface HasElementClickListener<T extends ElementComposite> {
+
+  /**
+   * Adds a click listener to this component.
+   *
+   * @param listener the listener to add
+   * @param options the options
+   *
+   * @return A listener registration for removing the event listener
+   */
+  public default ListenerRegistration<ElementClickEvent<T>> addClickListener(
+      EventListener<ElementClickEvent<T>> listener, ElementEventOptions options) {
+    return ElementCompositeUtil.addEventListener(this, ElementClickEvent.class, listener, options);
+  }
+
+  /**
+   * Adds a click listener to this component.
+   *
+   * @param listener the listener to add
+   *
+   * @return A listener registration for removing the event listener
+   */
+  public default ListenerRegistration<ElementClickEvent<T>> addClickListener(
+      EventListener<ElementClickEvent<T>> listener) {
+    return addClickListener(listener, null);
+  }
+
+  /**
+   * Adds an onClick listener to this component.
+   *
+   * @param listener the listener to add
+   * @param options the options
+   *
+   * @return A listener registration for removing the event listener
+   */
+  public default ListenerRegistration<ElementClickEvent<T>> onClick(
+      EventListener<ElementClickEvent<T>> listener, ElementEventOptions options) {
+    return addClickListener(listener, options);
+  }
+
+  /**
+   * Adds an onClick listener to this component.
+   *
+   * @param listener the listener to add
+   *
+   * @return A listener registration for removing the event listener
+   */
+  public default ListenerRegistration<ElementClickEvent<T>> onClick(
+      EventListener<ElementClickEvent<T>> listener) {
+    return addClickListener(listener);
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/component/element/concern/HasElementEventListener.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/concern/HasElementEventListener.java
@@ -1,0 +1,53 @@
+package com.webforj.component.element.concern;
+
+import com.webforj.component.element.ElementCompositeUtil;
+import com.webforj.component.element.annotation.EventName;
+import com.webforj.component.element.event.ElementEventOptions;
+import com.webforj.component.event.ComponentEvent;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+
+/**
+ * A mixin interface for element components that have custom event listeners.
+ *
+ * @see EventName
+ * @see ElementEventOptions
+ * @see EventListener
+ * @see ElementComposite
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public interface HasElementEventListener {
+
+  /**
+   * Adds a listener for the given event type.
+   *
+   * @param <E> The event type
+   *
+   * @param eventClass The event class
+   * @param listener The listener
+   * @param options The event options
+   *
+   * @return A listener registration for removing the event listener
+   */
+  public default <E extends ComponentEvent<?>> ListenerRegistration<E> addEventListener(
+      Class<? super E> eventClass, EventListener<E> listener, ElementEventOptions options) {
+    return ElementCompositeUtil.addEventListener(this, eventClass, listener, options);
+  }
+
+  /**
+   * Adds a listener for the given event type.
+   *
+   * @param <E> The event type
+   *
+   * @param eventClass The event class
+   * @param listener The listener
+   *
+   * @return A listener registration for removing the event listener
+   */
+  public default <E extends ComponentEvent<?>> ListenerRegistration<E> addEventListener(
+      Class<? super E> eventClass, EventListener<E> listener) {
+    return addEventListener(eventClass, listener, null);
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/component/element/event/ElementClickEvent.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/event/ElementClickEvent.java
@@ -1,32 +1,32 @@
-package com.webforj.component.html.event;
+package com.webforj.component.element.event;
 
+import com.webforj.component.element.ElementComposite;
 import com.webforj.component.element.annotation.EventName;
 import com.webforj.component.element.annotation.EventOptions;
 import com.webforj.component.element.annotation.EventOptions.EventData;
 import com.webforj.component.event.ComponentEvent;
-import com.webforj.component.html.HtmlComponent;
 import java.util.Map;
 
 /**
- * Event fired when an HtmlComponent is clicked.
+ * Event fired when an ElementComposite is clicked.
  *
  * @param <T> the component type
  *
  * @author Hyyan Abo Fakher
- * @since 23.06
+ * @since 24.11
  */
 @EventName("click")
 @EventOptions(data = {@EventData(key = "screenX", exp = "event.screenX"),
-    @EventData(key = "screenY", exp = "component.screenY"),
+    @EventData(key = "screenY", exp = "event.screenY"),
     @EventData(key = "clientX", exp = "event.clientX"),
-    @EventData(key = "clientY", exp = "component.clientY"),
+    @EventData(key = "clientY", exp = "event.clientY"),
     @EventData(key = "detail", exp = "event.detail"),
     @EventData(key = "button", exp = "event.button"),
     @EventData(key = "ctrlKey", exp = "event.ctrlKey"),
     @EventData(key = "shiftKey", exp = "event.shiftKey"),
     @EventData(key = "altKey", exp = "event.altKey"),
     @EventData(key = "metaKey", exp = "event.metaKey")})
-public class HtmlClickEvent<T extends HtmlComponent<T>> extends ComponentEvent<HtmlComponent<T>> {
+public class ElementClickEvent<T extends ElementComposite> extends ComponentEvent<T> {
 
   /**
    * Creates a new component event.
@@ -34,7 +34,7 @@ public class HtmlClickEvent<T extends HtmlComponent<T>> extends ComponentEvent<H
    * @param component the source component
    * @param eventMap the event data
    */
-  public HtmlClickEvent(HtmlComponent<T> component, Map<String, Object> eventMap) {
+  public ElementClickEvent(T component, Map<String, Object> eventMap) {
     super(component, eventMap);
   }
 
@@ -136,5 +136,13 @@ public class HtmlClickEvent<T extends HtmlComponent<T>> extends ComponentEvent<H
   @Override
   public T getComponent() {
     return (T) super.getComponent();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String toString() {
+    return "ElementClickEvent{" + "component=" + getComponent() + ", eventMap=" + getData() + '}';
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/component/element/event/ElementClickEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/event/ElementClickEventTest.java
@@ -1,19 +1,19 @@
-package com.webforj.component.html.event;
+package com.webforj.component.element.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import com.webforj.component.html.HtmlComponent;
+import com.webforj.component.element.ElementComposite;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class HtmlClickEventTest {
+class ElementClickEventTest {
 
-  private HtmlClickEvent clickEvent;
+  private ElementClickEvent<?> clickEvent;
 
   @BeforeEach
   void setUp() {
@@ -29,56 +29,56 @@ class HtmlClickEventTest {
     eventMap.put("altKey", true);
     eventMap.put("metaKey", false);
 
-    clickEvent = new HtmlClickEvent(mock(HtmlComponent.class), eventMap);
+    clickEvent = new ElementClickEvent(mock(ElementComposite.class), eventMap);
   }
 
   @Test
-  void testGetScreenX() {
+  void shouldGetScreenX() {
     assertEquals(100, clickEvent.getScreenX());
   }
 
   @Test
-  void testGetScreenY() {
+  void shouldGetScreenY() {
     assertEquals(200, clickEvent.getScreenY());
   }
 
   @Test
-  void testGetClientX() {
+  void shouldGetClientX() {
     assertEquals(50, clickEvent.getClientX());
   }
 
   @Test
-  void testGetClientY() {
+  void shouldGetClientY() {
     assertEquals(100, clickEvent.getClientY());
   }
 
   @Test
-  void testGetDetail() {
+  void shouldGetDetail() {
     assertEquals(1, clickEvent.getDetail());
   }
 
   @Test
-  void testGetButton() {
+  void shouldGetButton() {
     assertEquals(1, clickEvent.getButton());
   }
 
   @Test
-  void testIsCtrlKey() {
+  void shouldCheckIfCtrlKeyIsPressed() {
     assertTrue(clickEvent.isCtrlKey());
   }
 
   @Test
-  void testIsShiftKey() {
+  void shouldCheckIfShiftKeyIsPressed() {
     assertFalse(clickEvent.isShiftKey());
   }
 
   @Test
-  void testIsAltKey() {
+  void shouldCheckIfAltKeyIsPressed() {
     assertTrue(clickEvent.isAltKey());
   }
 
   @Test
-  void testIsMetaKey() {
+  void shouldCheckIfMetaKeyIsPressed() {
     assertFalse(clickEvent.isMetaKey());
   }
 }


### PR DESCRIPTION
The PR adds the `HasElementEventListener` and `HasElementClickListener` mixins, enabling element composite components to handle click events and custom events without requiring the implementation of event handling logic within the implemented components themselves.

```java
public class MyComponent extends ElementComposite 
    implements HasElementClickListener<MyComponent> {
}
```