### PR TITLE
feat: Add support for icons URL handling in Assets and related components

### DIFF
--- a/webforj-components/webforj-html-elements/src/main/java/com/webforj/component/html/elements/Img.java
+++ b/webforj-components/webforj-html-elements/src/main/java/com/webforj/component/html/elements/Img.java
@@ -66,6 +66,8 @@ public class Img extends HtmlComponent<Img> {
 
     if (Assets.isWebServerUrl(src)) {
       url = Assets.resolveWebServerUrl(src);
+    } else if (Assets.isIconsUrl(src)) {
+      url = Assets.resolveIconsUrl(src);
     } else if (Assets.isContextUrl(src)) {
       String resolvedUrl = Assets.resolveContextUrl(src);
       String content = Assets.contentOf(resolvedUrl, Assets.ContentFormat.BASE64);

--- a/webforj-foundation/src/main/java/com/webforj/annotation/AnnotationProcessor.java
+++ b/webforj-foundation/src/main/java/com/webforj/annotation/AnnotationProcessor.java
@@ -386,13 +386,23 @@ public final class AnnotationProcessor {
       return;
     }
 
-    String iconFilename = Assets.getFileName(defaultIcon.value());
+    String iconValue = defaultIcon.value();
+    String queryParams = "";
+
+    int queryIndex = iconValue.indexOf('?');
+    if (queryIndex != -1) {
+      queryParams = iconValue.substring(queryIndex);
+      iconValue = iconValue.substring(0, queryIndex);
+    }
+
+    String iconFilename = Assets.getFileName(iconValue);
     String iconBaseName = iconFilename.substring(0, iconFilename.lastIndexOf('.'));
     String iconExtension = Assets.getFileExtension(iconFilename);
 
     for (int size : defaultIcon.sizes()) {
-      String src = defaultIcon.value().replace(iconFilename,
-          iconBaseName + "-" + size + "x" + size + iconExtension);
+      String src =
+          iconValue.replace(iconFilename, iconBaseName + "-" + size + "x" + size + iconExtension)
+              + queryParams;
       // @formatter:off
       ProfileDescriptor.Image image = new ProfileDescriptor.Image.ImageBuilder()
           .setSrc(resolveUrl(src, base))
@@ -513,6 +523,11 @@ public final class AnnotationProcessor {
     boolean isWs = Assets.isWebServerUrl(src);
     if (isWs) {
       resolved = Assets.resolveWebServerUrl(src);
+    }
+
+    boolean isIcons = Assets.isIconsUrl(src);
+    if (isIcons) {
+      resolved = Assets.resolveIconsUrl(src);
     }
 
     // If resolved is not a fully qualified URL, resolve it with the base URL

--- a/webforj-foundation/src/main/java/com/webforj/annotation/AppProfile.java
+++ b/webforj-foundation/src/main/java/com/webforj/annotation/AppProfile.java
@@ -28,7 +28,7 @@ public @interface AppProfile {
   String DEFAULT_START_URL = ".";
   String DEFAULT_VIEWPORT =
       "viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no";
-  String DEFAULT_ICON_SRC = "ws://icons/icon.png";
+  String DEFAULT_ICON_SRC = "icons://icon.png";
 
   /**
    * The id of the application.
@@ -158,12 +158,10 @@ public @interface AppProfile {
    * The default icon of the application.
    *
    * <p>
-   * The default icon is used to specify the default icon for the app. By default, the icons should
-   * be placed in <code>static/icons</code> directory. and named <code>icon.png</code>. And the
-   * sizes should be <code>144x144</code>, <code>192x192</code>, and <code>512x512</code> variants
-   * of the icon should be placed in the same directory. for example:
-   * <code>static/icons/icon-144x144.png</code>
+   * The icon path can be be a <code>webserver://</code> or <code>icons://</code> URL.
    * </p>
+   *
+   * @return the default icon
    */
   DefaultIcon defaultIcon() default @DefaultIcon(DEFAULT_ICON_SRC);
 


### PR DESCRIPTION
By default, webforj serves icons from the `resources/icons/` directory. You can change the endpoint name by setting the `webforj.iconsDir` property in the webforj configuration file. The default endpoint is `icons/`.

The icons endpoint accepts the icon file name as a path parameter with a specified size. For example, `icons://icon-144x144.png` will return the icon with a size of 144x144. The base image should be placed in the `resources/icons/` directory and named `icon.png`.

Additionally, you can add padding or a background color to the icon using the following query parameters:

- **`padding`**: The padding around the icon, specified as a number between 0 and 1.  
  For example, `icons://icon-144x144.png?padding=.3` adds a 30% padding around the icon.
- **`background`**: The background color of the icon, specified as a valid hex color.  
  For example, `icons://icon-144x144.png?background=ffffff` adds a white background to the icon.
