### PR TITLE
fix: table's cell double click and cell click both fire on single click

### DIFF
--- a/webforj-components/webforj-table/src/main/java/com/webforj/component/table/event/cell/TableCellDoubleClickEvent.java
+++ b/webforj-components/webforj-table/src/main/java/com/webforj/component/table/event/cell/TableCellDoubleClickEvent.java
@@ -12,7 +12,7 @@ import java.util.Map;
  * @author Hyyan Abo Fakher
  * @since 24.00
  */
-@EventName("dwc-cell-clicked")
+@EventName("dwc-cell-dbclicked")
 public class TableCellDoubleClickEvent<T> extends TableCellEvent<T> {
 
   /**


### PR DESCRIPTION
fixes #873 