### PR TITLE
feat: add `toolbar` component

### DIFF
--- a/webforj-components/pom.xml
+++ b/webforj-components/pom.xml
@@ -31,6 +31,7 @@
     <module>webforj-icons</module>
     <module>webforj-loading</module>
     <module>webforj-login</module>
+    <module>webforj-toolbar</module>
     <module>webforj-youtube</module>
     <module>webforj-table</module>
   </modules>

--- a/webforj-components/webforj-toolbar/pom.xml
+++ b/webforj-components/webforj-toolbar/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.webforj</groupId>
+    <artifactId>webforj-components</artifactId>
+    <version>24.12-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>webforj-toolbar</artifactId>
+  <name>${project.artifactId}</name>
+  <description>webforJ Toolbar component which provides a flexible container for grouping and aligning components in a app layout.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.webforj</groupId>
+      <artifactId>webforj-foundation</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webforj</groupId>
+      <artifactId>webforj-applayout</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webforj</groupId>
+      <artifactId>webforj-html-elements</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.basis.lib</groupId>
+      <artifactId>BBj</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.basis.lib</groupId>
+      <artifactId>BBjStartup</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.basis.lib</groupId>
+      <artifactId>BBjUtil</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.basis.lib</groupId>
+      <artifactId>BBjsp</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/webforj-components/webforj-toolbar/pom.xml
+++ b/webforj-components/webforj-toolbar/pom.xml
@@ -19,16 +19,6 @@
       <artifactId>webforj-foundation</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.webforj</groupId>
-      <artifactId>webforj-applayout</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.webforj</groupId>
-      <artifactId>webforj-html-elements</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/webforj-components/webforj-toolbar/src/main/java/com/webforj/component/layout/toolbar/Toolbar.java
+++ b/webforj-components/webforj-toolbar/src/main/java/com/webforj/component/layout/toolbar/Toolbar.java
@@ -1,0 +1,146 @@
+package com.webforj.component.layout.toolbar;
+
+import com.webforj.component.Component;
+import com.webforj.component.Theme;
+import com.webforj.component.element.Element;
+import com.webforj.component.element.ElementCompositeContainer;
+import com.webforj.component.element.PropertyDescriptor;
+import com.webforj.component.element.annotation.NodeName;
+import com.webforj.concern.HasAttribute;
+import com.webforj.concern.HasClassName;
+import com.webforj.concern.HasSize;
+import com.webforj.concern.HasStyle;
+import com.webforj.concern.HasVisibility;
+
+/**
+ * The Toolbar component provides a flexible container for grouping and aligning components in a app
+ * layout.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.12
+ */
+@NodeName("dwc-toolbar")
+public class Toolbar extends ElementCompositeContainer implements HasClassName<Toolbar>,
+    HasStyle<Toolbar>, HasVisibility<Toolbar>, HasSize<Toolbar>, HasAttribute<Toolbar> {
+
+  // Slots
+  static final String START_SLOT = "start";
+  static final String TITLE_SLOT = "title";
+  static final String CONTENT_SLOT = "content";
+  static final String END_SLOT = "end";
+
+  // Property descriptors
+  private final PropertyDescriptor<Theme> themeProp =
+      PropertyDescriptor.property("theme", Theme.DEFAULT);
+  private final PropertyDescriptor<Boolean> compactProp =
+      PropertyDescriptor.property("compact", false);
+
+  /**
+   * Instantiates a new app layout.
+   */
+  public Toolbar() {
+    super();
+  }
+
+  /**
+   * Adds the component to the start slot.
+   *
+   * @param components the component to be added
+   * @return the component itself
+   */
+  public Toolbar addToStart(Component... components) {
+    getElement().add(START_SLOT, components);
+    return this;
+  }
+
+  /**
+   * Adds the component to the title slot.
+   *
+   * @param components the component to be added
+   * @return the component itself
+   */
+  public Toolbar addToTitle(Component... components) {
+    getElement().add(TITLE_SLOT, components);
+    return this;
+  }
+
+  /**
+   * Adds the component to the content slot.
+   *
+   * @param components the components to be added
+   */
+  @Override
+  public void add(Component... components) {
+    addToContent(components);
+  }
+
+  /**
+   * Alias for {@link #add(Component...)}.
+   *
+   * @param components the component to be added
+   * @return the component itself
+   */
+  public Toolbar addToContent(Component... components) {
+    getElement().add(CONTENT_SLOT, components);
+    return this;
+  }
+
+  /**
+   * Adds the component to the end slot.
+   *
+   * @param components the component to be added
+   * @return the component itself
+   */
+  public Toolbar addToEnd(Component... components) {
+    getElement().add(END_SLOT, components);
+    return this;
+  }
+
+  /**
+   * Sets the toolbar theme.
+   *
+   * @param theme the theme
+   * @return the component itself
+   */
+  public Toolbar setTheme(Theme theme) {
+    set(themeProp, theme);
+    return this;
+  }
+
+  /**
+   * Gets the toolbar theme.
+   *
+   * @return the theme
+   */
+  public Theme getTheme() {
+    return get(themeProp);
+  }
+
+  /**
+   * Sets the toolbar compact mode.
+   *
+   * <p>
+   * The compact mode is used to reduce the toolbar height by not using a padding.
+   * </p>
+   *
+   * @param compact the compact mode
+   * @return the component itself
+   */
+  public Toolbar setCompact(boolean compact) {
+    set(compactProp, compact);
+    return this;
+  }
+
+  /**
+   * Checks if the toolbar is in compact mode.
+   *
+   * @return the compact mode
+   */
+  public boolean isCompact() {
+    return get(compactProp);
+  }
+
+  Element getOriginalElement() {
+    return getElement();
+  }
+}

--- a/webforj-components/webforj-toolbar/src/test/java/com/webforj/component/layout/toolbar/ToolbarTest.java
+++ b/webforj-components/webforj-toolbar/src/test/java/com/webforj/component/layout/toolbar/ToolbarTest.java
@@ -1,0 +1,73 @@
+package com.webforj.component.layout.toolbar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+
+import com.webforj.component.Component;
+import com.webforj.component.element.PropertyDescriptorTester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ToolbarTest {
+
+  Toolbar component;
+
+  @BeforeEach
+  void setUp() {
+    component = new Toolbar();
+  }
+
+  @Nested
+  @DisplayName("Properties API")
+  class PropertiesApi {
+
+    @Test
+    void shouldSetGetProperties() {
+      try {
+        PropertyDescriptorTester.run(Toolbar.class, component);
+      } catch (Exception e) {
+        fail("PropertyDescriptor test failed: " + e.getMessage());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("Slots API")
+  class SlotsApi {
+
+    @Test
+    void shouldAddToStart() {
+      Component header = mock(Component.class);
+      component.addToStart(header);
+      assertEquals(header,
+          component.getOriginalElement().getFirstComponentInSlot(Toolbar.START_SLOT));
+    }
+
+    @Test
+    void shouldAddToTitle() {
+      Component header = mock(Component.class);
+      component.addToTitle(header);
+      assertEquals(header,
+          component.getOriginalElement().getFirstComponentInSlot(Toolbar.TITLE_SLOT));
+    }
+
+    @Test
+    void shouldAddToContent() {
+      Component header = mock(Component.class);
+      component.addToContent(header);
+      assertEquals(header,
+          component.getOriginalElement().getFirstComponentInSlot(Toolbar.CONTENT_SLOT));
+    }
+
+    @Test
+    void shouldAddToEnd() {
+      Component header = mock(Component.class);
+      component.addToEnd(header);
+      assertEquals(header,
+          component.getOriginalElement().getFirstComponentInSlot(Toolbar.END_SLOT));
+    }
+  }
+}

--- a/webforj-report-aggregate/pom.xml
+++ b/webforj-report-aggregate/pom.xml
@@ -106,6 +106,11 @@
     </dependency>
     <dependency>
       <groupId>com.webforj</groupId>
+      <artifactId>webforj-toolbar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webforj</groupId>
       <artifactId>webforj-markdown</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/webforj/pom.xml
+++ b/webforj/pom.xml
@@ -71,6 +71,11 @@
     </dependency>
     <dependency>
       <groupId>com.webforj</groupId>
+      <artifactId>webforj-toolbar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webforj</groupId>
       <artifactId>webforj-spinner</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
The PR introduces the `Toolbar` component for use with `AppLayout`, reducing boilerplate code when working with `AppLayout`.


```java
Toolbar toolbar = new Toolbar();
toolbar.addToStart(new AppDrawerToggle());
toolbar.addToTitle(new H1("DWC App"));
toolbar.setTheme(Theme.PRIMARY);

AppLayout layout = new AppLayout();
layout.addToHeader(toolbar);
```