### PR TITLE
fix: normalize path in Location

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/router/history/Location.java
+++ b/webforj-foundation/src/main/java/com/webforj/router/history/Location.java
@@ -1,10 +1,10 @@
 package com.webforj.router.history;
 
+import com.webforj.router.RouterUtils;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import com.webforj.router.RouterUtils;
 
 /**
  * Represents a relative URL made up of path segments and query parameters.

--- a/webforj-foundation/src/main/java/com/webforj/router/history/Location.java
+++ b/webforj-foundation/src/main/java/com/webforj/router/history/Location.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import com.webforj.router.RouterUtils;
 
 /**
  * Represents a relative URL made up of path segments and query parameters.
@@ -127,7 +128,7 @@ public class Location implements Serializable {
       uriBuilder.append('#').append(fragment);
     }
 
-    return uriBuilder.toString();
+    return RouterUtils.normalizePath("/" + uriBuilder.toString());
   }
 
   /**

--- a/webforj-foundation/src/test/java/com/webforj/router/history/LocationTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/router/history/LocationTest.java
@@ -76,7 +76,7 @@ class LocationTest {
     Location location =
         new Location(List.of("segment1", "segment2"), "param1=value1&param2=value2", "fragment");
     String fullURI = location.getFullURI();
-    assertEquals("segment1/segment2?param1=value1&param2=value2#fragment", fullURI);
+    assertEquals("/segment1/segment2?param1=value1&param2=value2#fragment", fullURI);
   }
 
   @Test
@@ -84,13 +84,13 @@ class LocationTest {
     Location location =
         new Location(List.of("segment1", "segment2"), "param1=value1&param2=value2");
     String fullURI = location.getFullURI();
-    assertEquals("segment1/segment2?param1=value1&param2=value2", fullURI);
+    assertEquals("/segment1/segment2?param1=value1&param2=value2", fullURI);
   }
 
   @Test
   void shouldGetFullURIWithoutQuery() {
     Location location = new Location(List.of("segment1", "segment2"));
     String fullURI = location.getFullURI();
-    assertEquals("segment1/segment2", fullURI);
+    assertEquals("/segment1/segment2", fullURI);
   }
 }


### PR DESCRIPTION
The `Location` should normalize the path when `getFullURI` is invoked