### PR TITLE
refactor: consolidate autofocus implementation using the `HasAutoFocus` interface

### DIFF
--- a/webforj-components/webforj-dialog/src/main/java/com/webforj/component/dialog/Dialog.java
+++ b/webforj-components/webforj-dialog/src/main/java/com/webforj/component/dialog/Dialog.java
@@ -1,6 +1,7 @@
 package com.webforj.component.dialog;
 
 import com.google.gson.annotations.SerializedName;
+import com.webforj.annotation.ExcludeFromJacocoGeneratedReport;
 import com.webforj.component.Component;
 import com.webforj.component.Theme;
 import com.webforj.component.dialog.event.DialogCloseEvent;
@@ -9,6 +10,8 @@ import com.webforj.component.element.Element;
 import com.webforj.component.element.ElementCompositeContainer;
 import com.webforj.component.element.PropertyDescriptor;
 import com.webforj.component.element.annotation.NodeName;
+import com.webforj.component.element.annotation.PropertyMethods;
+import com.webforj.concern.HasAutoFocus;
 import com.webforj.concern.HasClassName;
 import com.webforj.concern.HasStyle;
 import com.webforj.dispatcher.EventListener;
@@ -22,7 +25,7 @@ import com.webforj.dispatcher.ListenerRegistration;
  */
 @NodeName("dwc-dialog")
 public class Dialog extends ElementCompositeContainer
-    implements HasClassName<Dialog>, HasStyle<Dialog> {
+    implements HasClassName<Dialog>, HasStyle<Dialog>, HasAutoFocus<Dialog> {
 
   /**
    * The dialog alignments.
@@ -49,6 +52,7 @@ public class Dialog extends ElementCompositeContainer
   // Properties
   private final PropertyDescriptor<Alignment> alignmentProp =
       PropertyDescriptor.property("alignment", Alignment.CENTER);
+  @PropertyMethods(setter = "setAutoFocus", getter = "isAutoFocus")
   private final PropertyDescriptor<Boolean> autoFocusProp =
       PropertyDescriptor.property("autofocus", false);
   private final PropertyDescriptor<Boolean> backdropProp =
@@ -170,18 +174,51 @@ public class Dialog extends ElementCompositeContainer
    *
    * @param autofocus the autofocus
    * @return the component itself
+   *
+   * @deprecated Use {@link #setAutoFocus(boolean)} instead.
    */
+  @ExcludeFromJacocoGeneratedReport
+  @Deprecated(since = "24.21", forRemoval = true)
   public Dialog setAutofocus(boolean autofocus) {
-    set(autoFocusProp, autofocus);
-    return this;
+    return setAutoFocus(autofocus);
   }
 
   /**
    * Gets the dialog autofocus.
    *
    * @return the autofocus
+   *
+   * @deprecated Use {@link #isAutoFocus()} instead.
    */
+  @ExcludeFromJacocoGeneratedReport
+  @Deprecated(since = "24.21", forRemoval = true)
   public boolean isAutofocus() {
+    return isAutoFocus();
+  }
+
+  /**
+   * Auto focus the dialog when it is opened.
+   *
+   * <p>
+   * When true then automatically focus the first focusable element in the dialog.
+   * </p>
+   *
+   * @param autofocus the autofocus
+   * @return the component itself
+   */
+  @Override
+  public Dialog setAutoFocus(boolean autofocus) {
+    set(autoFocusProp, autofocus);
+    return this;
+  }
+
+  /**
+   * Checks if the dialog should be auto focused when it is opened.
+   *
+   * @return the autofocus
+   */
+  @Override
+  public boolean isAutoFocus() {
     return get(autoFocusProp);
   }
 

--- a/webforj-components/webforj-drawer/src/main/java/com/webforj/component/drawer/Drawer.java
+++ b/webforj-components/webforj-drawer/src/main/java/com/webforj/component/drawer/Drawer.java
@@ -1,6 +1,7 @@
 package com.webforj.component.drawer;
 
 import com.google.gson.annotations.SerializedName;
+import com.webforj.annotation.ExcludeFromJacocoGeneratedReport;
 import com.webforj.component.Component;
 import com.webforj.component.drawer.Drawer;
 import com.webforj.component.drawer.event.DrawerCloseEvent;
@@ -9,6 +10,8 @@ import com.webforj.component.element.Element;
 import com.webforj.component.element.ElementCompositeContainer;
 import com.webforj.component.element.PropertyDescriptor;
 import com.webforj.component.element.annotation.NodeName;
+import com.webforj.component.element.annotation.PropertyMethods;
+import com.webforj.concern.HasAutoFocus;
 import com.webforj.concern.HasClassName;
 import com.webforj.concern.HasStyle;
 import com.webforj.dispatcher.EventListener;
@@ -23,7 +26,7 @@ import com.webforj.dispatcher.ListenerRegistration;
  */
 @NodeName("dwc-drawer")
 public class Drawer extends ElementCompositeContainer
-    implements HasClassName<Drawer>, HasStyle<Drawer> {
+    implements HasClassName<Drawer>, HasStyle<Drawer>, HasAutoFocus<Drawer> {
 
   /**
    * The drawer placement.
@@ -60,6 +63,7 @@ public class Drawer extends ElementCompositeContainer
   private static final String FOOTER_SLOT = "footer";
 
   // Property descriptors
+  @PropertyMethods(setter = "setAutoFocus", getter = "isAutoFocus")
   private final PropertyDescriptor<Boolean> autoFocusProp =
       PropertyDescriptor.property("autofocus", false);
   private final PropertyDescriptor<String> labelProp =
@@ -119,18 +123,51 @@ public class Drawer extends ElementCompositeContainer
    *
    * @param autoFocus When true then automatically focus the first focusable element in the drawer.
    * @return the drawer
+   *
+   * @deprecated Use {@link #setAutoFocus(boolean)} instead.
    */
+  @ExcludeFromJacocoGeneratedReport
+  @Deprecated(since = "24.21", forRemoval = true)
   public Drawer setAutofocus(boolean autoFocus) {
-    set(autoFocusProp, autoFocus);
-    return this;
+    return setAutoFocus(autoFocus);
   }
 
   /**
    * Gets Drawer auto focus.
    *
    * @return the drawer auto focus
+   *
+   * @deprecated Use {@link #isAutoFocus()} instead.
    */
+  @ExcludeFromJacocoGeneratedReport
+  @Deprecated(since = "24.21", forRemoval = true)
   public boolean isAutofocus() {
+    return isAutoFocus();
+  }
+
+  /**
+   * Auto focus the drawer when it is opened.
+   *
+   * <p>
+   * When true then automatically focus the first focusable element in the drawer.
+   * </p>
+   *
+   * @param autoFocus When true then automatically focus the first focusable element in the drawer.
+   * @return the drawer
+   */
+  @Override
+  public Drawer setAutoFocus(boolean autoFocus) {
+    set(autoFocusProp, autoFocus);
+    return this;
+  }
+
+  /**
+   * Checks if the drawer should be auto focused when it is opened.
+   *
+   * @return the drawer auto focus
+   */
+  @Override
+  public boolean isAutoFocus() {
     return get(autoFocusProp);
   }
 

--- a/webforj-foundation/src/main/java/com/webforj/App.java
+++ b/webforj-foundation/src/main/java/com/webforj/App.java
@@ -403,7 +403,7 @@ public abstract class App {
    */
   @Deprecated(since = "24.02", forRemoval = true)
   public static int msgbox(String alert) {
-    return Environment.getCurrent().getWebforjHelper().msgbox(alert, 0, "");
+    return Environment.getCurrent().getBridge().msgbox(alert, 0, "");
   }
 
   /**
@@ -417,7 +417,7 @@ public abstract class App {
    */
   @Deprecated(since = "24.02", forRemoval = true)
   public static int msgbox(String alert, int options) {
-    return Environment.getCurrent().getWebforjHelper().msgbox(alert, options, "");
+    return Environment.getCurrent().getBridge().msgbox(alert, options, "");
   }
 
   /**
@@ -432,7 +432,7 @@ public abstract class App {
    */
   @Deprecated(since = "24.02", forRemoval = true)
   public static int msgbox(String alert, int options, String title) {
-    return Environment.getCurrent().getWebforjHelper().msgbox(alert, options, title);
+    return Environment.getCurrent().getBridge().msgbox(alert, options, title);
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/Environment.java
+++ b/webforj-foundation/src/main/java/com/webforj/Environment.java
@@ -16,31 +16,69 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
+/**
+ * The Environment class represents the runtime environment for the webforj application. It provides
+ * methods to initialize, configure, and manage the environment, including handling errors, managing
+ * debug mode, and accessing configuration settings.
+ *
+ * <p>
+ * This class is designed to be used in a multi-threaded context, with each thread having its own
+ * instance of the Environment.
+ * </p>
+ *
+ * @author Stephan Wald
+ * @author Hyyan Abo Fakher
+ * @since 0.001
+ */
 public final class Environment {
 
   private static final String RESOURCE_PREFIX = "!!";
   private static final HashMap<Object, Environment> instanceMap = new HashMap<>();
   private final BBjAPI api;
   private final BBjSysGui sysgui;
-  private final WebforjBBjBridge helper;
+  private final WebforjBBjBridge bridge;
   private boolean debug = false;
 
-  private Environment(BBjAPI api, WebforjBBjBridge helper, boolean debug) throws BBjException {
+  /**
+   * Creates a new environment.
+   *
+   * @param api the BBjAPI instance.
+   * @param bridge the WebforjBBjBridge instance.
+   * @param debug {@code true} if debug mode is enabled, {@code false} otherwise.
+   * @throws BBjException if an error occurs while creating the environment.
+   */
+  private Environment(BBjAPI api, WebforjBBjBridge bridge, boolean debug) throws BBjException {
     this.api = api;
     this.sysgui = api.openSysGui("X0");
-    this.helper = helper;
+    this.bridge = bridge;
     this.debug = debug;
   }
 
+  /**
+   * Initializes the environment for the current thread.
+   *
+   * @param api the BBjAPI instance.
+   * @param helper the WebforjBBjBridge instance.
+   * @param debug {@code 1} if debug mode is enabled, {@code 0} otherwise.
+   * @throws BBjException if an error occurs while initializing the environment.
+   */
   public static void init(BBjAPI api, WebforjBBjBridge helper, int debug) throws BBjException {
     Environment env = new Environment(api, helper, debug > 0);
     Environment.instanceMap.put(Thread.currentThread().getId(), env);
   }
 
+  /**
+   * Cleans up the environment for the current thread.
+   */
   public static void cleanup() {
     Environment.instanceMap.remove(Thread.currentThread().getId());
   }
 
+  /**
+   * Returns the environment for the current thread.
+   *
+   * @return the environment for the current thread.
+   */
   public static Environment getCurrent() {
     return Environment.instanceMap.get(Thread.currentThread().getId());
   }
@@ -87,7 +125,7 @@ public final class Environment {
    *        255. (Some systems may allow waits longer than 255 seconds.)
    */
   public void sleep(int seconds) {
-    getWebforjHelper().sleep(seconds);
+    getBridge().sleep(seconds);
   }
 
   /**
@@ -187,8 +225,24 @@ public final class Environment {
     return this.sysgui;
   }
 
+  /**
+   * Returns the WebforjBBjBridge instance.
+   *
+   * @return the WebforjBBjBridge instance.
+   */
+  public WebforjBBjBridge getBridge() {
+    return bridge;
+  }
+
+  /**
+   * Returns the WebforjBBjBridge instance.
+   *
+   * @return the WebforjBBjBridge instance.
+   * @deprecated since 24.12 for removal in 25.0. Use {@link #getBridge()} instead.
+   */
+  @Deprecated(since = "24.12", forRemoval = true)
   public WebforjBBjBridge getWebforjHelper() {
-    return helper;
+    return bridge;
   }
 
   /*

--- a/webforj-foundation/src/main/java/com/webforj/Environment.java
+++ b/webforj-foundation/src/main/java/com/webforj/Environment.java
@@ -242,7 +242,7 @@ public final class Environment {
    */
   @Deprecated(since = "24.12", forRemoval = true)
   public WebforjBBjBridge getWebforjHelper() {
-    return bridge;
+    return getBridge();
   }
 
   /*

--- a/webforj-foundation/src/main/java/com/webforj/Interval.java
+++ b/webforj-foundation/src/main/java/com/webforj/Interval.java
@@ -97,7 +97,7 @@ public final class Interval {
     BBjAPI api = getEnvironment().getBBjAPI();
 
     try {
-      CustomObject handler = getEnvironment().getWebforjHelper().getEventProxy(this, "handleEvent");
+      CustomObject handler = getEnvironment().getBridge().getEventProxy(this, "handleEvent");
       api.createTimer(key, BasisNumber.createBasisNumber(getDelay()), handler, "onEvent");
       running = true;
     } catch (NumberFormatException | BBjException e) {

--- a/webforj-foundation/src/main/java/com/webforj/MaskDecorator.java
+++ b/webforj-foundation/src/main/java/com/webforj/MaskDecorator.java
@@ -74,7 +74,7 @@ public final class MaskDecorator {
     Objects.requireNonNull(mask, MASK_CANNOT_BE_NULL);
 
     Environment env = Environment.getCurrent();
-    return env.getWebforjHelper().maskString(input, mask);
+    return env.getBridge().maskString(input, mask);
   }
 
   /**
@@ -171,7 +171,7 @@ public final class MaskDecorator {
     Objects.requireNonNull(mask, MASK_CANNOT_BE_NULL);
 
     Environment env = Environment.getCurrent();
-    return env.getWebforjHelper().maskNumber(input, mask);
+    return env.getBridge().maskNumber(input, mask);
   }
 
   /**
@@ -247,7 +247,7 @@ public final class MaskDecorator {
     JulianLocaleDateTransformer transformer = new JulianLocaleDateTransformer();
     int julian = transformer.transformToComponent(input);
 
-    return env.getWebforjHelper().maskDateTime(julian, null, mask);
+    return env.getBridge().maskDateTime(julian, null, mask);
   }
 
   /**
@@ -331,7 +331,7 @@ public final class MaskDecorator {
     HoursLocalTimeTransformer transformer = new HoursLocalTimeTransformer();
     double hms = transformer.transformToComponent(input);
 
-    return env.getWebforjHelper().maskDateTime(0, hms, mask);
+    return env.getBridge().maskDateTime(0, hms, mask);
   }
 
   /**
@@ -429,7 +429,7 @@ public final class MaskDecorator {
     int julian = dateTransformer.transformToComponent(input.toLocalDate());
     double hms = timeTransformer.transformToComponent(input.toLocalTime());
 
-    return env.getWebforjHelper().maskDateTime(julian, hms, mask);
+    return env.getBridge().maskDateTime(julian, hms, mask);
   }
 
   /**
@@ -504,8 +504,7 @@ public final class MaskDecorator {
     Objects.requireNonNull(mask, MASK_CANNOT_BE_NULL);
 
     Environment env = Environment.getCurrent();
-    int julian =
-        env.getWebforjHelper().parseDate(input, mask, locale == null ? App.getLocale() : locale);
+    int julian = env.getBridge().parseDate(input, mask, locale == null ? App.getLocale() : locale);
     JulianLocaleDateTransformer transformer = new JulianLocaleDateTransformer();
 
     return transformer.transformToModel(julian);
@@ -661,8 +660,7 @@ public final class MaskDecorator {
     Objects.requireNonNull(mask, MASK_CANNOT_BE_NULL);
 
     Environment env = Environment.getCurrent();
-    double hms =
-        env.getWebforjHelper().parseTime(input, mask, locale == null ? App.getLocale() : locale);
+    double hms = env.getBridge().parseTime(input, mask, locale == null ? App.getLocale() : locale);
     HoursLocalTimeTransformer transformer = new HoursLocalTimeTransformer();
 
     return transformer.transformToModel(hms);

--- a/webforj-foundation/src/main/java/com/webforj/Page.java
+++ b/webforj-foundation/src/main/java/com/webforj/Page.java
@@ -1010,7 +1010,7 @@ public final class Page implements HasJsExecution {
 
       try {
         BBjWebManager webManager = getEnvironment().getBBjAPI().getWebManager();
-        CustomObject handler = getEnvironment().getWebforjHelper()
+        CustomObject handler = getEnvironment().getBridge()
             .getEventProxy(new PageUnloadEventHandler(this, dispatcher), "handleEvent");
         webManager.setCallback(SysGuiEventConstants.ON_BROWSER_CLOSE, handler, "onEvent");
       } catch (BBjException e) {

--- a/webforj-foundation/src/main/java/com/webforj/PageExecuteJsAsyncHandler.java
+++ b/webforj-foundation/src/main/java/com/webforj/PageExecuteJsAsyncHandler.java
@@ -32,7 +32,7 @@ public final class PageExecuteJsAsyncHandler {
       return;
     }
 
-    CustomObject handler = env.getWebforjHelper().getEventProxy(this, "handleEvent");
+    CustomObject handler = env.getBridge().getEventProxy(this, "handleEvent");
     try {
       env.getBBjAPI().getWebManager().setCallback(SysGuiEventConstants.ON_EXECUTE_SCRIPT, handler,
           "onEvent");

--- a/webforj-foundation/src/main/java/com/webforj/Request.java
+++ b/webforj-foundation/src/main/java/com/webforj/Request.java
@@ -49,7 +49,7 @@ public final class Request {
    */
   @Deprecated(since = "24.02", forRemoval = true)
   public static String getQueryParam(String key) {
-    return Environment.getCurrent().getWebforjHelper().getQueryParam(key);
+    return Environment.getCurrent().getBridge().getQueryParam(key);
   }
 
   /**
@@ -136,7 +136,7 @@ public final class Request {
    * @since 24.02
    */
   public String getQueryParameter(String key) {
-    return getEnvironment().getWebforjHelper().getQueryParam(key);
+    return getEnvironment().getBridge().getQueryParam(key);
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/bridge/BBjWindowAdapter.java
+++ b/webforj-foundation/src/main/java/com/webforj/bridge/BBjWindowAdapter.java
@@ -7,9 +7,9 @@ import com.webforj.component.window.Window;
  * This class adapts a BBjWindow for use with webforJ components.
  *
  * <p>
- * It is specifically designed for integrating webforJ components into BBj code.
- * This adapter converts a BBjWindow into a webforJ {@link Window}, enabling
- * the addition of webforJ components in BBj code.
+ * It is specifically designed for integrating webforJ components into BBj code. This adapter
+ * converts a BBjWindow into a webforJ {@link Window}, enabling the addition of webforJ components
+ * in BBj code.
  * </p>
  */
 public final class BBjWindowAdapter extends Window {

--- a/webforj-foundation/src/main/java/com/webforj/component/event/sink/AbstractDwcEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/event/sink/AbstractDwcEventSink.java
@@ -43,7 +43,7 @@ public abstract class AbstractDwcEventSink implements DwcEventSink<Component> {
     this.eventType = eventType;
 
     if (Environment.getCurrent() != null) {
-      setWebforjHelper(Environment.getCurrent().getWebforjHelper());
+      setWebforjHelper(Environment.getCurrent().getBridge());
     }
   }
 

--- a/webforj-foundation/src/main/java/com/webforj/component/field/DwcField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/DwcField.java
@@ -9,6 +9,7 @@ import com.webforj.component.event.KeypressEvent;
 import com.webforj.component.event.ModifyEvent;
 import com.webforj.component.event.sink.KeypressEventSink;
 import com.webforj.component.event.sink.ModifyEventSink;
+import com.webforj.concern.HasAutoFocus;
 import com.webforj.concern.HasExpanse;
 import com.webforj.concern.HasFocusStatus;
 import com.webforj.concern.HasHelperText;
@@ -40,8 +41,8 @@ import com.webforj.dispatcher.ListenerRegistration;
  */
 public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasReadOnly<T>, V>
     extends DwcValidatableComponent<T, V> implements HasLabel<T>, HasReadOnly<T>, HasRequired<T>,
-    HasExpanse<T, Expanse>, HasFocusStatus, HasHighlightOnFocus<T>, HasPlaceholder<T>,
-    ValueChangeModeAware<T>, HasHelperText<T>, HasPrefixAndSuffix<T> {
+    HasExpanse<T, Expanse>, HasFocusStatus, HasHighlightOnFocus<T>, HasAutoFocus<T>,
+    HasPlaceholder<T>, ValueChangeModeAware<T>, HasHelperText<T>, HasPrefixAndSuffix<T> {
   private final ComponentEventSinkRegistry<ModifyEvent> modifyEventSinkListenerRegistry =
       new ComponentEventSinkRegistry<>(new ModifyEventSink(this, getEventDispatcher()),
           ModifyEvent.class);
@@ -244,11 +245,9 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
   }
 
   /**
-   * When true, the component should automatically have focus when the app has finished loading.
-   *
-   * @param autofocus true to automatically have focus when the app has finished loading.
-   * @return the component itself
+   * {@inheritDoc}
    */
+  @Override
   public T setAutoFocus(boolean autofocus) {
     this.autoFocus = autofocus;
     setUnrestrictedProperty("autofocus", autofocus);
@@ -256,11 +255,9 @@ public abstract class DwcField<T extends DwcValidatableComponent<T, V> & HasRead
   }
 
   /**
-   * Checks if the component should automatically have focus when the app has finished loading.
-   *
-   * @return true if the component should automatically have focus when the app has finished
-   *         loading.
+   * {@inheritDoc}
    */
+  @Override
   public boolean isAutoFocus() {
     return this.autoFocus;
   }

--- a/webforj-foundation/src/main/java/com/webforj/component/fontchooser/sink/FontChooserApproveEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/fontchooser/sink/FontChooserApproveEventSink.java
@@ -26,8 +26,7 @@ public final class FontChooserApproveEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(fc);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_FILECHOOSER_APPROVE,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "changeEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "changeEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/fontchooser/sink/FontChooserCancelEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/fontchooser/sink/FontChooserCancelEventSink.java
@@ -26,8 +26,7 @@ public final class FontChooserCancelEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(fc);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_FILECHOOSER_CANCEL,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "cancelEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "cancelEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/fontchooser/sink/FontChooserChangeEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/fontchooser/sink/FontChooserChangeEventSink.java
@@ -26,8 +26,7 @@ public final class FontChooserChangeEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(fc);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_FILECHOOSER_CHANGE,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "changeEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "changeEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/htmlcontainer/sink/HtmlContainerNativeJavascriptEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/htmlcontainer/sink/HtmlContainerNativeJavascriptEventSink.java
@@ -29,7 +29,7 @@ public final class HtmlContainerNativeJavascriptEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(htmlv);
       bbjctrl.setCallback(SysGuiEventConstants.ON_NATIVE_JAVASCRIPT,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "onEvent"), "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "onEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/htmlcontainer/sink/HtmlContainerPageLoadEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/htmlcontainer/sink/HtmlContainerPageLoadEventSink.java
@@ -26,7 +26,7 @@ public final class HtmlContainerPageLoadEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(htmlv);
       bbjctrl.setCallback(SysGuiEventConstants.ON_PAGE_LOADED,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "onEvent"), "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "onEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/htmlcontainer/sink/HtmlContainerScriptFailEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/htmlcontainer/sink/HtmlContainerScriptFailEventSink.java
@@ -30,8 +30,7 @@ public class HtmlContainerScriptFailEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(container);
       bbjctrl.setCallback(SysGuiEventConstants.ON_SCRIPT_FAILED,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "scriptFailedEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "scriptFailedEvent"), "onEvent");
 
     } catch (Exception e) {
       Environment.logError(e);

--- a/webforj-foundation/src/main/java/com/webforj/component/htmlcontainer/sink/HtmlContainerScriptLoadEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/htmlcontainer/sink/HtmlContainerScriptLoadEventSink.java
@@ -28,8 +28,7 @@ public class HtmlContainerScriptLoadEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(container);
       bbjctrl.setCallback(SysGuiEventConstants.ON_SCRIPT_LOADED,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "scriptLoadedEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "scriptLoadedEvent"), "onEvent");
 
     } catch (Exception e) {
       Environment.logError(e);

--- a/webforj-foundation/src/main/java/com/webforj/component/optiondialog/ConfirmDialog.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optiondialog/ConfirmDialog.java
@@ -424,7 +424,7 @@ public final class ConfirmDialog extends DwcMsgBox<ConfirmDialog> {
    * @return the result of the confirm dialog
    */
   public Result show() {
-    int result = Environment.getCurrent().getWebforjHelper().msgbox(this);
+    int result = Environment.getCurrent().getBridge().msgbox(this);
     return mapResult(result);
   }
 

--- a/webforj-foundation/src/main/java/com/webforj/component/optiondialog/FileChooserDialog.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optiondialog/FileChooserDialog.java
@@ -369,7 +369,7 @@ public final class FileChooserDialog extends DwcFileOpen<FileChooserDialog> {
    * @return the result of the FileChooser dialog
    */
   public String show() {
-    String result = Environment.getCurrent().getWebforjHelper().fileChooser(this);
+    String result = Environment.getCurrent().getBridge().fileChooser(this);
     if ("::CANCEL::".equals(result) || "::BAD::".equals(result)) {
       return null;
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/optiondialog/FileUploadDialog.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optiondialog/FileUploadDialog.java
@@ -203,7 +203,7 @@ public final class FileUploadDialog extends DwcFileOpen<FileUploadDialog> {
    * @return the result of the FileUpload dialog
    */
   public UploadedFile show() {
-    String result = Environment.getCurrent().getWebforjHelper().fileUpload(this);
+    String result = Environment.getCurrent().getBridge().fileUpload(this);
     if ("::CANCEL::".equals(result) || "::BAD::".equals(result)) {
       return null;
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/optiondialog/InputDialog.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optiondialog/InputDialog.java
@@ -436,7 +436,7 @@ public final class InputDialog extends DwcPromptMsgBox<InputDialog> {
    * @return the result of the input dialog
    */
   public String show() {
-    String result = Environment.getCurrent().getWebforjHelper().prompt(this);
+    String result = Environment.getCurrent().getBridge().prompt(this);
     if (!"::CANCEL::".equals(result)) {
       return result;
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/optioninput/sink/AbstractRadioButtonEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optioninput/sink/AbstractRadioButtonEventSink.java
@@ -44,7 +44,7 @@ public abstract class AbstractRadioButtonEventSink implements DwcEventSink<Compo
     this.eventType = eventType;
 
     if (Environment.getCurrent() != null) {
-      setWebforjHelper(Environment.getCurrent().getWebforjHelper());
+      setWebforjHelper(Environment.getCurrent().getBridge());
     }
   }
 

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeBlurEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeBlurEventSink.java
@@ -25,8 +25,7 @@ public class TreeBlurEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(tree);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_LOST_FOCUS,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "lostFocusEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "lostFocusEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeCollapseEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeCollapseEventSink.java
@@ -24,8 +24,7 @@ public class TreeCollapseEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(tree);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_TREE_COLLAPSE,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "collapseEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "collapseEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeDeselectEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeDeselectEventSink.java
@@ -24,8 +24,7 @@ public final class TreeDeselectEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(tree);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_TREE_DESELECT,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "deselectEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "deselectEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeDoubleClickEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeDoubleClickEventSink.java
@@ -25,8 +25,7 @@ public class TreeDoubleClickEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(tree);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_TREE_DOUBLE_CLICK,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "doubleClickEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "doubleClickEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeEditStopEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeEditStopEventSink.java
@@ -24,8 +24,7 @@ public class TreeEditStopEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(tree);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_TREE_EDIT_STOP,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "editStopEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "editStopEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeExpandEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeExpandEventSink.java
@@ -25,8 +25,7 @@ public class TreeExpandEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(tree);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_TREE_EXPAND,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "expandEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "expandEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeFocusEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeFocusEventSink.java
@@ -25,8 +25,7 @@ public class TreeFocusEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(tree);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_GAINED_FOCUS,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "gainedFocusEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "gainedFocusEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeSelectEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/sink/TreeSelectEventSink.java
@@ -25,8 +25,7 @@ public final class TreeSelectEventSink {
     try {
       bbjctrl = ComponentAccessor.getDefault().getBBjControl(tree);
       bbjctrl.setCallback(Environment.getCurrent().getBBjAPI().ON_TREE_SELECT,
-          Environment.getCurrent().getWebforjHelper().getEventProxy(this, "selectEvent"),
-          "onEvent");
+          Environment.getCurrent().getBridge().getEventProxy(this, "selectEvent"), "onEvent");
     } catch (Exception e) {
       Environment.logError(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/concern/HasAutoFocus.java
+++ b/webforj-foundation/src/main/java/com/webforj/concern/HasAutoFocus.java
@@ -1,0 +1,48 @@
+package com.webforj.concern;
+
+import com.webforj.component.Component;
+import com.webforj.component.ComponentUtil;
+
+/**
+ * An interface that allows components to set and retrieve autofocus property.
+ *
+ * @param <T> the type of the component that implements this interface.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 24.21
+ */
+public interface HasAutoFocus<T extends Component> {
+
+  /**
+   * Checks if the component should automatically have focus when the app has finished loading.
+   *
+   * @return true if the component should automatically have focus when the app has finished
+   *         loading.
+   */
+  public default boolean isAutoFocus() {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasAutoFocus) {
+      return ((HasAutoFocus<?>) component).isAutoFocus();
+    }
+
+    throw new UnsupportedOperationException("The component does not support autofocus property");
+  }
+
+  /**
+   * When true, the component should automatically have focus when the app has finished loading.
+   *
+   * @param autofocus true to automatically have focus when the app has finished loading.
+   * @return the component itself
+   */
+  public default T setAutoFocus(boolean autofocus) {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasAutoFocus) {
+      ((HasAutoFocus<?>) component).setAutoFocus(autofocus);
+      return (T) this;
+    }
+
+    throw new UnsupportedOperationException("The component does not support autofocus property");
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/environment/namespace/sink/NamespaceEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/environment/namespace/sink/NamespaceEventSink.java
@@ -43,8 +43,7 @@ public final class NamespaceEventSink {
         if (Boolean.TRUE.equals(fChangeOnly)) {
           try {
             ns.setCallbackForNamespaceChange(
-                Environment.getCurrent().getWebforjHelper().getEventProxy(this, "onNsChange"),
-                ON_EVENT);
+                Environment.getCurrent().getBridge().getEventProxy(this, "onNsChange"), ON_EVENT);
             ArrayList<Consumer<NamespaceEvent>> consumerlist =
                 namespaceChangeTargets.computeIfAbsent(nsname, k -> new ArrayList<>());
             consumerlist.add(consumer);
@@ -54,8 +53,7 @@ public final class NamespaceEventSink {
         } else {
           try {
             ns.setCallbackForNamespace(
-                Environment.getCurrent().getWebforjHelper().getEventProxy(this, "onNsAccess"),
-                ON_EVENT);
+                Environment.getCurrent().getBridge().getEventProxy(this, "onNsAccess"), ON_EVENT);
             ArrayList<Consumer<NamespaceEvent>> consumerlist =
                 namespaceAccessTargets.computeIfAbsent(nsname, k -> new ArrayList<>());
             consumerlist.add(consumer);
@@ -70,8 +68,7 @@ public final class NamespaceEventSink {
         if (Boolean.TRUE.equals(fChangeOnly)) {
           try {
             ns.setCallbackForVariableChange(key,
-                Environment.getCurrent().getWebforjHelper().getEventProxy(this, "onVarChange"),
-                ON_EVENT);
+                Environment.getCurrent().getBridge().getEventProxy(this, "onVarChange"), ON_EVENT);
             ArrayList<Consumer<NamespaceEvent>> consumerlist =
                 variableChangeTargets.computeIfAbsent(nsname + "\0" + key, k -> new ArrayList<>());
             consumerlist.add(consumer);
@@ -81,8 +78,7 @@ public final class NamespaceEventSink {
         } else {
           try {
             ns.setCallbackForVariable(key,
-                Environment.getCurrent().getWebforjHelper().getEventProxy(this, "onVarAccess"),
-                ON_EVENT);
+                Environment.getCurrent().getBridge().getEventProxy(this, "onVarAccess"), ON_EVENT);
             ArrayList<Consumer<NamespaceEvent>> consumerlist =
                 variableAccessTargets.computeIfAbsent(nsname + "\0" + key, k -> new ArrayList<>());
             consumerlist.add(consumer);

--- a/webforj-foundation/src/main/java/com/webforj/sink/page/PageEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/sink/page/PageEventSink.java
@@ -54,7 +54,7 @@ public class PageEventSink implements DwcEventSink<Page> {
   public String setCallback(Object options) {
     if (isConnected()) {
       try {
-        WebforjBBjBridge bridge = getEnvironment().getWebforjHelper();
+        WebforjBBjBridge bridge = getEnvironment().getBridge();
         CustomObject handler = bridge.getEventProxy(this, "handleEvent");
         return doSetCallback(getBbjWebManager(), options, handler, "onEvent");
       } catch (BBjException e) {

--- a/webforj-foundation/src/test/java/com/webforj/AppTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/AppTest.java
@@ -47,7 +47,7 @@ class AppTest {
 
     when(environment.getBBjAPI()).thenReturn(api);
     when(environment.getSysGui()).thenReturn(sysGui);
-    when(environment.getWebforjHelper()).thenReturn(bridge);
+    when(environment.getBridge()).thenReturn(bridge);
     when(api.getWebManager()).thenReturn(webManager);
     when(webManager.getBusyIndicator()).thenReturn(busyIndicator);
 

--- a/webforj-foundation/src/test/java/com/webforj/IntervalTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/IntervalTest.java
@@ -39,7 +39,7 @@ class IntervalTest {
     listener = mock(EventListener.class);
 
     when(environment.getBBjAPI()).thenReturn(api);
-    when(environment.getWebforjHelper()).thenReturn(bridge);
+    when(environment.getBridge()).thenReturn(bridge);
 
     interval = spy(new Interval(1.0f, listener));
     doReturn(environment).when(interval).getEnvironment();

--- a/webforj-foundation/src/test/java/com/webforj/MaskDecoratorTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/MaskDecoratorTest.java
@@ -30,7 +30,7 @@ class MaskDecoratorTest {
   void shouldMaskString() {
     try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
       mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-      when(env.getWebforjHelper()).thenReturn(bridge);
+      when(env.getBridge()).thenReturn(bridge);
 
       String input = "qw12";
       String mask = "AA-00";
@@ -48,7 +48,7 @@ class MaskDecoratorTest {
   void shouldMaskNumber() {
     try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
       mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-      when(env.getWebforjHelper()).thenReturn(bridge);
+      when(env.getBridge()).thenReturn(bridge);
       float input = 12345;
       String mask = "##,###,###.00";
       String expected = "12,345.00";
@@ -65,7 +65,7 @@ class MaskDecoratorTest {
   void shouldMaskDate() {
     try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
       mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-      when(env.getWebforjHelper()).thenReturn(bridge);
+      when(env.getBridge()).thenReturn(bridge);
 
       LocalDate input = LocalDate.now();
       String mask = "%Dz-%Mz-%Yl";
@@ -84,7 +84,7 @@ class MaskDecoratorTest {
   void shouldMaskTime() {
     try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
       mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-      when(env.getWebforjHelper()).thenReturn(bridge);
+      when(env.getBridge()).thenReturn(bridge);
 
       LocalTime input = LocalTime.of(14, 30, 15);
       String mask = "%Hz:%mz:%sz";
@@ -103,7 +103,7 @@ class MaskDecoratorTest {
   void shouldMaskDateTime() {
     try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
       mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-      when(env.getWebforjHelper()).thenReturn(bridge);
+      when(env.getBridge()).thenReturn(bridge);
 
       LocalDateTime input = LocalDateTime.of(2023, 6, 12, 14, 30, 15);
       String mask = "%Dz-%Mz-%Yl %Hz:%mz:%s";
@@ -125,7 +125,7 @@ class MaskDecoratorTest {
   void shouldParseDate() {
     try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
       mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-      when(env.getWebforjHelper()).thenReturn(bridge);
+      when(env.getBridge()).thenReturn(bridge);
 
       String input = "12";
       String mask = "%Dz-%Mz-%Yz";
@@ -145,7 +145,7 @@ class MaskDecoratorTest {
   void shouldParseTime() {
     try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
       mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-      when(env.getWebforjHelper()).thenReturn(bridge);
+      when(env.getBridge()).thenReturn(bridge);
 
       String input = "9pm";
       String mask = "%Hz:%Mz:%S";

--- a/webforj-foundation/src/test/java/com/webforj/PageTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/PageTest.java
@@ -66,7 +66,7 @@ class PageTest {
 
     when(environment.getBBjAPI()).thenReturn(api);
     when(environment.getSysGui()).thenReturn(sysGui);
-    when(environment.getWebforjHelper()).thenReturn(bridge);
+    when(environment.getBridge()).thenReturn(bridge);
     when(api.getWebManager()).thenReturn(webManager);
     when(api.getThinClient()).thenReturn(thinClient);
     when(thinClient.getClientFileSystem()).thenReturn(clientFileSystem);

--- a/webforj-foundation/src/test/java/com/webforj/RequestTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/RequestTest.java
@@ -39,7 +39,7 @@ class RequestTest {
     when(api.getThinClient()).thenReturn(thinClient);
     when(api.getWebManager()).thenReturn(webManager);
     when(environment.getSysGui()).thenReturn(sysGui);
-    when(environment.getWebforjHelper()).thenReturn(bridge);
+    when(environment.getBridge()).thenReturn(bridge);
 
     request = spy(Request.class);
     when(request.getEnvironment()).thenReturn(environment);

--- a/webforj-foundation/src/test/java/com/webforj/component/field/MaskedDateFieldTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/field/MaskedDateFieldTest.java
@@ -127,7 +127,7 @@ class MaskedDateFieldTest {
 
       try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
         mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-        when(env.getWebforjHelper()).thenReturn(bridge);
+        when(env.getBridge()).thenReturn(bridge);
 
         LocalDate value = LocalDate.of(2020, 10, 1);
         String mask = MaskedDateField.DEFAULT_MASK;
@@ -211,7 +211,7 @@ class MaskedDateFieldTest {
 
       try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
         mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-        when(env.getWebforjHelper()).thenReturn(bridge);
+        when(env.getBridge()).thenReturn(bridge);
 
         LocalDate expectedValue = LocalDate.of(2020, 10, 1);
         String mask = MaskedDateField.DEFAULT_MASK;
@@ -234,7 +234,7 @@ class MaskedDateFieldTest {
 
       try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
         mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-        when(env.getWebforjHelper()).thenReturn(bridge);
+        when(env.getBridge()).thenReturn(bridge);
 
         String mask = MaskedDateField.DEFAULT_MASK;
         String expected = "2020-10-01";

--- a/webforj-foundation/src/test/java/com/webforj/component/field/MaskedTimeFieldTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/field/MaskedTimeFieldTest.java
@@ -128,7 +128,7 @@ class MaskedTimeFieldTest {
 
       try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
         mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-        when(env.getWebforjHelper()).thenReturn(bridge);
+        when(env.getBridge()).thenReturn(bridge);
 
         LocalTime value = LocalTime.of(12, 30);
         String mask = MaskedTimeField.DEFAULT_MASK;
@@ -212,7 +212,7 @@ class MaskedTimeFieldTest {
 
       try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
         mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-        when(env.getWebforjHelper()).thenReturn(bridge);
+        when(env.getBridge()).thenReturn(bridge);
 
         LocalTime expectedValue = LocalTime.of(12, 30);
         String mask = MaskedTimeField.DEFAULT_MASK;
@@ -235,7 +235,7 @@ class MaskedTimeFieldTest {
 
       try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
         mockedEnvironment.when(Environment::getCurrent).thenReturn(env);
-        when(env.getWebforjHelper()).thenReturn(bridge);
+        when(env.getBridge()).thenReturn(bridge);
 
         String mask = MaskedTimeField.DEFAULT_MASK;
         String expected = "2020-10-01";

--- a/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
@@ -28,7 +28,8 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
     HasHelperText<ConcernComponentMock>, HasMask<ConcernComponentMock>,
     HasRestoreValue<ConcernComponentMock, Double>, HasLocale<ConcernComponentMock>,
     HasStep<ConcernComponentMock, Double>, HasPredictedText<ConcernComponentMock>,
-    HasSize<ConcernComponentMock>, HasPrefixAndSuffix<ConcernComponentMock> {
+    HasSize<ConcernComponentMock>, HasPrefixAndSuffix<ConcernComponentMock>,
+    HasAutoFocus<ConcernComponentMock> {
 
   private Map<String, String> attributes = new HashMap<>();
   private Map<String, Object> properties = new HashMap<>();
@@ -72,6 +73,7 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
   private String maxHeight;
   private Component prefixComponent;
   private Component suffixComponent;
+  private boolean autofocus = false;
 
   @Override
   public String getAttribute(String attribute) {
@@ -605,6 +607,16 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
     return this.prefixComponent;
   }
 
+  @Override
+  public ConcernComponentMock setAutoFocus(boolean autofocus) {
+    this.autofocus = autofocus;
+    return this;
+  }
+
+  @Override
+  public boolean isAutoFocus() {
+    return this.autofocus;
+  }
 
   @Override
   protected void onCreate(Window window) {

--- a/webforj-foundation/src/test/java/com/webforj/concern/HasAutoFocusTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/HasAutoFocusTest.java
@@ -1,0 +1,30 @@
+package com.webforj.concern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.webforj.component.Composite;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HasAutoFocusTest {
+
+  private CompositeMock component;
+
+  @BeforeEach
+  void setup() {
+    component = new CompositeMock();
+  }
+
+  @Test
+  void shouldSetGetAutofocus() {
+    boolean expectedAutofocus = true;
+
+    assertSame(component, component.setAutoFocus(expectedAutofocus));
+    assertEquals(expectedAutofocus, component.isAutoFocus());
+  }
+
+  class CompositeMock extends Composite<ConcernComponentMock>
+      implements HasAutoFocus<CompositeMock> {
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/sink/page/PageEventSinkTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/sink/page/PageEventSinkTest.java
@@ -58,7 +58,7 @@ class PageEventSinkTest {
     webManager = mock(BBjWebManager.class);
 
     when(environment.getBBjAPI()).thenReturn(api);
-    when(environment.getWebforjHelper()).thenReturn(mock(WebforjBBjBridge.class));
+    when(environment.getBridge()).thenReturn(mock(WebforjBBjBridge.class));
     when(api.getWebManager()).thenReturn(webManager);
 
     page = spy(Page.class);
@@ -92,7 +92,7 @@ class PageEventSinkTest {
   void shouldProcessPayload() throws BBjException {
     try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class)) {
       mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
-      when(environment.getWebforjHelper()).thenReturn(mock(WebforjBBjBridge.class));
+      when(environment.getBridge()).thenReturn(mock(WebforjBBjBridge.class));
 
       BBjWebEventOptions optionsMock = mock(BBjWebEventOptions.class);
       when(webManager.newEventOptions()).thenReturn(optionsMock);


### PR DESCRIPTION
In the Dialog and Drawer components:

1. `setAutofocus` has been renamed to `setAutoFocus`.
2. `isAutofocus` has been renamed to `isAutoFocus`.

Old methods are scheduled for removal in version `25.00`.

closes #833