### PR TITLE
feat: add experimental support to desktop notifications 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "projectKey": "webforj"
   },
   "cSpell.words": [
+    "desktopnotification",
     "infinitescroll"
   ],
   "java.completion.favoriteStaticMembers": [

--- a/webforj-bom/pom.xml
+++ b/webforj-bom/pom.xml
@@ -46,6 +46,11 @@
       </dependency>
       <dependency>
         <groupId>com.webforj</groupId>
+        <artifactId>webforj-desktop-notification</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.webforj</groupId>
         <artifactId>webforj-dialog</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/webforj-components/pom.xml
+++ b/webforj-components/pom.xml
@@ -19,6 +19,7 @@
     <module>webforj-applayout</module>
     <module>webforj-appnav</module>
     <module>webforj-columnslayout</module>
+    <module>webforj-desktop-notification</module>
     <module>webforj-dialog</module>
     <module>webforj-drawer</module>
     <module>webforj-flexlayout</module>

--- a/webforj-components/webforj-desktop-notification/pom.xml
+++ b/webforj-components/webforj-desktop-notification/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.webforj</groupId>
+    <artifactId>webforj-components</artifactId>
+    <version>25.00-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>webforj-desktop-notification</artifactId>
+  <name>${project.artifactId}</name>
+  <description>webforJ Desktop Notification</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.webforj</groupId>
+      <artifactId>webforj-foundation</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/DesktopNotification.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/DesktopNotification.java
@@ -14,7 +14,27 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * The Notification component is used to configure and display desktop notifications to the user.
+ * The {@code Notification} component enables applications to configure and display native desktop
+ * notifications to users.
+ *
+ * <p>
+ * Desktop notifications allow an application to alert users about new messages or updates while the
+ * browser is open. Once permission is granted, the browser can display notifications on the user's
+ * screen. However, notifications are only shown after the user interacts with the application—such
+ * as by pressing a key or clicking/tapping within the app. Without user interaction, only a
+ * notification icon appears in the browser’s address bar, and no visible notification is displayed.
+ * </p>
+ *
+ * <p>
+ * To successfully display desktop notifications, the following conditions must be met:
+ * <ul>
+ * <li>The application must run in a secure context (e.g., over HTTPS).</li>
+ * <li>The application must not be in incognito/private browsing mode.</li>
+ * <li>The notification must be triggered by a user gesture, such as a button click or keyboard
+ * input.</li>
+ * <li>The user must have granted permission to display notifications.</li>
+ * </ul>
+ * </p>
  *
  * @author Hyyan Abo Fakher
  * @since 25.00
@@ -58,7 +78,7 @@ public class DesktopNotification {
    * @return The component itself.
    */
   public DesktopNotification setTitle(String title) {
-    Objects.requireNonNull(title, "The title can not be null");
+    Objects.requireNonNull(title, "The notification's title can not be null");
     this.title = title;
     return this;
   }
@@ -79,7 +99,7 @@ public class DesktopNotification {
    * @return The component itself.
    */
   public DesktopNotification setBody(String body) {
-    Objects.requireNonNull(body, "The body can not be null");
+    Objects.requireNonNull(body, "The notification's body can not be null");
     this.body = body;
     return this;
   }
@@ -96,12 +116,24 @@ public class DesktopNotification {
   /**
    * Sets The icon of the notification.
    *
-   * @param icon The icon of the notification.
+   * <p>
+   * <b> This feature will not work on all browsers. For example, it will not work on Safari but
+   * will work on Chrome and Firefox. </b>
+   * </p>
+   *
+   * @param src The URL of the image. If a URL is provided and begins with {@code context://}, it
+   *        will be resolved as a context URL, pointing to the root of your application's resources
+   *        folder, and the image URL will be a base64-encoded string of the image. If a URL is
+   *        provided and starts with {@code ws://}, it will be resolved as a web server URL,
+   *        pointing to the root of the web server, and the image URL will be a fully qualified URL.
+   *        if a URL is provided and starts with {@code icons://}, it will be resolved as an icons
+   *        URL.
+   *
    * @return The component itself.
    */
-  public DesktopNotification setIcon(String icon) {
-    Objects.requireNonNull(icon, "The icon can not be null");
-    this.icon = icon;
+  public DesktopNotification setIcon(String src) {
+    Objects.requireNonNull(src, "The icon can not be null");
+    this.icon = src;
     return this;
   }
 
@@ -109,6 +141,7 @@ public class DesktopNotification {
    * Gets The icon of the notification.
    *
    * @return The icon of the notification.
+   * @see #setIcon(String)
    */
   public String getIcon() {
     return icon;
@@ -144,7 +177,8 @@ public class DesktopNotification {
           }
           if(granted) show();
         })()
-      }""";
+      }
+        """;
     // @formatter:on
 
     Page.ifPresent(page -> {
@@ -179,7 +213,32 @@ public class DesktopNotification {
   }
 
   /**
-   * Shows a notification with the given title and body.
+   * Shows a notification with the given title and body and icon.
+   *
+   * <p>
+   * Desktop notifications allow an application to alert users about new messages or updates while
+   * the browser is open. Once permission is granted, the browser can display notifications on the
+   * user's screen. However, notifications are only shown after the user interacts with the
+   * application—such as by pressing a key or clicking/tapping within the app. Without user
+   * interaction, only a notification icon appears in the browser’s address bar, and no visible
+   * notification is displayed.
+   * </p>
+   *
+   * <p>
+   * To successfully display desktop notifications, the following conditions must be met:
+   * <ul>
+   * <li>The application must run in a secure context (e.g., over HTTPS).</li>
+   * <li>The application must not be in incognito/private browsing mode.</li>
+   * <li>The notification must be triggered by a user gesture, such as a button click or keyboard
+   * input.</li>
+   * <li>The user must have granted permission to display notifications.</li>
+   * </ul>
+   * </p>
+   *
+   * <p>
+   * Note that icons are not supported in all browsers. For example, it will not work on Safari but
+   * will work on Chrome and Firefox.
+   * </p>
    *
    * @param title The title of the notification.
    * @param body The body of the notification.
@@ -194,6 +253,26 @@ public class DesktopNotification {
   /**
    * Shows a notification with the given title and body.
    *
+   * <p>
+   * Desktop notifications allow an application to alert users about new messages or updates while
+   * the browser is open. Once permission is granted, the browser can display notifications on the
+   * user's screen. However, notifications are only shown after the user interacts with the
+   * application—such as by pressing a key or clicking/tapping within the app. Without user
+   * interaction, only a notification icon appears in the browser’s address bar, and no visible
+   * notification is displayed.
+   * </p>
+   *
+   * <p>
+   * To successfully display desktop notifications, the following conditions must be met:
+   * <ul>
+   * <li>The application must run in a secure context (e.g., over HTTPS).</li>
+   * <li>The application must not be in incognito/private browsing mode.</li>
+   * <li>The notification must be triggered by a user gesture, such as a button click or keyboard
+   * input.</li>
+   * <li>The user must have granted permission to display notifications.</li>
+   * </ul>
+   * </p>
+   *
    * @param title The title of the notification.
    * @param body The body of the notification.
    *
@@ -205,6 +284,26 @@ public class DesktopNotification {
 
   /**
    * Shows a notification with the given body.
+   *
+   * <p>
+   * Desktop notifications allow an application to alert users about new messages or updates while
+   * the browser is open. Once permission is granted, the browser can display notifications on the
+   * user's screen. However, notifications are only shown after the user interacts with the
+   * application—such as by pressing a key or clicking/tapping within the app. Without user
+   * interaction, only a notification icon appears in the browser’s address bar, and no visible
+   * notification is displayed.
+   * </p>
+   *
+   * <p>
+   * To successfully display desktop notifications, the following conditions must be met:
+   * <ul>
+   * <li>The application must run in a secure context (e.g., over HTTPS).</li>
+   * <li>The application must not be in incognito/private browsing mode.</li>
+   * <li>The notification must be triggered by a user gesture, such as a button click or keyboard
+   * input.</li>
+   * <li>The user must have granted permission to display notifications.</li>
+   * </ul>
+   * </p>
    *
    * @param body The body of the notification.
    *

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/DesktopNotification.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/DesktopNotification.java
@@ -1,6 +1,5 @@
 package com.webforj.component.desktopnotification;
 
-import com.basis.bbj.iris.bdt.gbf.profile.Event;
 import com.webforj.Page;
 import com.webforj.annotation.Experimental;
 import com.webforj.component.desktopnotification.event.DesktopNotificationClickEvent;

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/DesktopNotification.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/DesktopNotification.java
@@ -412,8 +412,23 @@ public class DesktopNotification {
   /**
    * Adds a listener for the notification click event.
    *
-   * @param listener the listener
-   * @return A registration object for removing the event listener
+   * <p>
+   * The listener is triggered when the user clicks on a desktop notification created by this API.
+   * <strong>Note:</strong> the click event is used solely for notification purposes and does not
+   * automatically bring the application tab or window into focus. Due to browser security and UX
+   * policies, the focus behavior must be handled separately by the application and cannot be
+   * guaranteed by this event.
+   * <p>
+   * Limitations include:
+   * <ul>
+   * <li>The click event is dispatched only when a user actively clicks the notification.</li>
+   * <li>Browsers do not permit forcing focus to the app tab solely from a notification click.</li>
+   * <li>Any logic to refocus the app must be implemented by the application, keeping in mind that
+   * user gestures or additional browser-specific allowances are required.</li>
+   * </ul>
+   *
+   * @param listener the listener to be notified when the notification is clicked
+   * @return a registration object for removing the event listener
    */
   public ListenerRegistration<DesktopNotificationClickEvent> addClickListener(
       EventListener<DesktopNotificationClickEvent> listener) {

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/DesktopNotification.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/DesktopNotification.java
@@ -1,0 +1,344 @@
+package com.webforj.component.desktopnotification;
+
+import com.webforj.Page;
+import com.webforj.annotation.Experimental;
+import com.webforj.component.desktopnotification.event.DesktopNotificationClickEvent;
+import com.webforj.component.desktopnotification.event.DesktopNotificationCloseEvent;
+import com.webforj.component.desktopnotification.event.DesktopNotificationErrorEvent;
+import com.webforj.component.desktopnotification.event.DesktopNotificationOpenEvent;
+import com.webforj.dispatcher.EventDispatcher;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+import com.webforj.utilities.Assets;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * The Notification component is used to configure and display desktop notifications to the user.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.00
+ */
+@Experimental(since = "25.00")
+public class DesktopNotification {
+  private final String id = UUID.randomUUID().toString();
+  private final EventDispatcher eventDispatcher = new EventDispatcher();
+  private boolean openListenerRegistered = false;
+  private boolean closeListenerRegistered = false;
+  private boolean errorListenerRegistered = false;
+  private boolean clickListenerRegistered = false;
+  private String title = "";
+  private String body = "";
+  private String icon = "icons://icon-32x32.png";
+
+  /**
+   * Creates a new instance of the DesktopNotification.
+   *
+   * @param title The title of the notification.
+   * @param body The body of the notification.
+   */
+  public DesktopNotification(String title, String body) {
+    setTitle(title);
+    setBody(body);
+  }
+
+  /**
+   * Creates a new instance of the DesktopNotification.
+   *
+   * @param body The body of the notification.
+   */
+  public DesktopNotification(String body) {
+    setBody(body);
+  }
+
+  /**
+   * Sets The title of the notification.
+   *
+   * @param title The title of the notification.
+   * @return The component itself.
+   */
+  public DesktopNotification setTitle(String title) {
+    Objects.requireNonNull(title, "The title can not be null");
+    this.title = title;
+    return this;
+  }
+
+  /**
+   * Gets The title of the notification.
+   *
+   * @return The title of the notification.
+   */
+  public String getTitle() {
+    return title;
+  }
+
+  /**
+   * Sets The body of the notification.
+   *
+   * @param body The body of the notification.
+   * @return The component itself.
+   */
+  public DesktopNotification setBody(String body) {
+    Objects.requireNonNull(body, "The body can not be null");
+    this.body = body;
+    return this;
+  }
+
+  /**
+   * Gets The body of the notification.
+   *
+   * @return The body of the notification.
+   */
+  public String getBody() {
+    return body;
+  }
+
+  /**
+   * Sets The icon of the notification.
+   *
+   * @param icon The icon of the notification.
+   * @return The component itself.
+   */
+  public DesktopNotification setIcon(String icon) {
+    Objects.requireNonNull(icon, "The icon can not be null");
+    this.icon = icon;
+    return this;
+  }
+
+  /**
+   * Gets The icon of the notification.
+   *
+   * @return The icon of the notification.
+   */
+  public String getIcon() {
+    return icon;
+  }
+
+  /**
+   * Opens the notification.
+   *
+   * @return The component itself.
+   */
+  public DesktopNotification open() {
+    // @formatter:off
+    String scriptTemplate = """
+      var __isMobileOrTablet__ = /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
+                                .test(navigator.userAgent);
+      if(('Notification' in window) && !__isMobileOrTablet__) {
+        (async () => {
+          const show = () => {
+            const n = new Notification('%s', {body: `%s`,icon: `%s`, tag: '%4$s'});
+            n.onshow = () => window.dispatchEvent(new CustomEvent('%4$s-opened'));
+            n.onclose = () => window.dispatchEvent(new CustomEvent('%4$s-closed'));
+            n.onerror = () =>  window.dispatchEvent(new CustomEvent('%4$s-errored'));
+            n.onclick = () => window.dispatchEvent(new CustomEvent('%4$s-clicked'));
+            window.__desktop__notifications = window.__desktop__notifications || {};
+            window.__desktop__notifications['%4$s'] = n;
+          };
+          let granted = false;
+          if (Notification.permission === 'granted') {
+            granted = true;
+          } else if (Notification.permission !== 'denied') {
+            let permission = await Notification.requestPermission();
+            granted = permission === 'granted' ? true : false;
+          }
+          if(granted) show();
+        })()
+      }""";
+    // @formatter:on
+
+    Page.ifPresent(page -> {
+      String script = String.format(scriptTemplate, getTitle(), getBody(),
+          Assets.resolveImageSource(getIcon()), id);
+      page.executeJsVoidAsync(script);
+    });
+
+    return this;
+  }
+
+
+  /**
+   * Closes the notification.
+   *
+   * @return The component itself.
+   */
+  public DesktopNotification close() {
+    // @formatter:off
+    String scriptTemplate = """
+    if(window.__desktop__notifications && window.__desktop__notifications['%1$s']) {
+      window.__desktop__notifications['%1$s'].close();
+    }""";
+    // @formatter:on
+
+    Page.ifPresent(page -> {
+      String script = String.format(scriptTemplate, id);
+      page.executeJsVoidAsync(script);
+    });
+
+    return this;
+  }
+
+  /**
+   * Shows a notification with the given title and body.
+   *
+   * @param title The title of the notification.
+   * @param body The body of the notification.
+   * @param icon The icon of the notification.
+   *
+   * @return The created notification.
+   */
+  public static DesktopNotification show(String title, String body, String icon) {
+    return new DesktopNotification(title, body).setIcon(icon).open();
+  }
+
+  /**
+   * Shows a notification with the given title and body.
+   *
+   * @param title The title of the notification.
+   * @param body The body of the notification.
+   *
+   * @return The created notification.
+   */
+  public static DesktopNotification show(String title, String body) {
+    return new DesktopNotification(title, body).open();
+  }
+
+  /**
+   * Shows a notification with the given body.
+   *
+   * @param body The body of the notification.
+   *
+   * @return The created notification.
+   */
+  public static DesktopNotification show(String body) {
+    return new DesktopNotification(body).open();
+  }
+
+  /**
+   * Adds a listener for the notification open event.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<DesktopNotificationOpenEvent> addOpenListener(
+      EventListener<DesktopNotificationOpenEvent> listener) {
+
+    if (!openListenerRegistered) {
+      Page.ifPresent(page -> {
+        page.addEventListener(id + "-opened", event -> { // NOSONAR
+          eventDispatcher.dispatchEvent(new DesktopNotificationOpenEvent(this));
+        });
+      });
+      openListenerRegistered = true;
+    }
+
+    return eventDispatcher.addListener(DesktopNotificationOpenEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addOpenListener(EventListener)}.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<DesktopNotificationOpenEvent> onOpen(
+      EventListener<DesktopNotificationOpenEvent> listener) {
+    return addOpenListener(listener);
+  }
+
+  /**
+   * Adds a listener for the notification close event.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<DesktopNotificationCloseEvent> addCloseListener(
+      EventListener<DesktopNotificationCloseEvent> listener) {
+
+    if (!closeListenerRegistered) {
+      Page.ifPresent(page -> {
+        page.addEventListener(id + "-closed", event -> { // NOSONAR
+          eventDispatcher.dispatchEvent(new DesktopNotificationCloseEvent(this));
+        });
+      });
+      closeListenerRegistered = true;
+    }
+
+    return eventDispatcher.addListener(DesktopNotificationCloseEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addCloseListener(EventListener)}.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<DesktopNotificationCloseEvent> onClose(
+      EventListener<DesktopNotificationCloseEvent> listener) {
+    return addCloseListener(listener);
+  }
+
+  /**
+   * Adds a listener for the notification error event.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<DesktopNotificationErrorEvent> addErrorListener(
+      EventListener<DesktopNotificationErrorEvent> listener) {
+
+    if (!errorListenerRegistered) {
+      Page.ifPresent(page -> {
+        page.addEventListener(id + "-errored", event -> { // NOSONAR
+          eventDispatcher.dispatchEvent(new DesktopNotificationErrorEvent(this));
+        });
+      });
+      errorListenerRegistered = true;
+    }
+
+    return eventDispatcher.addListener(DesktopNotificationErrorEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addErrorListener(EventListener)}.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<DesktopNotificationErrorEvent> onError(
+      EventListener<DesktopNotificationErrorEvent> listener) {
+    return addErrorListener(listener);
+  }
+
+  /**
+   * Adds a listener for the notification click event.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<DesktopNotificationClickEvent> addClickListener(
+      EventListener<DesktopNotificationClickEvent> listener) {
+
+    if (!clickListenerRegistered) {
+      Page.ifPresent(page -> {
+        page.addEventListener(id + "-clicked", event -> { // NOSONAR
+          eventDispatcher.dispatchEvent(new DesktopNotificationClickEvent(this));
+        });
+      });
+      clickListenerRegistered = true;
+    }
+
+    return eventDispatcher.addListener(DesktopNotificationClickEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addClickListener(EventListener)}.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<DesktopNotificationClickEvent> onClick(
+      EventListener<DesktopNotificationClickEvent> listener) {
+    return addClickListener(listener);
+  }
+}

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationClickEvent.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationClickEvent.java
@@ -1,0 +1,21 @@
+package com.webforj.component.desktopnotification.event;
+
+import com.webforj.component.desktopnotification.DesktopNotification;
+
+/**
+ * The event which is triggered when the notification is clicked.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.00
+ */
+public class DesktopNotificationClickEvent extends DesktopNotificationEvent {
+
+  /**
+   * Constructs a new DesktopNotificationClickEvent.
+   *
+   * @param source the component which triggered the event.
+   */
+  public DesktopNotificationClickEvent(DesktopNotification source) {
+    super(source);
+  }
+}

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationCloseEvent.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationCloseEvent.java
@@ -1,0 +1,21 @@
+package com.webforj.component.desktopnotification.event;
+
+import com.webforj.component.desktopnotification.DesktopNotification;
+
+/**
+ * The event which is triggered when the notification is closed.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.00
+ */
+public class DesktopNotificationCloseEvent extends DesktopNotificationEvent {
+
+  /**
+   * Constructs a new DesktopNotificationCloseEvent.
+   *
+   * @param source the component which triggered the event.
+   */
+  public DesktopNotificationCloseEvent(DesktopNotification source) {
+    super(source);
+  }
+}

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationErrorEvent.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationErrorEvent.java
@@ -1,0 +1,21 @@
+package com.webforj.component.desktopnotification.event;
+
+import com.webforj.component.desktopnotification.DesktopNotification;
+
+/**
+ * The event which is triggered when the notification is errored.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.00
+ */
+public class DesktopNotificationErrorEvent extends DesktopNotificationEvent {
+
+  /**
+   * Constructs a new DesktopNotificationErrorEvent.
+   *
+   * @param source the component which triggered the event.
+   */
+  public DesktopNotificationErrorEvent(DesktopNotification source) {
+    super(source);
+  }
+}

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationEvent.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationEvent.java
@@ -1,0 +1,41 @@
+package com.webforj.component.desktopnotification.event;
+
+import com.webforj.component.desktopnotification.DesktopNotification;
+import java.util.EventObject;
+
+/**
+ * The base class for all DesktopNotification events.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.00
+ */
+public class DesktopNotificationEvent extends EventObject {
+
+  /**
+   * Constructs a new DesktopNotificationEvent.
+   *
+   * @param source the component which triggered the event.
+   */
+  public DesktopNotificationEvent(DesktopNotification source) {
+    super(source);
+  }
+
+  /**
+   * Gets the component which triggered the event.
+   *
+   * @return the component which triggered the event.
+   */
+  public DesktopNotification getComponent() {
+    return getSource();
+  }
+
+  /**
+   * Gets the source of the event.
+   *
+   * @return the source of the event.
+   */
+  @Override
+  public DesktopNotification getSource() {
+    return (DesktopNotification) super.getSource();
+  }
+}

--- a/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationOpenEvent.java
+++ b/webforj-components/webforj-desktop-notification/src/main/java/com/webforj/component/desktopnotification/event/DesktopNotificationOpenEvent.java
@@ -1,0 +1,21 @@
+package com.webforj.component.desktopnotification.event;
+
+import com.webforj.component.desktopnotification.DesktopNotification;
+
+/**
+ * The event which is triggered when the notification is opened.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.00
+ */
+public class DesktopNotificationOpenEvent extends DesktopNotificationEvent {
+
+  /**
+   * Constructs a new DesktopNotificationOpenEvent.
+   *
+   * @param source the component which triggered the event.
+   */
+  public DesktopNotificationOpenEvent(DesktopNotification source) {
+    super(source);
+  }
+}

--- a/webforj-components/webforj-desktop-notification/src/test/java/com/webforj/component/desktopnotification/DesktopNotificationTest.java
+++ b/webforj-components/webforj-desktop-notification/src/test/java/com/webforj/component/desktopnotification/DesktopNotificationTest.java
@@ -1,0 +1,167 @@
+package com.webforj.component.desktopnotification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import com.webforj.Page;
+import com.webforj.component.desktopnotification.event.DesktopNotificationClickEvent;
+import com.webforj.component.desktopnotification.event.DesktopNotificationCloseEvent;
+import com.webforj.component.desktopnotification.event.DesktopNotificationErrorEvent;
+import com.webforj.component.desktopnotification.event.DesktopNotificationOpenEvent;
+import com.webforj.dispatcher.ListenerRegistration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class DesktopNotificationTest {
+
+  private DesktopNotification notification;
+  private static MockedStatic<Page> mockedPage;
+
+  @BeforeAll
+  static void setup() {
+    mockedPage = mockStatic(Page.class);
+  }
+
+  @AfterAll
+  static void teardown() {
+    mockedPage.close();
+  }
+
+  @BeforeEach
+  void setUp() {
+    notification = new DesktopNotification("Test Title", "Test Body");
+    mockedPage.when(Page::getCurrent).thenReturn(mock(Page.class));
+  }
+
+  @Test
+  void shouldSetTitle() {
+    String title = "New Title";
+    notification.setTitle(title);
+    assertEquals(title, notification.getTitle());
+  }
+
+  @Test
+  void shouldSetBody() {
+    String body = "New Body";
+    notification.setBody(body);
+    assertEquals(body, notification.getBody());
+  }
+
+  @Test
+  void shouldSetIcon() {
+    String icon = "icons://new-icon.png";
+    notification.setIcon(icon);
+    assertEquals(icon, notification.getIcon());
+  }
+
+  @Nested
+  class ShowNotification {
+    @Test
+    void shouldShowNotificationWithBody() {
+      String body = "Body";
+      DesktopNotification result = DesktopNotification.show(body);
+      assertNotNull(result);
+      assertEquals(body, result.getBody());
+    }
+
+    @Test
+    void shouldShowNotificationWithBodyAndErrorListener() {
+      String body = "Body";
+      DesktopNotification result = DesktopNotification.show(body, event -> {
+      });
+      assertNotNull(result);
+      assertEquals(body, result.getBody());
+      assertTrue(result.getEventDispatcher().getCount(DesktopNotificationErrorEvent.class) > 0);
+    }
+
+    @Test
+    void shouldShowNotificationWithTitleBody() {
+      String title = "Title";
+      String body = "Body";
+      DesktopNotification result = DesktopNotification.show(title, body);
+      assertNotNull(result);
+      assertEquals(title, result.getTitle());
+      assertEquals(body, result.getBody());
+    }
+
+    @Test
+    void shouldShowNotificationWithTitleBodyAndErrorListener() {
+      String title = "Title";
+      String body = "Body";
+      DesktopNotification result = DesktopNotification.show(title, body, event -> {
+      });
+      assertNotNull(result);
+      assertEquals(title, result.getTitle());
+      assertEquals(body, result.getBody());
+      assertTrue(result.getEventDispatcher().getCount(DesktopNotificationErrorEvent.class) > 0);
+    }
+
+    @Test
+    void shouldShowNotificationWithTitleBodyIcon() {
+      String title = "Title";
+      String body = "Body";
+      String icon = "icons://icon.png";
+      DesktopNotification result = DesktopNotification.show(title, body, icon);
+      assertNotNull(result);
+      assertEquals(title, result.getTitle());
+      assertEquals(body, result.getBody());
+      assertEquals(icon, result.getIcon());
+    }
+
+    @Test
+    void shouldShowNotificationWithTitleBodyIconAndErrorListener() {
+      String title = "Title";
+      String body = "Body";
+      String icon = "icons://icon.png";
+      DesktopNotification result = DesktopNotification.show(title, body, icon, event -> {
+      });
+      assertNotNull(result);
+      assertEquals(title, result.getTitle());
+      assertEquals(body, result.getBody());
+      assertEquals(icon, result.getIcon());
+      assertTrue(result.getEventDispatcher().getCount(DesktopNotificationErrorEvent.class) > 0);
+    }
+  }
+
+  @Nested
+  class Listeners {
+    @Test
+    void shouldAddOpenListener() {
+      ListenerRegistration<DesktopNotificationOpenEvent> registration =
+          notification.addOpenListener(event -> {
+          });
+      assertNotNull(registration);
+    }
+
+    @Test
+    void shouldAddCloseListener() {
+      ListenerRegistration<DesktopNotificationCloseEvent> registration =
+          notification.addCloseListener(event -> {
+          });
+      assertNotNull(registration);
+    }
+
+    @Test
+    void shouldAddErrorListener() {
+      ListenerRegistration<DesktopNotificationErrorEvent> registration =
+          notification.addErrorListener(event -> {
+          });
+      assertNotNull(registration);
+    }
+
+    @Test
+    void shouldAddClickListener() {
+      ListenerRegistration<DesktopNotificationClickEvent> registration =
+          notification.addClickListener(event -> {
+          });
+      assertNotNull(registration);
+    }
+  }
+}

--- a/webforj-report-aggregate/pom.xml
+++ b/webforj-report-aggregate/pom.xml
@@ -70,6 +70,11 @@
     </dependency>
     <dependency>
       <groupId>com.webforj</groupId>
+      <artifactId>webforj-desktop-notification</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webforj</groupId>
       <artifactId>webforj-dialog</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/webforj/pom.xml
+++ b/webforj/pom.xml
@@ -52,6 +52,10 @@
     </dependency>
     <dependency>
       <groupId>com.webforj</groupId>
+      <artifactId>webforj-desktop-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.webforj</groupId>
       <artifactId>webforj-dialog</artifactId>
     </dependency>
     <dependency>

--- a/webforj/pom.xml
+++ b/webforj/pom.xml
@@ -52,10 +52,6 @@
     </dependency>
     <dependency>
       <groupId>com.webforj</groupId>
-      <artifactId>webforj-desktop-notification</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.webforj</groupId>
       <artifactId>webforj-dialog</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
The Notification component is used to configure and display **Native** desktop notifications to the user.

https://github.com/user-attachments/assets/4658f593-3d71-42c5-953c-f15583e062b9

