### PR TITLE
feat: Add table sort index functionality and enable single column sorting mode

### DIFF
--- a/webforj-components/webforj-table/src/main/java/com/webforj/component/table/Column.java
+++ b/webforj-components/webforj-table/src/main/java/com/webforj/component/table/Column.java
@@ -127,6 +127,7 @@ public final class Column<T, V> implements Serializable {
   private PinDirection pinned = PinDirection.AUTO;
   private boolean sortable = false;
   private SortDirection sort = SortDirection.NONE;
+  private int sortIndex = 0;
   private boolean suppressNavigable = false;
   private Float minWidth = null;
   @SuppressWarnings("unused")
@@ -375,6 +376,35 @@ public final class Column<T, V> implements Serializable {
    */
   public SortDirection getSortDirection() {
     return sort;
+  }
+
+  /**
+   * Sets the sort index of the column.
+   *
+   * @param sortIndex the new sort index
+   * @return the column itself
+   *
+   * @throws IllegalArgumentException if the sort index is negative
+   */
+  public Column<T, V> setSortIndex(int sortIndex) {
+    int oldSortIndex = this.sortIndex;
+    if (sortIndex < 0) {
+      throw new IllegalArgumentException("Sort index cannot be negative");
+    }
+
+    this.sortIndex = sortIndex;
+    changeSupport.firePropertyChange("sortIndex", oldSortIndex, sortIndex);
+
+    return this;
+  }
+
+  /**
+   * Returns the sort index of the column.
+   *
+   * @return the sort index
+   */
+  public int getSortIndex() {
+    return sortIndex;
   }
 
   /**

--- a/webforj-components/webforj-table/src/main/java/com/webforj/component/table/event/TableSortChangeEvent.java
+++ b/webforj-components/webforj-table/src/main/java/com/webforj/component/table/event/TableSortChangeEvent.java
@@ -1,5 +1,7 @@
 package com.webforj.component.table.event;
 
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
 import com.webforj.component.element.annotation.EventName;
 import com.webforj.component.element.annotation.EventOptions;
 import com.webforj.component.element.annotation.EventOptions.EventData;
@@ -7,8 +9,10 @@ import com.webforj.component.table.Column;
 import com.webforj.component.table.Table;
 import com.webforj.data.repository.OrderCriteria;
 import com.webforj.data.repository.OrderCriteriaList;
+import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -21,9 +25,10 @@ import java.util.function.Function;
  * @since 24.00
  */
 @EventName("dwc-sort-changed")
-@EventOptions(data = {@EventData(key = "criteria", exp = "event.detail")})
+@EventOptions(data = {@EventData(key = "criteria", exp = "JSON.stringify(event.detail)")})
 public class TableSortChangeEvent<T> extends TableEvent<T> {
-  private Map<String, String> clientCriteria = new HashMap<>();
+  private final transient Map<String, String> clientCriteria = new LinkedHashMap<>();
+  private final transient List<ClientCriteria> criteriaDetails;
 
   /**
    * Creates a new sort event.
@@ -33,16 +38,32 @@ public class TableSortChangeEvent<T> extends TableEvent<T> {
    */
   public TableSortChangeEvent(Table<T> table, Map<String, Object> eventMap) {
     super(table, eventMap);
-    this.clientCriteria = (Map<String, String>) eventMap.get("criteria");
+    TypeToken<List<ClientCriteria>> criteriaListToken = new TypeToken<List<ClientCriteria>>() {};
+    this.criteriaDetails =
+        new Gson().fromJson((String) eventMap.get("criteria"), criteriaListToken.getType());
   }
 
   /**
-   * Returns the client side sort criteria.
+   * Returns the client side sort criteria as a map.
+   *
+   * <p>
+   * This method is used to get the client side sort criteria. The criteria are stored in a map
+   * where the key is the column id and the value is the sort direction (asc or desc).
+   * </p>
    *
    * @return the client side sort criteria
    */
   public Map<String, String> getClientCriterion() {
-    return clientCriteria;
+    // no need to sort the criteria, it is already sorted by the client
+    if (clientCriteria.isEmpty()) {
+      for (ClientCriteria clientCriterion : criteriaDetails) {
+        String columnId = clientCriterion.getId();
+        String sort = clientCriterion.getSort();
+        clientCriteria.put(columnId, sort);
+      }
+    }
+
+    return Collections.unmodifiableMap(clientCriteria);
   }
 
   /**
@@ -54,7 +75,8 @@ public class TableSortChangeEvent<T> extends TableEvent<T> {
     OrderCriteriaList<T> criterion = new OrderCriteriaList<>();
 
     // loop over the criteria and create a list of OrderCriteria
-    for (Map.Entry<String, String> entry : clientCriteria.entrySet()) {
+    var localClientCriterion = getClientCriterion();
+    for (var entry : localClientCriterion.entrySet()) {
       String columnId = entry.getKey();
       OrderCriteria.Direction direction =
           entry.getValue().equalsIgnoreCase("asc") ? OrderCriteria.Direction.ASC
@@ -71,5 +93,53 @@ public class TableSortChangeEvent<T> extends TableEvent<T> {
     }
 
     return criterion;
+  }
+
+  /**
+   * Represents the client criteria.
+   *
+   * @return the OrderCriteriaList
+   * @since 25.00
+   */
+  static final class ClientCriteria {
+    private String id;
+    private String sort;
+    private int sortIndex;
+
+    /**
+     * Get the id of the column.
+     *
+     * @return the id of the column
+     */
+    public String getId() {
+      return id;
+    }
+
+    /**
+     * Get the sort direction.
+     *
+     * @return the sort direction
+     */
+    public String getSort() {
+      return sort;
+    }
+
+    /**
+     * Get the sort index.
+     *
+     * @return the sort index
+     */
+    public int getSortIndex() {
+      return sortIndex;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+      return "ClientCriteria{" + "id='" + id + '\'' + ", sort='" + sort + '\'' + ", sortIndex="
+          + sortIndex + '}';
+    }
   }
 }

--- a/webforj-components/webforj-table/src/test/java/com/webforj/component/table/TableTest.java
+++ b/webforj-components/webforj-table/src/test/java/com/webforj/component/table/TableTest.java
@@ -396,20 +396,33 @@ class TableTest {
       component.addColumn("col3", Function.identity()).setSortDirection(Column.SortDirection.DESC);
 
       Map<String, Object> payload = new HashMap<>();
-      payload.put("criteria", new HashMap<>() {
-        {
-          put("col1", "asc");
-          put("col2", "desc");
-        }
-      });
+      payload.put("criteria", """
+          [
+            {
+              "id": "col1",
+              "sort": "asc",
+              "sortIndex": 1
+            },
+            {
+              "id": "col2",
+              "sort": "asc",
+              "sortIndex": 2
+            },
+            {
+              "id": "col3",
+              "sort": "desc",
+              "sortIndex": 3
+            }
+          ]
+          """);
       TableSortChangeEvent<String> event = new TableSortChangeEvent<>(component, payload);
 
       component.handleSortChanged(event);
 
       // check columns directions are updated
       assertEquals(Column.SortDirection.ASC, component.getColumnById("col1").getSortDirection());
-      assertEquals(Column.SortDirection.DESC, component.getColumnById("col2").getSortDirection());
-      assertEquals(Column.SortDirection.NONE, component.getColumnById("col3").getSortDirection());
+      assertEquals(Column.SortDirection.ASC, component.getColumnById("col2").getSortDirection());
+      assertEquals(Column.SortDirection.DESC, component.getColumnById("col3").getSortDirection());
     }
 
     @Test

--- a/webforj-components/webforj-table/src/test/java/com/webforj/component/table/event/TableSortChangeEventTest.java
+++ b/webforj-components/webforj-table/src/test/java/com/webforj/component/table/event/TableSortChangeEventTest.java
@@ -13,26 +13,56 @@ import org.junit.jupiter.api.Test;
 
 class TableSortChangeEventTest {
 
-  Table<String> table = null;
+  Table<Person> table = null;
 
   @BeforeEach
   void setup() {
-    table = new Table<String>();
-    table.addColumn("item", String::valueOf).setLabel("Items");
-    table.setItems(List.of("Item 0"));
+    table = new Table<Person>();
+    table.addColumn("name", Person::name);
+    table.addColumn("city", Person::city);
+    table.addColumn("age", Person::age);
+
+    table.setItems(List.of(new Person("Hyyan", "Syria", 30), new Person("Stephen", "DE", 25),
+        new Person("John", "US", 35), new Person("Jane", "UK", 28)));
   }
 
   @Test
   void shouldReturnSortCriteria() {
     Map<String, Object> eventMap = new HashMap<>();
-    eventMap.put("criteria", Map.of("item", "desc"));
+    eventMap.put("criteria", """
+        [
+          {
+            "id": "name",
+            "sort": "asc",
+            "sortIndex": 1
+          },
+          {
+            "id": "city",
+            "sort": "asc",
+            "sortIndex": 2
+          },
+          {
+            "id": "age",
+            "sort": "desc",
+            "sortIndex": 3
+          }
+        ]
+        """);
 
-    TableSortChangeEvent<String> event = new TableSortChangeEvent<>(table, eventMap);
+    TableSortChangeEvent<Person> event = new TableSortChangeEvent<>(table, eventMap);
 
-    OrderCriteriaList<String> criterion = event.getOrderCriteriaList();
-    assertEquals(1, criterion.size());
+    OrderCriteriaList<Person> criterion = event.getOrderCriteriaList();
+    assertEquals(3, criterion.size());
 
-    OrderCriteria<String, ?> criteria = criterion.iterator().next();
-    assertEquals(OrderCriteria.Direction.DESC, criteria.getDirection());
+    OrderCriteria<Person, ?> criteria = criterion.iterator().next();
+    assertEquals(OrderCriteria.Direction.ASC, criteria.getDirection());
+  }
+
+  static record Person(String name, String city, int age) {
+    public Person(String name, String city, int age) {
+      this.name = name;
+      this.city = city;
+      this.age = age;
+    }
   }
 }


### PR DESCRIPTION
Starting with webforj 25.00, tables now support single-column sorting by default. Clicking on a column header will sort that column and automatically clear sorting from all other columns.

To enable multi-column sorting, use the new API method `setMultiSorting(boolean)`. Setting it to `true` allows users to sort multiple columns simultaneously. When multi-sorting is enabled, the table will visually indicate the sort order by numbering the sorted columns, making it easy for users to track the sorting sequence.

When configuring server-side sorting, the user must call `setSortOrder` on the columns that should be sorted to define their priority. Otherwise, the table will sort the data based on the default column order.

![table](https://github.com/user-attachments/assets/9dcaa6d3-b03b-4d72-8684-3298da4f5489)

```java

import java.util.List;

import com.webforj.component.Composite;
import com.webforj.component.layout.flexlayout.FlexDirection;
import com.webforj.component.layout.flexlayout.FlexLayout;
import com.webforj.component.table.Table;
import com.webforj.router.annotation.Route;

@Route("/")
public class HelloWorldView extends Composite<FlexLayout> {

  private FlexLayout self = getBoundComponent();
  private Table<Person> table = new Table<>();

  public HelloWorldView() {
    self.setDirection(FlexDirection.COLUMN);
    self.setMaxWidth(760);
    self.setStyle("margin", "1em auto");

    List<Person> data = List.of(
        new Person("Alice", 28, "New York"),
        new Person("Alice", 32, "Chicago"),
        new Person("Bob", 28, "Chicago"),
        new Person("Bob", 35, "New York"),
        new Person("Charlie", 25, "Los Angeles"),
        new Person("Charlie", 25, "New York"),
        new Person("David", 40, "San Francisco"),
        new Person("Eve", 30, "Boston"),
        new Person("Frank", 30, "Boston"),
        new Person("Grace", 27, "Seattle"));

    table.addColumn("Name", Person::name).setSortable(true);
    table.addColumn("Age", Person::age).setSortable(true);
    table.addColumn("City", Person::city).setSortable(true);

    // By default, only one column can be sorted at a time. Clicking on a column
    // header will sort the
    // column and remove the sorting from the other columns. Setting this property
    // to true allows multiple columns to be sorted at once.
    table.setMultiSorting(true);
    table.setItems(data);
    table.setSize("100%", "400px");

    self.add(table);
  }

  public static record Person(String name, int age, String city) {
  }
}
```


