### PR TITLE
refactor: streamline the behavior of list components to set/get selected items

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/list/ChoiceBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ChoiceBox.java
@@ -12,6 +12,8 @@ import com.webforj.exceptions.WebforjRuntimeException;
 import com.webforj.utilities.BBjFunctionalityHelper;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents a ChoiceBox component that provides users with a list of options for selection.
@@ -92,6 +94,32 @@ public final class ChoiceBox extends DwcSelectDropdown<ChoiceBox>
   @ExcludeFromJacocoGeneratedReport
   public ButtonTheme getTheme() {
     return super.<ButtonTheme>getComponentTheme();
+  }
+
+  /**
+   * Selects the item with the given text.
+   *
+   * @return the component itself
+   */
+  @Override
+  public ChoiceBox setText(String text) {
+    Objects.requireNonNull(text, "The text cannot be null");
+
+    String needle = text.trim();
+    getItems().stream().filter(item -> item.getText().equals(needle)).findFirst()
+        .ifPresent(this::select);
+
+    return this;
+  }
+
+  /**
+   * Selects an item with the given key.
+   *
+   * @return the component itself
+   */
+  @Override
+  public String getText() {
+    return Optional.ofNullable(getSelectedItem()).map(ListItem::getText).orElse(null);
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
@@ -2,7 +2,6 @@ package com.webforj.component.list;
 
 import com.basis.bbj.proxies.sysgui.BBjComboBox;
 import com.basis.startup.type.BBjException;
-import com.webforj.annotation.ExcludeFromJacocoGeneratedReport;
 import com.webforj.bridge.ComponentAccessor;
 import com.webforj.component.Component;
 import com.webforj.component.event.ComponentEventSinkRegistry;

--- a/webforj-foundation/src/main/java/com/webforj/component/list/ListBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ListBox.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Represents a component that displays a list of objects and allows users to select single or
@@ -309,6 +310,54 @@ public final class ListBox extends DwcList<ListBox, List<Object>>
   @Override
   public List<Object> getValue() {
     return getSelectedKeys();
+  }
+
+  /**
+   * Selects the items with the given text.
+   *
+   * <p>
+   * Selects one or more items with the given text. For multiple selection mode, the text should be
+   * separated by a comma. If the text is not found in the list, it will be ignored.
+   * </p>
+   *
+   * @return the component itself
+   */
+  @Override
+  public ListBox setText(String text) {
+    Objects.requireNonNull(text, "The text cannot be null");
+
+    List<String> items = Arrays.asList(text.trim().split(",\\s*"));
+
+    // find all items with the given text
+    Stream<ListItem> matched = getItems().stream().filter(i -> items.contains(i.getText()));
+    SelectionMode mode = getSelectionMode();
+
+    if (mode.equals(SelectionMode.SINGLE)) {
+      matched.findFirst().ifPresent(this::select);
+    } else if (mode.equals(SelectionMode.MULTIPLE)) {
+      select(matched.toArray(ListItem[]::new));
+    }
+
+    return this;
+  }
+
+  /**
+   * Returns the text of the selected items separated by a comma.
+   *
+   * <p>
+   * If no item is selected, then null is returned.
+   * </p>
+   *
+   * @return the text of the selected items
+   */
+  @Override
+  public String getText() {
+    List<ListItem> items = getSelectedItems();
+    if (items.isEmpty()) {
+      return null;
+    }
+
+    return items.stream().map(ListItem::getText).collect(Collectors.joining(","));
   }
 
   /**

--- a/webforj-foundation/src/test/java/com/webforj/component/list/ChoiceBoxTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/ChoiceBoxTest.java
@@ -1,0 +1,55 @@
+package com.webforj.component.list;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.basis.bbj.proxies.sysgui.BBjListButton;
+import com.webforj.component.ReflectionUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChoiceBoxTest {
+
+  @Mock
+  BBjListButton control;
+
+  @InjectMocks
+  ChoiceBox component = new ChoiceBox();
+
+  @Nested
+  @DisplayName("Text API")
+  class TextApi {
+
+    @Test
+    @DisplayName("should set text and get text")
+    void shouldSetTextAndGetText() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      component.add("key-1", "value-1");
+      component.add("key-2", "value-2");
+      component.add("key-3", "value-3");
+
+      component.setText("value-2");
+
+      assertEquals("value-2", component.getText());
+    }
+
+    @Test
+    @DisplayName("should return empty text when no items are selected")
+    void shouldReturnEmptyTextWhenNoItemsAreSelected() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      component.add("key-1", "value-1");
+      component.add("key-2", "value-2");
+      component.add("key-3", "value-3");
+
+      assertNull(component.getText());
+    }
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/component/list/DwcListTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/DwcListTest.java
@@ -21,7 +21,6 @@ import com.webforj.component.list.event.ListSelectEvent;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.exceptions.WebforjRuntimeException;
-import java.sql.Ref;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/webforj-foundation/src/test/java/com/webforj/component/list/ListBoxTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/ListBoxTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.list;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -256,6 +257,55 @@ class ListBoxTest {
         throws BBjException {
       doThrow(BBjException.class).when(control).getSelectedIndices();
       assertThrows(WebforjRuntimeException.class, () -> component.getSelectedIndices());
+    }
+  }
+
+  @Nested
+  @DisplayName("Text API")
+  class TextApi {
+
+    @Test
+    @DisplayName("should set text and get text")
+    void shouldSetTextAndGetText() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      component.setSelectionMode(SelectionMode.MULTIPLE);
+      component.add("key-1", "value-1");
+      component.add("key-2", "value-2");
+      component.add("key-3", "value-3");
+
+      component.setText("   value-2,    value-3");
+
+      assertEquals("value-2,value-3", component.getText());
+    }
+
+    @Test
+    @DisplayName("should return empty text when no items are selected")
+    void shouldReturnEmptyTextWhenNoItemsAreSelected() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      component.setSelectionMode(SelectionMode.MULTIPLE);
+      component.add("key-1", "value-1");
+      component.add("key-2", "value-2");
+      component.add("key-3", "value-3");
+
+      assertNull(component.getText());
+    }
+
+    @Test
+    @DisplayName("should set text and get text in single selection mode")
+    void shouldSetTextAndGetTextInSingleSelectionMode()
+        throws BBjException, IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      component.setSelectionMode(SelectionMode.SINGLE);
+      component.add("key-1", "value-1");
+      component.add("key-2", "value-2");
+      component.add("key-3", "value-3");
+
+      component.setText("   value-2,    value-3");
+
+      assertEquals("value-2", component.getText());
     }
   }
 


### PR DESCRIPTION
The list controls have inherited some unclear behavior from BBj. Here's how the current BBj methods work:

1. **ListBox**:  
   - `setText`: Accepts a linefeed-delimited string to populate the list.  
   - `getText`: Returns the currently selected items as a comma-separated string.

2. **ListButton**:  
   - `setText`: Accepts a linefeed-delimited string to populate the list.  
   - `getText`: Returns the currently selected item.

3. **ListEdit**:  
   - `setText`: Sets the input text and selects the item if it exists in the list.  
   - `getText`: Returns the input text. If the text matches an item in the list, it returns the selected item. Otherwise, it simply returns the input text.

This PR refactors the behavior of the `ListBox` and `ChoiceBox` to standardize the `setText` and `getText` methods. Now, they will consistently set and retrieve selected items, aligning with the webforJ approach deviating from the original BBj behavior.

closes #800