### PR TITLE
feat: allow setting prefix and suffix slots for supported components

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/DwcComponent.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/DwcComponent.java
@@ -64,7 +64,9 @@ import java.util.stream.Collectors;
 public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
     implements HasText<T>, HasHtml<T>, HasAttribute<T>, HasProperty<T>, HasClassName<T>,
     HasStyle<T>, HasVisibility<T>, HasTooltip<T>, HasSize<T> {
-
+  private static final String PREFIX_SLOT = "prefix";
+  private static final String SUFFIX_SLOT = "suffix";
+  private final SlotAssigner slotAssigner = new SlotAssigner(this);
   private final List<String> classNames = new ArrayList<>();
   private final List<String> removedClassNames = new ArrayList<>();
   private final List<String> removedStyles = new ArrayList<>();
@@ -1063,6 +1065,72 @@ public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
   }
 
   /**
+   * Sets the prefix component for the component.
+   *
+   * <p>
+   * The prefix component is the component that is displayed in the component's prefix slot. If a
+   * prefix component is already set, then the old prefix component will be destroyed and replaced
+   * with the new one.
+   * </p>
+   *
+   * @param prefix the prefix component to set
+   * @return the component itself.
+   *
+   * @since 24.11
+   */
+  protected T setPrefixComponent(Component prefix) {
+    getSlotAssigner().reAssign(PREFIX_SLOT, prefix);
+    return getSelf();
+  }
+
+  /**
+   * Retrieves the prefix component for the component.
+   *
+   * @return the prefix component for the component.
+   * @since 24.11
+   */
+  protected Component getPrefixComponent() {
+    return getSlotAssigner().getSlotComponent(PREFIX_SLOT);
+  }
+
+  /**
+   * Sets the suffix component for the component.
+   *
+   * <p>
+   * The suffix component is the component that is displayed in the component's suffix slot. If a
+   * suffix component is already set, then the old suffix component will be destroyed and replaced
+   * with the new one.
+   * </p>
+   *
+   * @param suffix the suffix component to set
+   * @return the component itself.
+   *
+   * @since 24.11
+   */
+  protected T setSuffixComponent(Component suffix) {
+    getSlotAssigner().reAssign(SUFFIX_SLOT, suffix);
+    return getSelf();
+  }
+
+  /**
+   * Retrieves the suffix component for the component.
+   *
+   * @return the suffix component for the component.
+   */
+  protected Component getSuffixComponent() {
+    return getSlotAssigner().getSlotComponent(SUFFIX_SLOT);
+  }
+
+  /**
+   * Retrieves the slot assigner for the component.
+   *
+   * @return the slot assigner for the component.
+   */
+  protected SlotAssigner getSlotAssigner() {
+    return slotAssigner;
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
@@ -1098,6 +1166,7 @@ public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
   @Override
   protected void onAttach() {
     super.onAttach();
+    getSlotAssigner().attach();
     attachControlCallbacks();
 
     if (!Boolean.TRUE.equals(visible)) {

--- a/webforj-foundation/src/main/java/com/webforj/component/SlotAssigner.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/SlotAssigner.java
@@ -1,0 +1,259 @@
+package com.webforj.component;
+
+import com.basis.bbj.proxies.sysgui.BBjControl;
+import com.basis.startup.type.BBjException;
+import com.webforj.bridge.ComponentAccessor;
+import com.webforj.exceptions.WebforjRuntimeException;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * {@code SlotAssigner} is responsible for binding multiple components to a single target component.
+ * The components are assigned to slots in the target component's window.
+ *
+ * <p>
+ * Once a slot is assigned to a component, the associated control from the slot is linked with the
+ * control of the target component in the specified slot.
+ * </p>
+ *
+ * <p>
+ * This process allows for dynamic and flexible component slot management, making it possible to
+ * assign multiple slots to a single component and manage their lifecycle.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public final class SlotAssigner {
+  /**
+   * A functional interface for assigning slot controls to the target control.
+   *
+   * @see SlotAssigner#assign(SlotAssigner.Assigner)
+   *
+   * @author Hyyan Abo Fakher
+   * @since 24.11
+   */
+  @FunctionalInterface
+  public interface Assigner {
+    /**
+     * Assigns the slot control to the target control.
+     *
+     * @param slot the slot name to which the slot control is assigned.
+     * @param targetControl the target control to which the slot control is assigned.
+     * @param slotControl the slot control to be assigned to the target control.
+     */
+    void assign(String slot, BBjControl targetControl, BBjControl slotControl);
+  }
+
+  private final Component targetComponent;
+  private final SlotAssigner.Assigner assigner;
+  private final SlotRegistry slotRegistry;
+  private boolean attached = false;
+
+  /**
+   * Constructs a new {@code SlotAssigner} to bind multiple components to the given target
+   * component.
+   *
+   * @param targetComponent the target component to which slots will be assigned.
+   * @param assigner an optional assigner to handle the slot assignment logic.
+   * @param slotRegistry the slot registry to manage slots.
+   *
+   * @throws NullPointerException if {@code targetComponent} is null.
+   */
+  public SlotAssigner(Component targetComponent, SlotAssigner.Assigner assigner,
+      SlotRegistry slotRegistry) {
+    Objects.requireNonNull(targetComponent, "SlotAssigner target component must not be null");
+    Objects.requireNonNull(slotRegistry, "SlotRegistry must not be null");
+
+    this.targetComponent = targetComponent;
+    this.assigner = assigner;
+    this.slotRegistry = slotRegistry;
+  }
+
+
+  /**
+   * Constructs a new {@code SlotAssigner} to bind multiple components to the given target
+   * component.
+   *
+   * @param targetComponent the target component to which slots will be assigned.
+   * @param assigner an optional assigner to handle the slot assignment logic.
+   *
+   * @throws NullPointerException if {@code targetComponent} is null.
+   */
+  public SlotAssigner(Component targetComponent, SlotAssigner.Assigner assigner) {
+    this(targetComponent, assigner, new SlotRegistry());
+  }
+
+  /**
+   * Constructs a new {@code SlotAssigner} to bind multiple components to the given target
+   * component.
+   *
+   * @param targetComponent the target component to which slots will be assigned.
+   *
+   * @throws NullPointerException if {@code targetComponent} is null.
+   */
+  public SlotAssigner(Component targetComponent) {
+    this(targetComponent, null);
+  }
+
+  /**
+   * Returns the slot registry associated with this slot assigner.
+   *
+   * @return the slot registry.
+   */
+  public SlotRegistry getSlotRegistry() {
+    return slotRegistry;
+  }
+
+  /**
+   * Returns the first component assigned to the given slot.
+   *
+   * @param slot the slot name to which the component is assigned.
+   * @return the component assigned to the slot, or {@code null} if no component is assigned.
+   */
+  public Component getSlotComponent(String slot) {
+    return slotRegistry.getFirstComponentInSlot(slot);
+  }
+
+  /**
+   * Assigns the given component to the target component.
+   *
+   * @param slot the slot name to which the component is assigned.
+   * @param component the component to be assigned.
+   *
+   * @throws IllegalStateException if the slots have already been assigned.
+   * @throws WebforjRuntimeException if an error occurs during slot assignment.
+   */
+  public void assign(String slot, Component component) {
+    assignComponentToSlot(slot, component, false);
+  }
+
+  /**
+   * reAssigns the given component to the target component.
+   *
+   * @param slot the slot name to which the component is assigned.
+   * @param component the component to be assigned.
+   *
+   * @throws IllegalStateException if the slots have already been assigned.
+   * @throws WebforjRuntimeException if an error occurs during slot assignment.
+   */
+  public void reAssign(String slot, Component component) {
+    assignComponentToSlot(slot, component, true);
+  }
+
+  /**
+   * Catchup all queued slot assignments and link the slot controls to the target control.
+   *
+   * <p>
+   * This method should be called after the target component is attached to the window. It assigns
+   * the slot controls to the target control in the specified slot.
+   * </p>
+   *
+   * @throws IllegalStateException if {@code attach()} has already been called.
+   */
+  public void attach() {
+    if (isAttached()) {
+      throw new IllegalStateException(
+          "attach() has already been called. Slots cannot be attached multiple times.");
+    }
+
+    attached = true;
+    slotRegistry.getSlots().forEach(slot -> {
+      slotRegistry.getComponentsInSlot(slot).forEach(component -> {
+        linkComponentToSlotControl(slot, component);
+      });
+    });
+  }
+
+  /**
+   * Queues the slot assignment process to be executed.
+   *
+   * <p>
+   * This method can be called before the target component is attached to the window. The slot
+   * actual assignment will be executed when the target component is attached. If the target
+   * component is already attached, the slot assignment will be executed immediately.
+   * </p>
+   *
+   * @param slot the slot name to which the given component is assigned.
+   * @param component the component to be assigned.
+   * @param replace a flag indicating whether to replace the existing components in the slot.
+   *        {@code true} to replace the existing components, {@code false} to add the component to
+   *        the slot.
+   *
+   * @throws IllegalStateException if the slots have already been assigned or the target component
+   *         is destroyed.
+   * @throws WebforjRuntimeException if an error occurs during slot assignment.
+   */
+  private void assignComponentToSlot(String slot, Component component, boolean replace) {
+    if (component.isDestroyed()) {
+      throw new IllegalStateException("Cannot assign a destroyed component to slot \"" + slot
+          + "\". Ensure the component is not destroyed before assignment.");
+    }
+
+    // Add the component to the slot registry
+    if (replace) {
+      slotRegistry.replaceComponentsInSlot(slot, component);
+    } else {
+      slotRegistry.addComponentsToSlot(slot, component);
+    }
+
+    if (isAttached()) {
+      linkComponentToSlotControl(slot, component);
+    }
+  }
+
+  /**
+   * Links the given component's control to the target control in the specified slot.
+   *
+   * <p>
+   * This method is called when the target component is attached to the window. It assigns the slot
+   * controls to the target control in the specified slot.
+   * </p>
+   *
+   * @param slot the slot name to which the component is assigned.
+   * @param component the component to be assigned.
+   *
+   * @throws WebforjRuntimeException if an error occurs during slot assignment.
+   */
+  private void linkComponentToSlotControl(String slot, Component component) {
+    if (component.isDestroyed()) {
+      throw new IllegalStateException("Cannot link a destroyed component to slot \"" + slot
+          + "\". Ensure the component is not destroyed before linking.");
+    }
+
+    // If the slot's component is not attached we need to attach it to the target component's window
+    if (!component.isAttached()) {
+      targetComponent.getWindow().add(component);
+    }
+
+    BBjControl targetControl = getControl(targetComponent);
+    BBjControl slotControl = getControl(component);
+    String theSlot = slot == SlotRegistry.DEFAULT_SLOT ? "" : slot;
+    Optional.ofNullable(assigner)
+        .ifPresentOrElse(invoker -> invoker.assign(theSlot, targetControl, slotControl), () -> {
+          try {
+            slotControl.setVisible(false);
+            targetControl.setSlot(theSlot, slotControl);
+            slotControl.setVisible(true);
+          } catch (BBjException e) {
+            String message = "Failed to assign slot \"" + slot + "\" to component \""
+                + this.targetComponent.getClass().getName() + "\".";
+
+            throw new WebforjRuntimeException(message, e);
+          }
+        });
+  }
+
+  BBjControl getControl(Component component) {
+    try {
+      return ComponentAccessor.getDefault().getControl(component);
+    } catch (IllegalAccessException e) {
+      throw new WebforjRuntimeException(
+          "Failed to access control for component: " + component.getClass().getName(), e);
+    }
+  }
+
+  boolean isAttached() {
+    return attached;
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/component/SlotRegistry.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/SlotRegistry.java
@@ -8,13 +8,27 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * {@code SlotRegistry} manages components by associating them with named slots.
+ * {@code SlotRegistry} manages the association of components with named slots.
+ *
+ * <p>
+ * It allows components to be dynamically added to, replaced, and removed from named slots,
+ * including a default slot when no specific slot is provided. Each component can only be associated
+ * with one slot at a time, and lifecycle events are tracked to remove components upon destruction.
+ * </p>
+ *
+ * <p>
+ * {@code SlotRegistry} is primarily useful for managing flexible, dynamic component arrangements
+ * within a window or UI container, where different components may be associated with different
+ * slots and need to be managed centrally.
+ * </p>
+ *
+ * @see SlotAssigner
  *
  * @author Hyyan Abo Fakher
  * @since 24.11
  */
 public class SlotRegistry {
-  static final String DEFAULT_SLOT = "__default__";
+  public static final String DEFAULT_SLOT = "__default__";
   private final Map<String, List<Component>> slots = new LinkedHashMap<>();
 
   /**
@@ -167,6 +181,15 @@ public class SlotRegistry {
    */
   public <T extends Component> T getFirstComponentInSlot(String slot, Class<T> classOfT) {
     return getComponentsInSlot(slot, classOfT).stream().findFirst().orElse(null);
+  }
+
+  /**
+   * Returns the names of all slots.
+   *
+   * @return the list of slot names.
+   */
+  public List<String> getSlots() {
+    return new ArrayList<>(slots.keySet());
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/button/Button.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/button/Button.java
@@ -2,6 +2,8 @@ package com.webforj.component.button;
 
 import com.basis.bbj.proxies.sysgui.BBjWindow;
 import com.webforj.bridge.WindowAccessor;
+import com.webforj.component.Component;
+import com.webforj.component.Expanse;
 import com.webforj.component.button.event.ButtonClickEvent;
 import com.webforj.component.window.Window;
 import com.webforj.dispatcher.EventListener;
@@ -71,6 +73,31 @@ public final class Button extends DwcButton<Button> {
    */
   public Button(String text) {
     this(text, DEFAULT_THEME);
+  }
+
+  /**
+   * Construct the button with the given icon and a {@link ButtonClickEvent}.
+   *
+   * @param icon the icon of the button
+   * @param clickListener the listener to be called when the button is clicked
+   * @since 24.11
+   */
+  public Button(Component icon, EventListener<ButtonClickEvent> clickListener) {
+    super();
+    setIcon(icon);
+    if (clickListener != null) {
+      addClickListener(clickListener);
+    }
+  }
+
+  /**
+   * Construct the button with the given icon.
+   *
+   * @param icon the icon of the button
+   * @since 24.11
+   */
+  public Button(Component icon) {
+    this(icon, null);
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/button/DwcButton.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/button/DwcButton.java
@@ -4,14 +4,17 @@ import com.basis.bbj.proxies.sysgui.BBjButton;
 import com.basis.startup.type.BBjException;
 import com.webforj.annotation.ExcludeFromJacocoGeneratedReport;
 import com.webforj.bridge.ComponentAccessor;
+import com.webforj.component.Component;
 import com.webforj.component.DwcFocusableComponent;
 import com.webforj.component.Expanse;
+import com.webforj.component.SlotAssigner;
 import com.webforj.component.button.event.ButtonClickEvent;
 import com.webforj.component.button.sink.ButtonClickEventSink;
 import com.webforj.component.event.ComponentEventSinkRegistry;
 import com.webforj.concern.HasExpanse;
 import com.webforj.concern.HasFocusStatus;
 import com.webforj.concern.HasHorizontalAlignment;
+import com.webforj.concern.HasPrefixAndSuffix;
 import com.webforj.concern.HasTheme;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
@@ -39,7 +42,11 @@ import java.util.List;
  */
 public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcFocusableComponent<T>
     implements HasExpanse<T, Expanse>, HasTheme<T, ButtonTheme>, HasHorizontalAlignment<T>,
-    HasFocusStatus {
+    HasFocusStatus, HasPrefixAndSuffix<T> {
+  private static final String PREFIX_SLOT = "prefix";
+  private static final String SUFFIX_SLOT = "suffix";
+  private static final String ICON_SLOT = "icon";
+  private final SlotAssigner slotAssigner = new SlotAssigner(this);
   private boolean disableOnClick = false;
 
   private final ComponentEventSinkRegistry<ButtonClickEvent> clickEventSinkListenerRegistry =
@@ -178,6 +185,68 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public T setPrefixComponent(Component prefix) {
+    getSlotAssigner().reAssign(PREFIX_SLOT, prefix);
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public Component getPrefixComponent() {
+    return getSlotAssigner().getSlotComponent(PREFIX_SLOT);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public T setSuffixComponent(Component suffix) {
+    getSlotAssigner().reAssign(SUFFIX_SLOT, suffix);
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public Component getSuffixComponent() {
+    return getSlotAssigner().getSlotComponent(SUFFIX_SLOT);
+  }
+
+  /**
+   * Sets the icon of the button.
+   *
+   * @param icon the icon of the button
+   * @return the icon component
+   */
+  public Component setIcon(Component icon) {
+    getSlotAssigner().reAssign(null, icon);
+    return icon;
+  }
+
+  /**
+   * Returns the icon of the button.
+   *
+   * @return the icon component
+   */
+  public Component getIcon() {
+    return getSlotAssigner().getSlotComponent(null);
+  }
+
+  /**
    * Adds a {@link ButtonClickEvent} listener for the component.
    *
    * @param listener the event listener to be added
@@ -226,6 +295,7 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
   @Override
   protected void onAttach() {
     super.onAttach();
+    getSlotAssigner().attach();
 
     if (Boolean.TRUE.equals(disableOnClick)) {
       setDisableOnClick(disableOnClick);
@@ -238,5 +308,9 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
     } catch (IllegalAccessException e) {
       throw new WebforjRuntimeException(e);
     }
+  }
+
+  SlotAssigner getSlotAssigner() {
+    return slotAssigner;
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/button/DwcButton.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/button/DwcButton.java
@@ -42,7 +42,6 @@ import java.util.List;
 public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcFocusableComponent<T>
     implements HasExpanse<T, Expanse>, HasTheme<T, ButtonTheme>, HasHorizontalAlignment<T>,
     HasFocusStatus, HasPrefixAndSuffix<T> {
-  private static final String ICON_SLOT = "icon";
   private boolean disableOnClick = false;
 
   private final ComponentEventSinkRegistry<ButtonClickEvent> clickEventSinkListenerRegistry =
@@ -186,7 +185,6 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public T setPrefixComponent(Component prefix) {
     super.setPrefixComponent(prefix);
     return getSelf();
@@ -198,7 +196,6 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public Component getPrefixComponent() {
     return super.getPrefixComponent();
   }
@@ -209,7 +206,6 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public T setSuffixComponent(Component suffix) {
     super.setSuffixComponent(suffix);
     return getSelf();
@@ -221,7 +217,6 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public Component getSuffixComponent() {
     return super.getSuffixComponent();
   }
@@ -229,11 +224,19 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
   /**
    * Sets the icon of the button.
    *
+   * <p>
+   * Setting the icon will remove the text label of the button and only show the icon. Additionally,
+   * the icon the button expands will be set to {@link Expanse#NONE}.
+   * </p>
+   *
    * @param icon the icon of the button
    * @return the icon component
+   *
+   * @since 24.11
    */
   public Component setIcon(Component icon) {
     getSlotAssigner().reAssign(null, icon);
+    setExpanse(Expanse.NONE);
     return icon;
   }
 
@@ -241,6 +244,8 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * Returns the icon of the button.
    *
    * @return the icon component
+   *
+   * @since 24.11
    */
   public Component getIcon() {
     return getSlotAssigner().getSlotComponent(null);

--- a/webforj-foundation/src/main/java/com/webforj/component/button/DwcButton.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/button/DwcButton.java
@@ -7,7 +7,6 @@ import com.webforj.bridge.ComponentAccessor;
 import com.webforj.component.Component;
 import com.webforj.component.DwcFocusableComponent;
 import com.webforj.component.Expanse;
-import com.webforj.component.SlotAssigner;
 import com.webforj.component.button.event.ButtonClickEvent;
 import com.webforj.component.button.sink.ButtonClickEventSink;
 import com.webforj.component.event.ComponentEventSinkRegistry;
@@ -43,10 +42,7 @@ import java.util.List;
 public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcFocusableComponent<T>
     implements HasExpanse<T, Expanse>, HasTheme<T, ButtonTheme>, HasHorizontalAlignment<T>,
     HasFocusStatus, HasPrefixAndSuffix<T> {
-  private static final String PREFIX_SLOT = "prefix";
-  private static final String SUFFIX_SLOT = "suffix";
   private static final String ICON_SLOT = "icon";
-  private final SlotAssigner slotAssigner = new SlotAssigner(this);
   private boolean disableOnClick = false;
 
   private final ComponentEventSinkRegistry<ButtonClickEvent> clickEventSinkListenerRegistry =
@@ -190,8 +186,9 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public T setPrefixComponent(Component prefix) {
-    getSlotAssigner().reAssign(PREFIX_SLOT, prefix);
+    super.setPrefixComponent(prefix);
     return getSelf();
   }
 
@@ -201,8 +198,9 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public Component getPrefixComponent() {
-    return getSlotAssigner().getSlotComponent(PREFIX_SLOT);
+    return super.getPrefixComponent();
   }
 
   /**
@@ -211,8 +209,9 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public T setSuffixComponent(Component suffix) {
-    getSlotAssigner().reAssign(SUFFIX_SLOT, suffix);
+    super.setSuffixComponent(suffix);
     return getSelf();
   }
 
@@ -222,8 +221,9 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public Component getSuffixComponent() {
-    return getSlotAssigner().getSlotComponent(SUFFIX_SLOT);
+    return super.getSuffixComponent();
   }
 
   /**
@@ -295,7 +295,6 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
   @Override
   protected void onAttach() {
     super.onAttach();
-    getSlotAssigner().attach();
 
     if (Boolean.TRUE.equals(disableOnClick)) {
       setDisableOnClick(disableOnClick);
@@ -308,9 +307,5 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
     } catch (IllegalAccessException e) {
       throw new WebforjRuntimeException(e);
     }
-  }
-
-  SlotAssigner getSlotAssigner() {
-    return slotAssigner;
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/DwcField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/DwcField.java
@@ -1,8 +1,10 @@
 package com.webforj.component.field;
 
 import com.webforj.annotation.ExcludeFromJacocoGeneratedReport;
+import com.webforj.component.Component;
 import com.webforj.component.DwcValidatableComponent;
 import com.webforj.component.Expanse;
+import com.webforj.component.SlotAssigner;
 import com.webforj.component.event.ComponentEventSinkRegistry;
 import com.webforj.component.event.KeypressEvent;
 import com.webforj.component.event.ModifyEvent;
@@ -14,6 +16,7 @@ import com.webforj.concern.HasHelperText;
 import com.webforj.concern.HasHighlightOnFocus;
 import com.webforj.concern.HasLabel;
 import com.webforj.concern.HasPlaceholder;
+import com.webforj.concern.HasPrefixAndSuffix;
 import com.webforj.concern.HasReadOnly;
 import com.webforj.concern.HasRequired;
 import com.webforj.data.concern.ValueChangeModeAware;
@@ -37,10 +40,12 @@ import com.webforj.dispatcher.ListenerRegistration;
  * @since 23.05
  */
 public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasReadOnly<T>, V>
-    extends DwcValidatableComponent<T, V>
-    implements HasLabel<T>, HasReadOnly<T>, HasRequired<T>, HasExpanse<T, Expanse>, HasFocusStatus,
-    HasHighlightOnFocus<T>, HasPlaceholder<T>, ValueChangeModeAware<T>, HasHelperText<T> {
-
+    extends DwcValidatableComponent<T, V> implements HasLabel<T>, HasReadOnly<T>, HasRequired<T>,
+    HasExpanse<T, Expanse>, HasFocusStatus, HasHighlightOnFocus<T>, HasPlaceholder<T>,
+    ValueChangeModeAware<T>, HasHelperText<T>, HasPrefixAndSuffix<T> {
+  private static final String PREFIX_SLOT = "prefix";
+  private static final String SUFFIX_SLOT = "suffix";
+  private final SlotAssigner slotAssigner = new SlotAssigner(this);
   private final ComponentEventSinkRegistry<ModifyEvent> modifyEventSinkListenerRegistry =
       new ComponentEventSinkRegistry<>(new ModifyEventSink(this, getEventDispatcher()),
           ModifyEvent.class);
@@ -370,6 +375,48 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public T setPrefixComponent(Component prefix) {
+    getSlotAssigner().reAssign(PREFIX_SLOT, prefix);
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public Component getPrefixComponent() {
+    return getSlotAssigner().getSlotComponent(PREFIX_SLOT);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public T setSuffixComponent(Component suffix) {
+    getSlotAssigner().reAssign(SUFFIX_SLOT, suffix);
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public Component getSuffixComponent() {
+    return getSlotAssigner().getSlotComponent(SUFFIX_SLOT);
+  }
+
+  /**
    * Adds a {@link ModifyEvent} listener for the component.
    *
    * @param listener the event listener to be added
@@ -453,6 +500,15 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void onAttach() {
+    super.onAttach();
+    getSlotAssigner().attach();
+  }
+
+  /**
    * Converts the value from a string to the appropriate type.
    *
    * @param value the value to be converted
@@ -470,5 +526,9 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
 
     ValueChangeEvent<V> valueChangeEvent = new ValueChangeEvent<>(this, value);
     getEventDispatcher().dispatchEvent(valueChangeEvent);
+  }
+
+  SlotAssigner getSlotAssigner() {
+    return slotAssigner;
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/DwcField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/DwcField.java
@@ -4,7 +4,6 @@ import com.webforj.annotation.ExcludeFromJacocoGeneratedReport;
 import com.webforj.component.Component;
 import com.webforj.component.DwcValidatableComponent;
 import com.webforj.component.Expanse;
-import com.webforj.component.SlotAssigner;
 import com.webforj.component.event.ComponentEventSinkRegistry;
 import com.webforj.component.event.KeypressEvent;
 import com.webforj.component.event.ModifyEvent;
@@ -43,9 +42,6 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
     extends DwcValidatableComponent<T, V> implements HasLabel<T>, HasReadOnly<T>, HasRequired<T>,
     HasExpanse<T, Expanse>, HasFocusStatus, HasHighlightOnFocus<T>, HasPlaceholder<T>,
     ValueChangeModeAware<T>, HasHelperText<T>, HasPrefixAndSuffix<T> {
-  private static final String PREFIX_SLOT = "prefix";
-  private static final String SUFFIX_SLOT = "suffix";
-  private final SlotAssigner slotAssigner = new SlotAssigner(this);
   private final ComponentEventSinkRegistry<ModifyEvent> modifyEventSinkListenerRegistry =
       new ComponentEventSinkRegistry<>(new ModifyEventSink(this, getEventDispatcher()),
           ModifyEvent.class);
@@ -380,8 +376,9 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public T setPrefixComponent(Component prefix) {
-    getSlotAssigner().reAssign(PREFIX_SLOT, prefix);
+    super.setPrefixComponent(prefix);
     return getSelf();
   }
 
@@ -391,8 +388,9 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public Component getPrefixComponent() {
-    return getSlotAssigner().getSlotComponent(PREFIX_SLOT);
+    return super.getPrefixComponent();
   }
 
   /**
@@ -401,8 +399,9 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public T setSuffixComponent(Component suffix) {
-    getSlotAssigner().reAssign(SUFFIX_SLOT, suffix);
+    super.setSuffixComponent(suffix);
     return getSelf();
   }
 
@@ -412,8 +411,9 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public Component getSuffixComponent() {
-    return getSlotAssigner().getSlotComponent(SUFFIX_SLOT);
+    return super.getSuffixComponent();
   }
 
   /**
@@ -500,15 +500,6 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
   }
 
   /**
-   * {@inheritDoc}
-   */
-  @Override
-  protected void onAttach() {
-    super.onAttach();
-    getSlotAssigner().attach();
-  }
-
-  /**
    * Converts the value from a string to the appropriate type.
    *
    * @param value the value to be converted
@@ -526,9 +517,5 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
 
     ValueChangeEvent<V> valueChangeEvent = new ValueChangeEvent<>(this, value);
     getEventDispatcher().dispatchEvent(valueChangeEvent);
-  }
-
-  SlotAssigner getSlotAssigner() {
-    return slotAssigner;
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/DwcField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/DwcField.java
@@ -376,7 +376,6 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public T setPrefixComponent(Component prefix) {
     super.setPrefixComponent(prefix);
     return getSelf();
@@ -388,7 +387,6 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public Component getPrefixComponent() {
     return super.getPrefixComponent();
   }
@@ -399,7 +397,6 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public T setSuffixComponent(Component suffix) {
     super.setSuffixComponent(suffix);
     return getSelf();
@@ -411,7 +408,6 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public Component getSuffixComponent() {
     return super.getSuffixComponent();
   }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
@@ -316,7 +316,6 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public T setPrefixComponent(Component prefix) {
     super.setPrefixComponent(prefix);
     return getSelf();
@@ -328,7 +327,6 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public Component getPrefixComponent() {
     return super.getPrefixComponent();
   }
@@ -339,7 +337,6 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public T setSuffixComponent(Component suffix) {
     super.setSuffixComponent(suffix);
     return getSelf();
@@ -351,7 +348,6 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    * @since 24.11
    */
   @Override
-  @ExcludeFromJacocoGeneratedReport
   public Component getSuffixComponent() {
     return super.getSuffixComponent();
   }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
@@ -2,9 +2,9 @@ package com.webforj.component.list;
 
 import com.basis.bbj.proxies.sysgui.BBjComboBox;
 import com.basis.startup.type.BBjException;
+import com.webforj.annotation.ExcludeFromJacocoGeneratedReport;
 import com.webforj.bridge.ComponentAccessor;
 import com.webforj.component.Component;
-import com.webforj.component.SlotAssigner;
 import com.webforj.component.event.ComponentEventSinkRegistry;
 import com.webforj.component.list.event.ListClickEvent;
 import com.webforj.component.list.event.ListCloseEvent;
@@ -43,9 +43,6 @@ import com.webforj.exceptions.WebforjRuntimeException;
 @SuppressWarnings("squid:S110")
 public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends DwcList<T, Object>
     implements BindAware, HasPrefixAndSuffix<T> {
-  private static final String PREFIX_SLOT = "prefix";
-  private static final String SUFFIX_SLOT = "suffix";
-  private final SlotAssigner slotAssigner = new SlotAssigner(this);
   private final ComponentEventSinkRegistry<ListOpenEvent> openEventSinkListenerRegistry =
       new ComponentEventSinkRegistry<>(new ListOpenEventSink(this, getEventDispatcher()),
           ListOpenEvent.class);
@@ -319,8 +316,9 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public T setPrefixComponent(Component prefix) {
-    getSlotAssigner().reAssign(PREFIX_SLOT, prefix);
+    super.setPrefixComponent(prefix);
     return getSelf();
   }
 
@@ -330,8 +328,9 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public Component getPrefixComponent() {
-    return getSlotAssigner().getSlotComponent(PREFIX_SLOT);
+    return super.getPrefixComponent();
   }
 
   /**
@@ -340,8 +339,9 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public T setSuffixComponent(Component suffix) {
-    getSlotAssigner().reAssign(SUFFIX_SLOT, suffix);
+    super.setSuffixComponent(suffix);
     return getSelf();
   }
 
@@ -351,8 +351,9 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    * @since 24.11
    */
   @Override
+  @ExcludeFromJacocoGeneratedReport
   public Component getSuffixComponent() {
-    return getSlotAssigner().getSlotComponent(SUFFIX_SLOT);
+    return super.getSuffixComponent();
   }
 
   /**
@@ -470,7 +471,6 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
   @Override
   protected void onAttach() {
     super.onAttach();
-    getSlotAssigner().attach();
 
     catchupItemsChanges();
     catchupSingleSelection();
@@ -486,9 +486,5 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
     } catch (IllegalAccessException e) {
       throw new WebforjRuntimeException(e);
     }
-  }
-
-  SlotAssigner getSlotAssigner() {
-    return slotAssigner;
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
@@ -3,6 +3,8 @@ package com.webforj.component.list;
 import com.basis.bbj.proxies.sysgui.BBjComboBox;
 import com.basis.startup.type.BBjException;
 import com.webforj.bridge.ComponentAccessor;
+import com.webforj.component.Component;
+import com.webforj.component.SlotAssigner;
 import com.webforj.component.event.ComponentEventSinkRegistry;
 import com.webforj.component.list.event.ListClickEvent;
 import com.webforj.component.list.event.ListCloseEvent;
@@ -11,6 +13,7 @@ import com.webforj.component.list.event.ListSelectEvent;
 import com.webforj.component.list.sink.ListClickEventSink;
 import com.webforj.component.list.sink.ListCloseEventSink;
 import com.webforj.component.list.sink.ListOpenEventSink;
+import com.webforj.concern.HasPrefixAndSuffix;
 import com.webforj.data.binding.Binding;
 import com.webforj.data.binding.BindingContext;
 import com.webforj.data.binding.concern.BindAware;
@@ -39,7 +42,10 @@ import com.webforj.exceptions.WebforjRuntimeException;
 // framework's needs. The current structure is essential for meeting those needs.
 @SuppressWarnings("squid:S110")
 public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends DwcList<T, Object>
-    implements BindAware {
+    implements BindAware, HasPrefixAndSuffix<T> {
+  private static final String PREFIX_SLOT = "prefix";
+  private static final String SUFFIX_SLOT = "suffix";
+  private final SlotAssigner slotAssigner = new SlotAssigner(this);
   private final ComponentEventSinkRegistry<ListOpenEvent> openEventSinkListenerRegistry =
       new ComponentEventSinkRegistry<>(new ListOpenEventSink(this, getEventDispatcher()),
           ListOpenEvent.class);
@@ -308,6 +314,48 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public T setPrefixComponent(Component prefix) {
+    getSlotAssigner().reAssign(PREFIX_SLOT, prefix);
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public Component getPrefixComponent() {
+    return getSlotAssigner().getSlotComponent(PREFIX_SLOT);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public T setSuffixComponent(Component suffix) {
+    getSlotAssigner().reAssign(SUFFIX_SLOT, suffix);
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 24.11
+   */
+  @Override
+  public Component getSuffixComponent() {
+    return getSlotAssigner().getSlotComponent(SUFFIX_SLOT);
+  }
+
+  /**
    * Adds a {@link ListOpenEvent} listener for the component.
    *
    * @param listener the event listener to be added
@@ -422,6 +470,7 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
   @Override
   protected void onAttach() {
     super.onAttach();
+    getSlotAssigner().attach();
 
     catchupItemsChanges();
     catchupSingleSelection();
@@ -437,5 +486,9 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
     } catch (IllegalAccessException e) {
       throw new WebforjRuntimeException(e);
     }
+  }
+
+  SlotAssigner getSlotAssigner() {
+    return slotAssigner;
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/tabbedpane/Tab.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tabbedpane/Tab.java
@@ -1,5 +1,7 @@
 package com.webforj.component.tabbedpane;
 
+import com.webforj.component.Component;
+import com.webforj.component.SlotRegistry;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.UUID;
@@ -24,12 +26,32 @@ import java.util.UUID;
  * @see TabbedPane
  */
 public final class Tab {
+  static final String PREFIX_SLOT = "prefix";
+  static final String SUFFIX_SLOT = "suffix";
   private Object key = null;
   private String text = "";
   private String tooltip = "";
   private boolean enabled = true;
   private boolean closable = false;
+  private Component prefix = null;
+  private Component suffix = null;
+  private final SlotRegistry slotRegistry = new SlotRegistry();
   private final PropertyChangeSupport changeSupport = new PropertyChangeSupport(this);
+
+  /**
+   * Constructs a tab with the given text and prefix component.
+   *
+   * @param text the tab text.
+   * @param prefix the prefix component
+   * @since 24.11
+   */
+  public Tab(String text, Component prefix) {
+    this.key = UUID.randomUUID();
+    setText(text);
+    if (prefix != null) {
+      setPrefixComponent(prefix);
+    }
+  }
 
   /**
    * Constructs a tab with the given text.
@@ -37,8 +59,7 @@ public final class Tab {
    * @param text the tab text.
    */
   public Tab(String text) {
-    this.key = UUID.randomUUID();
-    this.text = text;
+    this(text, null);
   }
 
   /**
@@ -161,6 +182,70 @@ public final class Tab {
   }
 
   /**
+   * Sets the prefix component for the tab.
+   *
+   * <p>
+   * The prefix component is the component that is displayed in the tab's prefix slot. If a prefix
+   * component is already set, then the old prefix component will be destroyed and replaced with the
+   * new one.
+   * </p>
+   *
+   * @param prefix the prefix component to set
+   * @return the tab
+   * @since 24.11
+   */
+  public Tab setPrefixComponent(Component prefix) {
+    Component oldValue = this.prefix;
+    this.prefix = prefix;
+    this.changeSupport.firePropertyChange(PREFIX_SLOT, oldValue, prefix);
+    slotRegistry.replaceComponentsInSlot(PREFIX_SLOT, prefix);
+
+    return this;
+  }
+
+  /**
+   * Retrieves the prefix component for the tab.
+   *
+   * @return the prefix component for the tab
+   * @since 24.11
+   */
+  public Component getPrefixComponent() {
+    return prefix;
+  }
+
+  /**
+   * Sets the suffix component for the tab.
+   *
+   * <p>
+   * The suffix component is the component that is displayed in the tab's suffix slot. If a suffix
+   * component is already set, then the old suffix component will be destroyed and replaced with the
+   * new one.
+   * </p>
+   *
+   * @param suffix the suffix component to set
+   * @return the tab
+   * @since 24.11
+   */
+  public Tab setSuffixComponent(Component suffix) {
+    Component oldValue = this.suffix;
+    this.suffix = suffix;
+    this.changeSupport.firePropertyChange(SUFFIX_SLOT, oldValue, suffix);
+    slotRegistry.addComponentsToSlot(SUFFIX_SLOT, suffix);
+
+    return this;
+  }
+
+  /**
+   * Retrieves the suffix component for the tab.
+   *
+   * @return the suffix component for the tab
+   * @since 24.11
+   */
+  public Component getSuffixComponent() {
+    return suffix;
+  }
+
+  /**
    * Adds a property change listener.
    *
    * @param listener the listener
@@ -169,5 +254,14 @@ public final class Tab {
   Tab addPropertyChangeListener(PropertyChangeListener listener) {
     this.changeSupport.addPropertyChangeListener(listener);
     return this;
+  }
+
+  /**
+   * Gets the slot registry associated with this tab.
+   *
+   * @return the slot registry
+   */
+  SlotRegistry getSlotRegistry() {
+    return slotRegistry;
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/tabbedpane/TabChangeListener.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tabbedpane/TabChangeListener.java
@@ -2,6 +2,8 @@ package com.webforj.component.tabbedpane;
 
 import com.basis.bbj.proxies.sysgui.BBjTabCtrl;
 import com.basis.startup.type.BBjException;
+import com.webforj.component.Component;
+import com.webforj.component.SlotAssigner;
 import com.webforj.exceptions.WebforjRuntimeException;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -50,6 +52,14 @@ final class TabChangeListener implements PropertyChangeListener {
 
         case "tooltip":
           setToolTip(index, (String) evt.getNewValue());
+          break;
+
+        case "prefix":
+          setSlot(index, "prefix", (Component) evt.getNewValue());
+          break;
+
+        case "suffix":
+          setSlot(index, "suffix", (Component) evt.getNewValue());
           break;
 
         default:
@@ -123,6 +133,29 @@ final class TabChangeListener implements PropertyChangeListener {
       } catch (BBjException e) {
         throw new WebforjRuntimeException(e);
       }
+    }
+  }
+
+  /**
+   * Sets the slot of the tab at the specified index.
+   *
+   * @param index The index of the tab.
+   * @param slot The slot to set.
+   * @param component The component to set.
+   */
+  private void setSlot(int index, String slot, Component component) {
+    BBjTabCtrl tabCtrl = this.tabbedPane.inferTabCtrl();
+    if (tabCtrl != null) {
+      SlotAssigner assigner =
+          new SlotAssigner(this.tabbedPane, (theSlot, targeControl, slotControl) -> {
+            try {
+              ((BBjTabCtrl) targeControl).setSlotAt(index, theSlot, slotControl);
+            } catch (BBjException e) {
+              throw new WebforjRuntimeException("Failed to set slot for tab at index " + index, e);
+            }
+          });
+      assigner.reAssign(slot, component);
+      assigner.attach();
     }
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/concern/HasPrefix.java
+++ b/webforj-foundation/src/main/java/com/webforj/concern/HasPrefix.java
@@ -1,0 +1,59 @@
+package com.webforj.concern;
+
+import com.webforj.component.Component;
+import com.webforj.component.ComponentUtil;
+
+/**
+ * An interface for modifying a component's prefix component.
+ *
+ * <p>
+ * This interface provides methods to set and retrieve the prefix component for the component.
+ * </p>
+ *
+ * @param <T> the type of the component that implements this interface.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public interface HasPrefix<T extends Component> {
+
+  /**
+   * Sets the prefix component for the component.
+   *
+   * <p>
+   * The prefix component is the component that is displayed in the component's prefix slot. If a
+   * prefix component is already set, then the old prefix component will be destroyed and replaced
+   * with the new one.
+   * </p>
+   *
+   * @param prefix the prefix component to set
+   * @return the component itself.
+   */
+  public default T setPrefixComponent(Component prefix) {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasPrefix) {
+      ((HasPrefix<?>) component).setPrefixComponent(prefix);
+      return (T) this;
+    }
+
+    throw new UnsupportedOperationException(
+        "The component does not support setting a prefix component");
+  }
+
+  /**
+   * Retrieves the prefix component for the component.
+   *
+   * @return the prefix component for the component.
+   */
+  public default Component getPrefixComponent() {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasPrefix) {
+      return ((HasPrefix<?>) component).getPrefixComponent();
+    }
+
+    throw new UnsupportedOperationException(
+        "The component does not support setting a prefix component");
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/concern/HasPrefixAndSuffix.java
+++ b/webforj-foundation/src/main/java/com/webforj/concern/HasPrefixAndSuffix.java
@@ -1,0 +1,22 @@
+package com.webforj.concern;
+
+import com.webforj.component.Component;
+
+/**
+ * An interface for modifying a component's prefix and suffix components.
+ *
+ * <p>
+ * This interface provides methods to set and retrieve the prefix and suffix components for the
+ * component.
+ * </p>
+ *
+ * @param <T> the type of the component that implements this interface.
+ *
+ * @see HasPrefix
+ * @see HasSuffix
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public interface HasPrefixAndSuffix<T extends Component> extends HasPrefix<T>, HasSuffix<T> {
+}

--- a/webforj-foundation/src/main/java/com/webforj/concern/HasSuffix.java
+++ b/webforj-foundation/src/main/java/com/webforj/concern/HasSuffix.java
@@ -1,0 +1,59 @@
+package com.webforj.concern;
+
+import com.webforj.component.Component;
+import com.webforj.component.ComponentUtil;
+
+/**
+ * An interface for modifying a component's suffix component.
+ *
+ * <p>
+ * This interface provides methods to set and retrieve the suffix component for the component.
+ * </p>
+ *
+ * @param <T> the type of the component that implements this interface.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.11
+ */
+public interface HasSuffix<T extends Component> {
+
+  /**
+   * Sets the suffix component for the component.
+   *
+   * <p>
+   * The suffix component is the component that is displayed in the component's suffix slot. If a
+   * suffix component is already set, then the old suffix component will be destroyed and replaced
+   * with the new one.
+   * </p>
+   *
+   * @param suffix the suffix component to set
+   * @return the component itself.
+   */
+  public default T setSuffixComponent(Component suffix) {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasSuffix) {
+      ((HasSuffix<?>) component).setSuffixComponent(suffix);
+      return (T) this;
+    }
+
+    throw new UnsupportedOperationException(
+        "The component does not support setting a suffix component");
+  }
+
+  /**
+   * Retrieves the suffix component for the component.
+   *
+   * @return the suffix component for the component.
+   */
+  public default Component getSuffixComponent() {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasSuffix) {
+      return ((HasSuffix<?>) component).getSuffixComponent();
+    }
+
+    throw new UnsupportedOperationException(
+        "The component does not support setting a suffix component");
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -741,6 +742,41 @@ class DwcComponentTest {
       assertEquals("200px", spy.getComputedHeight());
       assertEquals("100px", spy.getComputedMinHeight());
       assertEquals("300px", spy.getComputedMaxHeight());
+    }
+  }
+
+  @Nested
+  class SlotsApi {
+
+    @Test
+    void shouldSetAndGetPrefix() {
+      Component prefixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      assertEquals(prefixComponent, component.getPrefixComponent());
+    }
+
+    @Test
+    void shouldSetAndGetSuffix() {
+      Component suffixComponent = mock(Component.class);
+      component.setSuffixComponent(suffixComponent);
+      assertEquals(suffixComponent, component.getSuffixComponent());
+    }
+
+    @Test
+    void shouldAttachPrefixAndSuffix() {
+      component = spy(component);
+      SlotAssigner slotAssigner = mock(SlotAssigner.class);
+      doReturn(slotAssigner).when(component).getSlotAssigner();
+
+      Component prefixComponent = mock(Component.class);
+      Component suffixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      component.setSuffixComponent(suffixComponent);
+
+      component.onAttach();
+
+      verify(slotAssigner, times(1)).attach();
+      verify(slotAssigner, times(1)).attach();
     }
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/component/SlotAssignerTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/SlotAssignerTest.java
@@ -1,0 +1,205 @@
+
+package com.webforj.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.basis.bbj.proxies.sysgui.BBjControl;
+import com.basis.startup.type.BBjException;
+import com.webforj.component.window.Window;
+import com.webforj.exceptions.WebforjRuntimeException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SlotAssignerTest {
+
+  SlotAssigner slotAssigner;
+  Component containerComponent;
+  SlotRegistry slotRegistry;
+  BBjControl controlMock;
+
+  @BeforeEach
+  void setUp() {
+    containerComponent = mock(Component.class);
+    slotAssigner = new SlotAssigner(containerComponent);
+  }
+
+  @Test
+  void shouldReturnSlotRegistry() {
+    assertNotNull(slotAssigner.getSlotRegistry());
+  }
+
+  @Test
+  void shouldReturnCustomSlotRegistry() {
+    SlotRegistry customSlotRegistry = new SlotRegistry();
+    slotAssigner = new SlotAssigner(containerComponent, null, customSlotRegistry);
+    assertEquals(customSlotRegistry, slotAssigner.getSlotRegistry());
+  }
+
+  @Test
+  void shouldAssignSlots() throws BBjException {
+    SlotAssigner spy = spy(slotAssigner);
+
+    // Slot component
+    Component slotComponentMock = mock(Component.class);
+    BBjControl slotControlMock = mock(BBjControl.class);
+
+    spy.assign("main", slotComponentMock);
+    doReturn(slotControlMock).when(spy).getControl(slotComponentMock);
+
+    // Container component
+    Window containerWindowMock = mock(Window.class);
+    BBjControl containerControlMock = mock(BBjControl.class);
+
+    doReturn(containerWindowMock).when(containerComponent).getWindow();
+    doReturn(containerControlMock).when(spy).getControl(containerComponent);
+
+    spy.attach();
+
+    verify(containerWindowMock).add(slotComponentMock);
+    verify(containerControlMock).setSlot("main", slotControlMock);
+  }
+
+  @Test
+  void shouldThrowExceptionForSlotsAlreadyAssigned() {
+    SlotAssigner spy = spy(slotAssigner);
+
+    // Slot component
+    Component slotComponentMock = mock(Component.class);
+    BBjControl slotControlMock = mock(BBjControl.class);
+
+    spy.assign("main", slotComponentMock);
+    doReturn(slotControlMock).when(spy).getControl(slotComponentMock);
+
+    // Container component
+    Window containerWindowMock = mock(Window.class);
+    BBjControl containerControlMock = mock(BBjControl.class);
+
+    doReturn(containerWindowMock).when(containerComponent).getWindow();
+    doReturn(containerControlMock).when(spy).getControl(containerComponent);
+
+    spy.attach();
+    assertThrows(IllegalStateException.class, () -> spy.attach());
+  }
+
+  @Test
+  void shouldUseCustomAssigner() {
+    AtomicReference<String> slotNameRef = new AtomicReference<>();
+    AtomicReference<BBjControl> targetControlRef = new AtomicReference<>();
+    AtomicReference<BBjControl> slotControlRef = new AtomicReference<>();
+    SlotAssigner spy =
+        spy(new SlotAssigner(containerComponent, (slot, targetControl, slotControl) -> {
+          slotNameRef.set(slot);
+          targetControlRef.set(targetControl);
+          slotControlRef.set(slotControl);
+        }));
+
+    // Slot component
+    Component slotComponentMock = mock(Component.class);
+    BBjControl slotControlMock = mock(BBjControl.class);
+
+    spy.assign("main", slotComponentMock);
+    doReturn(slotControlMock).when(spy).getControl(slotComponentMock);
+
+    // Container component
+    Window containerWindowMock = mock(Window.class);
+    BBjControl containerControlMock = mock(BBjControl.class);
+
+    doReturn(containerWindowMock).when(containerComponent).getWindow();
+    doReturn(containerControlMock).when(spy).getControl(containerComponent);
+
+    spy.attach();
+
+    assertEquals("main", slotNameRef.get());
+    assertEquals(containerControlMock, targetControlRef.get());
+    assertEquals(slotControlMock, slotControlRef.get());
+  }
+
+  @Test
+  void shouldNotQueueAssignment() throws BBjException {
+    SlotAssigner spy = spy(slotAssigner);
+    doReturn(true).when(spy).isAttached();
+
+    // Slot component
+    Component slotComponentMock = mock(Component.class);
+    BBjControl slotControlMock = mock(BBjControl.class);
+
+    doReturn(slotControlMock).when(spy).getControl(slotComponentMock);
+
+    // Container component
+    Window containerWindowMock = mock(Window.class);
+    BBjControl containerControlMock = mock(BBjControl.class);
+
+    doReturn(containerWindowMock).when(containerComponent).getWindow();
+    doReturn(containerControlMock).when(spy).getControl(containerComponent);
+
+    spy.assign("main", slotComponentMock);
+
+    verify(containerWindowMock).add(slotComponentMock);
+    verify(containerControlMock).setSlot("main", slotControlMock);
+  }
+
+  @Test
+  void shouldThrowExceptionIfSlotComponentIsDestroyed() {
+    SlotAssigner spy = spy(slotAssigner);
+
+    // Slot component
+    Component slotComponentMock = mock(Component.class);
+    doReturn(true).when(slotComponentMock).isDestroyed();
+
+    assertThrows(IllegalStateException.class, () -> spy.assign("main", slotComponentMock));
+  }
+
+  @Test
+  void shouldThrowExceptionIfSlotComponentIsDestroyedBeforeAttach() {
+    SlotAssigner spy = spy(slotAssigner);
+
+    // Slot component
+    Component slotComponentMock = mock(Component.class);
+    BBjControl slotControlMock = mock(BBjControl.class);
+
+    spy.assign("main", slotComponentMock);
+    doReturn(slotControlMock).when(spy).getControl(slotComponentMock);
+
+    // Container component
+    Window containerWindowMock = mock(Window.class);
+    BBjControl containerControlMock = mock(BBjControl.class);
+
+    doReturn(containerWindowMock).when(containerComponent).getWindow();
+    doReturn(containerControlMock).when(spy).getControl(containerComponent);
+
+    doReturn(true).when(slotComponentMock).isDestroyed();
+
+    assertThrows(IllegalStateException.class, () -> spy.attach());
+  }
+
+  @Test
+  void shouldCatchDefaultAssignerExceptions() throws BBjException {
+    SlotAssigner spy = spy(slotAssigner);
+
+    // Slot component
+    Component slotComponentMock = mock(Component.class);
+    BBjControl slotControlMock = mock(BBjControl.class);
+
+    spy.assign("main", slotComponentMock);
+    doReturn(slotControlMock).when(spy).getControl(slotComponentMock);
+
+    // Container component
+    Window containerWindowMock = mock(Window.class);
+    BBjControl containerControlMock = mock(BBjControl.class);
+
+    doReturn(containerWindowMock).when(containerComponent).getWindow();
+    doReturn(containerControlMock).when(spy).getControl(containerComponent);
+
+    doThrow(BBjException.class).when(containerControlMock).setSlot("main", slotControlMock);
+
+    assertThrows(WebforjRuntimeException.class, () -> spy.attach());
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/component/SlotRegistryTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/SlotRegistryTest.java
@@ -159,6 +159,17 @@ class SlotRegistryTest {
     assertTrue(components.isEmpty());
   }
 
+  @Test
+  void shouldReturnSlots() {
+    slotRegistry.addComponentsToSlot("header", component1);
+    slotRegistry.addComponentsToSlot("footer", component2);
+
+    List<String> slots = slotRegistry.getSlots();
+    assertEquals(2, slots.size());
+    assertTrue(slots.contains("header"));
+    assertTrue(slots.contains("footer"));
+  }
+
   static class TestComponent extends Component {
 
     @Override

--- a/webforj-foundation/src/test/java/com/webforj/component/button/DwcButtonTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/button/DwcButtonTest.java
@@ -5,16 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.basis.bbj.proxies.sysgui.BBjButton;
 import com.basis.startup.type.BBjException;
-import com.webforj.component.Component;
 import com.webforj.component.ReflectionUtils;
-import com.webforj.component.SlotAssigner;
 import com.webforj.component.button.event.ButtonClickEvent;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
@@ -87,41 +83,6 @@ class DwcButtonTest {
 
       assertThrows(WebforjRuntimeException.class, () -> component.setDisableOnClick(true));
       assertThrows(WebforjRuntimeException.class, () -> component.isDisableOnClick());
-    }
-  }
-
-  @Nested
-  class SlotsApi {
-
-    @Test
-    void shouldSetAndGetPrefix() {
-      Component prefixComponent = mock(Component.class);
-      component.setPrefixComponent(prefixComponent);
-      assertEquals(prefixComponent, component.getPrefixComponent());
-    }
-
-    @Test
-    void shouldSetAndGetSuffix() {
-      Component suffixComponent = mock(Component.class);
-      component.setSuffixComponent(suffixComponent);
-      assertEquals(suffixComponent, component.getSuffixComponent());
-    }
-
-    @Test
-    void shouldAttachPrefixAndSuffix() {
-      component = spy(component);
-      SlotAssigner slotAssigner = mock(SlotAssigner.class);
-      doReturn(slotAssigner).when(component).getSlotAssigner();
-
-      Component prefixComponent = mock(Component.class);
-      Component suffixComponent = mock(Component.class);
-      component.setPrefixComponent(prefixComponent);
-      component.setSuffixComponent(suffixComponent);
-
-      component.onAttach();
-
-      verify(slotAssigner, times(1)).attach();
-      verify(slotAssigner, times(1)).attach();
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/component/button/DwcButtonTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/button/DwcButtonTest.java
@@ -5,12 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.basis.bbj.proxies.sysgui.BBjButton;
 import com.basis.startup.type.BBjException;
+import com.webforj.component.Component;
 import com.webforj.component.ReflectionUtils;
+import com.webforj.component.SlotAssigner;
 import com.webforj.component.button.event.ButtonClickEvent;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
@@ -83,6 +87,41 @@ class DwcButtonTest {
 
       assertThrows(WebforjRuntimeException.class, () -> component.setDisableOnClick(true));
       assertThrows(WebforjRuntimeException.class, () -> component.isDisableOnClick());
+    }
+  }
+
+  @Nested
+  class SlotsApi {
+
+    @Test
+    void shouldSetAndGetPrefix() {
+      Component prefixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      assertEquals(prefixComponent, component.getPrefixComponent());
+    }
+
+    @Test
+    void shouldSetAndGetSuffix() {
+      Component suffixComponent = mock(Component.class);
+      component.setSuffixComponent(suffixComponent);
+      assertEquals(suffixComponent, component.getSuffixComponent());
+    }
+
+    @Test
+    void shouldAttachPrefixAndSuffix() {
+      component = spy(component);
+      SlotAssigner slotAssigner = mock(SlotAssigner.class);
+      doReturn(slotAssigner).when(component).getSlotAssigner();
+
+      Component prefixComponent = mock(Component.class);
+      Component suffixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      component.setSuffixComponent(suffixComponent);
+
+      component.onAttach();
+
+      verify(slotAssigner, times(1)).attach();
+      verify(slotAssigner, times(1)).attach();
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/component/button/DwcButtonTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/button/DwcButtonTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.basis.bbj.proxies.sysgui.BBjButton;
 import com.basis.startup.type.BBjException;
+import com.webforj.component.Component;
 import com.webforj.component.ReflectionUtils;
 import com.webforj.component.button.event.ButtonClickEvent;
 import com.webforj.dispatcher.EventListener;
@@ -101,6 +103,31 @@ class DwcButtonTest {
 
       r.remove();
       assertEquals(0, component.getEventListeners(ButtonClickEvent.class).size());
+    }
+  }
+
+  @Nested
+  class SlotsApi {
+
+    @Test
+    void shouldSetAndGetPrefix() {
+      Component prefixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      assertEquals(prefixComponent, component.getPrefixComponent());
+    }
+
+    @Test
+    void shouldSetAndGetSuffix() {
+      Component suffixComponent = mock(Component.class);
+      component.setSuffixComponent(suffixComponent);
+      assertEquals(suffixComponent, component.getSuffixComponent());
+    }
+
+    @Test
+    void shouldSetAndGetIcon() {
+      Component iconComponent = mock(Component.class);
+      component.setIcon(iconComponent);
+      assertEquals(iconComponent, component.getIcon());
     }
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/component/field/DwcFieldTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/field/DwcFieldTest.java
@@ -1,18 +1,13 @@
 package com.webforj.component.field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.basis.bbj.proxies.sysgui.BBjEditBox;
 import com.basis.startup.type.BBjException;
-import com.webforj.component.Component;
 import com.webforj.component.Expanse;
 import com.webforj.component.ReflectionUtils;
-import com.webforj.component.SlotAssigner;
 import com.webforj.component.event.BlurEvent;
 import com.webforj.component.event.KeypressEvent;
 import com.webforj.component.event.ModifyEvent;
@@ -139,41 +134,6 @@ class DwcFieldTest {
       assertEquals(true, component.isAutoFocus());
 
       verify(control, times(1)).setProperty("autofocus", true);
-    }
-  }
-
-  @Nested
-  class SlotsApi {
-
-    @Test
-    void shouldSetAndGetPrefix() {
-      Component prefixComponent = mock(Component.class);
-      component.setPrefixComponent(prefixComponent);
-      assertEquals(prefixComponent, component.getPrefixComponent());
-    }
-
-    @Test
-    void shouldSetAndGetSuffix() {
-      Component suffixComponent = mock(Component.class);
-      component.setSuffixComponent(suffixComponent);
-      assertEquals(suffixComponent, component.getSuffixComponent());
-    }
-
-    @Test
-    void shouldAttachPrefixAndSuffix() {
-      component = spy(component);
-      SlotAssigner slotAssigner = mock(SlotAssigner.class);
-      doReturn(slotAssigner).when(component).getSlotAssigner();
-
-      Component prefixComponent = mock(Component.class);
-      Component suffixComponent = mock(Component.class);
-      component.setPrefixComponent(prefixComponent);
-      component.setSuffixComponent(suffixComponent);
-
-      component.onAttach();
-
-      verify(slotAssigner, times(1)).attach();
-      verify(slotAssigner, times(1)).attach();
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/component/field/DwcFieldTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/field/DwcFieldTest.java
@@ -1,13 +1,18 @@
 package com.webforj.component.field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.basis.bbj.proxies.sysgui.BBjEditBox;
 import com.basis.startup.type.BBjException;
+import com.webforj.component.Component;
 import com.webforj.component.Expanse;
 import com.webforj.component.ReflectionUtils;
+import com.webforj.component.SlotAssigner;
 import com.webforj.component.event.BlurEvent;
 import com.webforj.component.event.KeypressEvent;
 import com.webforj.component.event.ModifyEvent;
@@ -134,6 +139,41 @@ class DwcFieldTest {
       assertEquals(true, component.isAutoFocus());
 
       verify(control, times(1)).setProperty("autofocus", true);
+    }
+  }
+
+  @Nested
+  class SlotsApi {
+
+    @Test
+    void shouldSetAndGetPrefix() {
+      Component prefixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      assertEquals(prefixComponent, component.getPrefixComponent());
+    }
+
+    @Test
+    void shouldSetAndGetSuffix() {
+      Component suffixComponent = mock(Component.class);
+      component.setSuffixComponent(suffixComponent);
+      assertEquals(suffixComponent, component.getSuffixComponent());
+    }
+
+    @Test
+    void shouldAttachPrefixAndSuffix() {
+      component = spy(component);
+      SlotAssigner slotAssigner = mock(SlotAssigner.class);
+      doReturn(slotAssigner).when(component).getSlotAssigner();
+
+      Component prefixComponent = mock(Component.class);
+      Component suffixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      component.setSuffixComponent(suffixComponent);
+
+      component.onAttach();
+
+      verify(slotAssigner, times(1)).attach();
+      verify(slotAssigner, times(1)).attach();
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/component/field/DwcFieldTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/field/DwcFieldTest.java
@@ -1,11 +1,13 @@
 package com.webforj.component.field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.basis.bbj.proxies.sysgui.BBjEditBox;
 import com.basis.startup.type.BBjException;
+import com.webforj.component.Component;
 import com.webforj.component.Expanse;
 import com.webforj.component.ReflectionUtils;
 import com.webforj.component.event.BlurEvent;
@@ -183,5 +185,23 @@ class DwcFieldTest {
     assertEquals("helper text", component.getHelperText());
 
     assertEquals("helper text", component.getProperty("helperText"));
+  }
+
+  @Nested
+  class SlotsApi {
+
+    @Test
+    void shouldSetAndGetPrefix() {
+      Component prefixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      assertEquals(prefixComponent, component.getPrefixComponent());
+    }
+
+    @Test
+    void shouldSetAndGetSuffix() {
+      Component suffixComponent = mock(Component.class);
+      component.setSuffixComponent(suffixComponent);
+      assertEquals(suffixComponent, component.getSuffixComponent());
+    }
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/component/list/DwcSelectDropdownTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/DwcSelectDropdownTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,9 +13,7 @@ import static org.mockito.Mockito.verify;
 import com.basis.bbj.proxies.sysgui.BBjListButton;
 import com.basis.startup.type.BBjException;
 import com.basis.startup.type.BBjVector;
-import com.webforj.component.Component;
 import com.webforj.component.ReflectionUtils;
-import com.webforj.component.SlotAssigner;
 import com.webforj.component.list.event.ListClickEvent;
 import com.webforj.component.list.event.ListCloseEvent;
 import com.webforj.component.list.event.ListOpenEvent;
@@ -198,41 +195,6 @@ class DwcSelectDropdownTest {
       component.onAttach();
 
       verify(control, times(1)).openList();
-    }
-  }
-
-  @Nested
-  class SlotsApi {
-
-    @Test
-    void shouldSetAndGetPrefix() {
-      Component prefixComponent = mock(Component.class);
-      component.setPrefixComponent(prefixComponent);
-      assertEquals(prefixComponent, component.getPrefixComponent());
-    }
-
-    @Test
-    void shouldSetAndGetSuffix() {
-      Component suffixComponent = mock(Component.class);
-      component.setSuffixComponent(suffixComponent);
-      assertEquals(suffixComponent, component.getSuffixComponent());
-    }
-
-    @Test
-    void shouldAttachPrefixAndSuffix() {
-      component = spy(component);
-      SlotAssigner slotAssigner = mock(SlotAssigner.class);
-      doReturn(slotAssigner).when(component).getSlotAssigner();
-
-      Component prefixComponent = mock(Component.class);
-      Component suffixComponent = mock(Component.class);
-      component.setPrefixComponent(prefixComponent);
-      component.setSuffixComponent(suffixComponent);
-
-      component.onAttach();
-
-      verify(slotAssigner, times(1)).attach();
-      verify(slotAssigner, times(1)).attach();
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/component/list/DwcSelectDropdownTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/DwcSelectDropdownTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -13,7 +14,9 @@ import static org.mockito.Mockito.verify;
 import com.basis.bbj.proxies.sysgui.BBjListButton;
 import com.basis.startup.type.BBjException;
 import com.basis.startup.type.BBjVector;
+import com.webforj.component.Component;
 import com.webforj.component.ReflectionUtils;
+import com.webforj.component.SlotAssigner;
 import com.webforj.component.list.event.ListClickEvent;
 import com.webforj.component.list.event.ListCloseEvent;
 import com.webforj.component.list.event.ListOpenEvent;
@@ -195,6 +198,41 @@ class DwcSelectDropdownTest {
       component.onAttach();
 
       verify(control, times(1)).openList();
+    }
+  }
+
+  @Nested
+  class SlotsApi {
+
+    @Test
+    void shouldSetAndGetPrefix() {
+      Component prefixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      assertEquals(prefixComponent, component.getPrefixComponent());
+    }
+
+    @Test
+    void shouldSetAndGetSuffix() {
+      Component suffixComponent = mock(Component.class);
+      component.setSuffixComponent(suffixComponent);
+      assertEquals(suffixComponent, component.getSuffixComponent());
+    }
+
+    @Test
+    void shouldAttachPrefixAndSuffix() {
+      component = spy(component);
+      SlotAssigner slotAssigner = mock(SlotAssigner.class);
+      doReturn(slotAssigner).when(component).getSlotAssigner();
+
+      Component prefixComponent = mock(Component.class);
+      Component suffixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      component.setSuffixComponent(suffixComponent);
+
+      component.onAttach();
+
+      verify(slotAssigner, times(1)).attach();
+      verify(slotAssigner, times(1)).attach();
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/component/list/DwcSelectDropdownTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/DwcSelectDropdownTest.java
@@ -118,7 +118,7 @@ class DwcSelectDropdownTest {
 
   @Test
   @DisplayName("deselect remove selection when control is defined")
-  void shouldRemoveSelectionWhenControlIsDefined() throws IllegalAccessException, BBjException {
+  void shouldRemoveSelectionWhenControlIsDefined() throws BBjException {
     component.insert("item 1", "item 2");
     component.selectIndex(1);
 

--- a/webforj-foundation/src/test/java/com/webforj/component/list/DwcSelectDropdownTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/DwcSelectDropdownTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import com.basis.bbj.proxies.sysgui.BBjListButton;
 import com.basis.startup.type.BBjException;
 import com.basis.startup.type.BBjVector;
+import com.webforj.component.Component;
 import com.webforj.component.ReflectionUtils;
 import com.webforj.component.list.event.ListClickEvent;
 import com.webforj.component.list.event.ListCloseEvent;
@@ -247,5 +249,23 @@ class DwcSelectDropdownTest {
     assertEquals("custom-type", component.getDropdownType());
 
     assertEquals("custom-type", component.getProperty("type"));
+  }
+
+  @Nested
+  class SlotsApi {
+
+    @Test
+    void shouldSetAndGetPrefix() {
+      Component prefixComponent = mock(Component.class);
+      component.setPrefixComponent(prefixComponent);
+      assertEquals(prefixComponent, component.getPrefixComponent());
+    }
+
+    @Test
+    void shouldSetAndGetSuffix() {
+      Component suffixComponent = mock(Component.class);
+      component.setSuffixComponent(suffixComponent);
+      assertEquals(suffixComponent, component.getSuffixComponent());
+    }
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
@@ -28,7 +28,7 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
     HasHelperText<ConcernComponentMock>, HasMask<ConcernComponentMock>,
     HasRestoreValue<ConcernComponentMock, Double>, HasLocale<ConcernComponentMock>,
     HasStep<ConcernComponentMock, Double>, HasPredictedText<ConcernComponentMock>,
-    HasSize<ConcernComponentMock> {
+    HasSize<ConcernComponentMock>, HasPrefixAndSuffix<ConcernComponentMock> {
 
   private Map<String, String> attributes = new HashMap<>();
   private Map<String, Object> properties = new HashMap<>();
@@ -70,6 +70,8 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
   private String height;
   private String minHeight;
   private String maxHeight;
+  private Component prefixComponent;
+  private Component suffixComponent;
 
   @Override
   public String getAttribute(String attribute) {
@@ -579,6 +581,28 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
   @Override
   public String getComputedMaxHeight() {
     return this.maxHeight;
+  }
+
+  @Override
+  public ConcernComponentMock setSuffixComponent(Component suffix) {
+    this.suffixComponent = suffix;
+    return this;
+  }
+
+  @Override
+  public Component getSuffixComponent() {
+    return this.suffixComponent;
+  }
+
+  @Override
+  public ConcernComponentMock setPrefixComponent(Component prefix) {
+    this.prefixComponent = prefix;
+    return this;
+  }
+
+  @Override
+  public Component getPrefixComponent() {
+    return this.prefixComponent;
   }
 
 

--- a/webforj-foundation/src/test/java/com/webforj/concern/HasPrefixAndSuffixTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/HasPrefixAndSuffixTest.java
@@ -1,0 +1,35 @@
+package com.webforj.concern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import com.webforj.component.Component;
+import com.webforj.component.Composite;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HasPrefixAndSuffixTest {
+
+  private CompositeMock component;
+
+  @BeforeEach
+  void setup() {
+    component = new CompositeMock();
+  }
+
+  @Test
+  void shouldSetGetPattern() {
+    Component expectedPattern = mock(Component.class);
+    assertSame(component, component.setPrefixComponent(expectedPattern));
+    assertEquals(expectedPattern, component.getPrefixComponent());
+
+    Component expectedSuffix = mock(Component.class);
+    assertSame(component, component.setSuffixComponent(expectedSuffix));
+    assertEquals(expectedSuffix, component.getSuffixComponent());
+  }
+
+  class CompositeMock extends Composite<ConcernComponentMock>
+      implements HasPrefixAndSuffix<CompositeMock> {
+  }
+}


### PR DESCRIPTION
The PR adds support for prefix and suffix slots in the following components:

1. Button
2. ChoiceBox
3. ComboBox
4. TabbedPane
5. All Field Types


## Button

```java
Button icon = new Button(new Img("http://localhost:8888/joystick.png"));

Button btn = new Button("Click me");
btn.setPrefixComponent(new Img("http://localhost:8888/joystick.png"));
btn.setSuffixComponent(new Img("http://localhost:8888/joystick.png"));
```

## Fields , ChoiceBox, ComboBox

```java
MaskedDateField dateField = new MaskedDateField("Chooser Date", LocalDate.now());
  dateField.setPrefixComponent(new Img("http://localhost:8888/joystick.png"));
  dateField.setSuffixComponent(new Img("http://localhost:8888/joystick.png"));
```

## TabbedPane

```java
TabbedPane pane = new TabbedPane();

pane.addTab(new Tab("Dashboard", new Img("http://localhost:8888/joystick.png")));
pane.addTab(new Tab("Orders", new Img("http://localhost:8888/joystick.png")));
pane.addTab(new Tab("Customers", new Img("http://localhost:8888/joystick.png")));
pane.addTab(new Tab("Products", new Img("http://localhost:8888/joystick.png")));
pane.addTab(new Tab("Documents", new Img("http://localhost:8888/joystick.png")));
```


