### PR TITLE
refactor: add `SlotRegistry` to manage components in slots

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/SlotRegistry.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/SlotRegistry.java
@@ -1,0 +1,181 @@
+package com.webforj.component;
+
+import com.webforj.component.ComponentLifecycleObserver.LifecycleEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@code SlotRegistry} manages components by associating them with named slots.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public class SlotRegistry {
+  static final String DEFAULT_SLOT = "__default__";
+  private final Map<String, List<Component>> slots = new LinkedHashMap<>();
+
+  /**
+   * Adds the given components to the specified slot.
+   *
+   * <p>
+   * If the slot name is null or empty, the components will be added to the default slot.
+   * </p>
+   *
+   * @param slot the slot name, or null/empty for the default slot.
+   * @param components the components to be added.
+   * @throws IllegalArgumentException if a component is already assigned to a slot.
+   */
+  public void addComponentsToSlot(String slot, Component... components) {
+    String resolvedSlot = resolveSlotName(slot);
+
+    for (Component component : components) {
+      // Check if the component is already in a slot
+      String currentSlot = findComponentSlot(component);
+      if (currentSlot != null) {
+        throw new IllegalArgumentException("Component is already assigned to slot.");
+      }
+
+      slots.computeIfAbsent(resolvedSlot, k -> new ArrayList<>()).add(component);
+      component.addLifecycleObserver((c, event) -> {
+        if (event == LifecycleEvent.DESTROY) {
+          removeComponentsFromSlot(c);
+        }
+      });
+    }
+  }
+
+  /**
+   * Replaces the content of the specified slot with new components.
+   *
+   * <p>
+   * All existing components in the slot are destroyed before adding the new ones.
+   * </p>
+   *
+   * @param slot the slot name, or null/empty for the default slot.
+   * @param components the new components to be added.
+   *
+   * @throws IllegalArgumentException if any of the components is already assigned to a slot.
+   */
+  public void replaceComponentsInSlot(String slot, Component... components) {
+    removeSlot(slot);
+    addComponentsToSlot(slot, components);
+  }
+
+  /**
+   * Removes the given components from their associated slots.
+   *
+   * @param components the components to be removed.
+   */
+  public void removeComponentsFromSlot(Component... components) {
+    for (Component component : components) {
+      String slot = findComponentSlot(component);
+      if (!component.isDestroyed()) {
+        component.destroy();
+      }
+
+      List<Component> slotRef = slots.get(resolveSlotName(slot));
+      if (slotRef != null) {
+        slotRef.remove(component);
+      }
+    }
+  }
+
+  /**
+   * Removes all components from the specified slot.
+   *
+   * @param slot the slot name, or null/empty for the default slot.
+   */
+  public void removeSlot(String slot) {
+    // Destroy all components in the slot
+    getComponentsInSlot(slot).forEach(Component::destroy);
+    slots.remove(resolveSlotName(slot));
+  }
+
+  /**
+   * Finds which slot a given component belongs to.
+   *
+   * @param component the component to search for.
+   * @return the name of the slot containing the component, or an empty string if not found.
+   */
+  public String findComponentSlot(Component component) {
+    for (Map.Entry<String, List<Component>> entry : slots.entrySet()) {
+      if (entry.getValue().contains(component)) {
+        return entry.getKey().equals(DEFAULT_SLOT) ? "" : entry.getKey();
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns a list of components assigned to the given slot.
+   *
+   * <p>
+   * If the slot name is null or empty, the default slot will be used.
+   * </p>
+   *
+   * @param slot the slot name, or null/empty for the default slot.
+   * @return the list of components in the specified slot, or an empty list if none exist.
+   */
+  public List<Component> getComponentsInSlot(String slot) {
+    return slots.getOrDefault(resolveSlotName(slot), Collections.emptyList());
+  }
+
+  /**
+   * Returns a list of components of the specified type assigned to the given slot.
+   *
+   * @param slot the slot name, or null/empty for the default slot.
+   * @param classOfT the class type to filter by.
+   * @param <T> the type of component.
+   *
+   * @return the list of components of the given type in the slot.
+   */
+  public <T extends Component> List<T> getComponentsInSlot(String slot, Class<T> classOfT) {
+    return slots.getOrDefault(resolveSlotName(slot), Collections.emptyList()).stream()
+        .filter(classOfT::isInstance).map(classOfT::cast).toList();
+  }
+
+  /**
+   * Gets the first component in the specified slot.
+   *
+   * <p>
+   * If the slot name is null or empty, the default slot will be used.
+   * </p>
+   *
+   * @param slot the slot name, or null/empty for the default slot.
+   * @return the first component in the slot, or null if the slot is empty.
+   */
+  public Component getFirstComponentInSlot(String slot) {
+    return getComponentsInSlot(slot).stream().findFirst().orElse(null);
+  }
+
+  /**
+   * Gets the first component of the specified type in the slot.
+   *
+   * <p>
+   * If the slot name is null or empty, the default slot will be used.
+   * </p>
+   *
+   * @param slot the slot name, or null/empty for the default slot.
+   * @param classOfT the class type to filter by.
+   * @param <T> the type of component.
+   *
+   * @return the first component of the given type in the slot, or null if none is found.
+   */
+  public <T extends Component> T getFirstComponentInSlot(String slot, Class<T> classOfT) {
+    return getComponentsInSlot(slot, classOfT).stream().findFirst().orElse(null);
+  }
+
+  /**
+   * Resolves the slot name, returning the default slot if the given slot name is null or empty.
+   *
+   * @param slot the slot name to resolve.
+   * @return the resolved slot name, or the default slot if null or empty.
+   */
+  private String resolveSlotName(String slot) {
+    return (slot == null || slot.trim().isEmpty()) ? DEFAULT_SLOT : slot;
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/component/SlotRegistryTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/SlotRegistryTest.java
@@ -1,0 +1,174 @@
+package com.webforj.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.webforj.component.window.Window;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SlotRegistryTest {
+
+  private SlotRegistry slotRegistry;
+  private Component component1;
+  private Component component2;
+
+  @BeforeEach
+  void setup() {
+    slotRegistry = new SlotRegistry();
+    component1 = mock(Component.class);
+    component2 = mock(Component.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldAddComponentsToSlot(String slot) {
+    slotRegistry.addComponentsToSlot(slot, component1, component2);
+    List<Component> components = slotRegistry.getComponentsInSlot(slot);
+
+    assertEquals(2, components.size());
+    assertTrue(components.contains(component1));
+    assertTrue(components.contains(component2));
+  }
+
+  @Test
+  void shouldNotAllowAddingComponentToMultipleSlots() {
+    slotRegistry.addComponentsToSlot("header", component1);
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      slotRegistry.addComponentsToSlot("footer", component1);
+    });
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldReplaceComponentsToSlot(String slot) {
+    slotRegistry.addComponentsToSlot(slot, component1, component2);
+    slotRegistry.replaceComponentsInSlot(slot, new TestComponent());
+
+    List<Component> components = slotRegistry.getComponentsInSlot(slot);
+    assertEquals(1, components.size());
+    assertTrue(components.get(0) instanceof TestComponent);
+
+    verify(component1).destroy();
+    verify(component2).destroy();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldRemoveComponentsFromSlot(String slot) {
+    slotRegistry.addComponentsToSlot(slot, component1, component2);
+    slotRegistry.removeComponentsFromSlot(component1);
+
+    List<Component> components = slotRegistry.getComponentsInSlot(slot);
+    assertEquals(1, components.size());
+    assertFalse(components.contains(component1));
+    assertTrue(components.contains(component2));
+
+    verify(component1).destroy();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldRemoveDestroyedComponentsFromSlot(String slot) {
+    component1 = new TestComponent();
+    component2 = new TestComponent();
+    slotRegistry.addComponentsToSlot(slot, component1, component2);
+    component1.destroy();
+
+    List<Component> components = slotRegistry.getComponentsInSlot(slot);
+    assertEquals(1, components.size());
+    assertFalse(components.contains(component1));
+    assertTrue(components.contains(component2));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldRemoveSlot(String slot) {
+    slotRegistry.addComponentsToSlot(slot, component1, component2);
+    slotRegistry.removeSlot(slot);
+
+    List<Component> components = slotRegistry.getComponentsInSlot(slot);
+    assertTrue(components.isEmpty());
+
+    verify(component1).destroy();
+    verify(component2).destroy();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", ""})
+  void shouldFindComponentSlot(String slot) {
+    slotRegistry.addComponentsToSlot(slot, component1);
+
+    assertEquals(slot, slotRegistry.findComponentSlot(component1));
+  }
+
+  @Test
+  void shouldReturnNullWhenComponentNotInAnySlot() {
+    assertNull(slotRegistry.findComponentSlot(component1));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldReturnFirstComponentInSlot(String slot) {
+    slotRegistry.addComponentsToSlot(slot, component1, component2);
+    Component firstComponent = slotRegistry.getFirstComponentInSlot(slot);
+
+    assertEquals(component1, firstComponent);
+  }
+
+  @Test
+  void shouldReturnNullWhenNoComponentsInSlot() {
+    Component firstComponent = slotRegistry.getFirstComponentInSlot("nonexistent");
+    assertNull(firstComponent);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldGetComponentsInSlotOfType(String slot) {
+    slotRegistry.addComponentsToSlot(slot, component1, component2, new TestComponent());
+
+    List<TestComponent> components = slotRegistry.getComponentsInSlot(slot, TestComponent.class);
+    assertEquals(1, components.size());
+
+    List<Component> allComponents = slotRegistry.getComponentsInSlot(slot, Component.class);
+    assertEquals(3, allComponents.size());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldReturnNullWhenNoComponentOfTypeInSlot(String slot) {
+    slotRegistry.addComponentsToSlot(slot, component1);
+    Component firstTypedComponent = slotRegistry.getFirstComponentInSlot(slot, TestComponent.class);
+
+    assertNull(firstTypedComponent);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"header", "", SlotRegistry.DEFAULT_SLOT})
+  void shouldReturnEmptyListWhenSlotIsEmpty(String slot) {
+    List<Component> components = slotRegistry.getComponentsInSlot(slot);
+    assertTrue(components.isEmpty());
+  }
+
+  static class TestComponent extends Component {
+
+    @Override
+    protected void onCreate(Window window) {
+      // no-op
+    }
+
+    @Override
+    protected void onDestroy() {
+      // no-op
+    }
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/component/element/ElementTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/ElementTest.java
@@ -3,6 +3,7 @@ package com.webforj.component.element;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,7 +28,6 @@ import com.webforj.component.element.event.ElementEventOptions;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.exceptions.WebforjRuntimeException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -128,7 +128,7 @@ class ElementTest {
       component.remove(child1);
       assertEquals(1, component.getComponentCount());
       assertFalse(component.hasComponent(child1));
-      assertTrue(component.findComponentSlot(child1).isEmpty());
+      assertNull(component.findComponentSlot(child1));
       assertEquals(child2, component.getFirstComponentInSlot("first"));
     }
   }
@@ -172,8 +172,7 @@ class ElementTest {
 
     @Test
     @DisplayName("onAttach will re-apply html changes")
-    void onAttachWillReapplyHtmlChanges()
-        throws BBjException, IllegalAccessException, InvocationTargetException {
+    void onAttachWillReapplyHtmlChanges() throws BBjException, IllegalAccessException {
       component.setHtml("html");
       ReflectionUtils.unNullifyControl(component, control);
       component.onAttach();


### PR DESCRIPTION
Add `SlotRegistry`  to manage components by associating them with named slots.