### PR TITLE
fix: `NumberField` display numbers always as doubles

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/field/NumberField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/NumberField.java
@@ -119,6 +119,10 @@ public final class NumberField extends DwcFieldInitializer<NumberField, Double>
    */
   @Override
   public NumberField setValue(Double value) {
+    if (value != null && value % 1 == 0) {
+      return setText(String.valueOf(value.intValue()));
+    }
+
     return setText(String.valueOf(value));
   }
 
@@ -224,7 +228,11 @@ public final class NumberField extends DwcFieldInitializer<NumberField, Double>
   @Override
   protected Double convertValue(String value) {
     try {
-      return Double.valueOf(value);
+      if (value.contains(".")) {
+        return Double.valueOf(value);
+      } else {
+        return Double.valueOf(Integer.valueOf(value));
+      }
     } catch (NumberFormatException e) {
       return null;
     }

--- a/webforj-foundation/src/test/java/com/webforj/component/field/NumberFieldTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/field/NumberFieldTest.java
@@ -2,6 +2,7 @@ package com.webforj.component.field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -150,6 +151,13 @@ class NumberFieldTest {
       doReturn("").when(control).getText();
 
       assertEquals(null, component.getValue());
+    }
+
+    @Test
+    void shouldSetValueAsInt() {
+      NumberField spy = spy(component);
+      spy.setValue(10.0);
+      verify(spy, times(1)).setText("10");
     }
   }
 }


### PR DESCRIPTION
The NumberField always displays numbers as doubles because the setValue method only accepts doubles. This Improves the component’s behavior to detect if the value can be displayed as an Integer and display it accordingly.