### PR TITLE
feat: add support for customizable table borders and striped rows

### DIFF
--- a/webforj-components/webforj-table/src/main/java/com/webforj/component/table/Table.java
+++ b/webforj-components/webforj-table/src/main/java/com/webforj/component/table/Table.java
@@ -954,7 +954,7 @@ public final class Table<T> extends HtmlComponent<Table<T>> implements HasReposi
    * @param value A set of borders to be drawn.
    * @return the component itself
    */
-  public Table<T> setVisibleBorders(Set<Border> value) {
+  public Table<T> setBordersVisible(Set<Border> value) {
     this.visibleBorders = value;
     set(border, value.contains(Border.AROUND));
     set(columnsBorder, value.contains(Border.COLUMNS));
@@ -968,7 +968,7 @@ public final class Table<T> extends HtmlComponent<Table<T>> implements HasReposi
    *
    * @return A set of borders to be drawn.
    */
-  public Set<Border> getVisibleBorders() {
+  public Set<Border> getBordersVisible() {
     return visibleBorders;
   }
 

--- a/webforj-components/webforj-table/src/main/java/com/webforj/component/table/Table.java
+++ b/webforj-components/webforj-table/src/main/java/com/webforj/component/table/Table.java
@@ -973,7 +973,7 @@ public final class Table<T> extends HtmlComponent<Table<T>> implements HasReposi
   }
 
   /**
-   * Sets Wether a background is provided for every other row.
+   * Sets Whether a background is provided for every other row.
    *
    * <p>
    * The striped property is used to apply a background color to every other row in the table,

--- a/webforj-components/webforj-table/src/test/java/com/webforj/component/table/TableTest.java
+++ b/webforj-components/webforj-table/src/test/java/com/webforj/component/table/TableTest.java
@@ -64,14 +64,14 @@ class TableTest {
     @Test
     void shouldSetGetBorders() {
       var borders = EnumSet.of(Table.Border.AROUND, Table.Border.ROWS, Table.Border.COLUMNS);
-      component.setVisibleBorders(borders);
+      component.setBordersVisible(borders);
 
-      assertEquals(borders, component.getVisibleBorders());
+      assertEquals(borders, component.getBordersVisible());
       assertTrue(component.getProperty("border", Boolean.class));
       assertTrue(component.getProperty("columnsBorder", Boolean.class));
       assertTrue(component.getProperty("rowsBorder", Boolean.class));
 
-      component.setVisibleBorders(EnumSet.noneOf(Table.Border.class));
+      component.setBordersVisible(EnumSet.noneOf(Table.Border.class));
 
       assertFalse(component.getProperty("border", Boolean.class));
       assertFalse(component.getProperty("columnsBorder", Boolean.class));

--- a/webforj-components/webforj-table/src/test/java/com/webforj/component/table/TableTest.java
+++ b/webforj-components/webforj-table/src/test/java/com/webforj/component/table/TableTest.java
@@ -26,6 +26,7 @@ import com.webforj.component.table.renderer.Renderer;
 import com.webforj.data.HasEntityKey;
 import com.webforj.dispatcher.EventListener;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -46,15 +47,35 @@ class TableTest {
     component = new Table<>();
   }
 
-  @Test
-  void shouldSetGetProperties() {
-    try {
-      PropertyDescriptorTester.run(Table.class, component, descriptor -> {
-        return !Arrays.asList("columnDefinitions", "data", "getRowId", "selected")
-            .contains(descriptor.getName());
-      });
-    } catch (Exception e) {
-      fail("PropertyDescriptor test failed: " + e.getMessage());
+  @Nested
+  class Properties {
+    @Test
+    void shouldSetGetProperties() {
+      try {
+        PropertyDescriptorTester.run(Table.class, component, descriptor -> {
+          return !Arrays.asList("columnDefinitions", "data", "getRowId", "selected")
+              .contains(descriptor.getName());
+        });
+      } catch (Exception e) {
+        fail("PropertyDescriptor test failed: " + e.getMessage());
+      }
+    }
+
+    @Test
+    void shouldSetGetBorders() {
+      var borders = EnumSet.of(Table.Border.AROUND, Table.Border.ROWS, Table.Border.COLUMNS);
+      component.setVisibleBorders(borders);
+
+      assertEquals(borders, component.getVisibleBorders());
+      assertTrue(component.getProperty("border", Boolean.class));
+      assertTrue(component.getProperty("columnsBorder", Boolean.class));
+      assertTrue(component.getProperty("rowsBorder", Boolean.class));
+
+      component.setVisibleBorders(EnumSet.noneOf(Table.Border.class));
+
+      assertFalse(component.getProperty("border", Boolean.class));
+      assertFalse(component.getProperty("columnsBorder", Boolean.class));
+      assertFalse(component.getProperty("rowsBorder", Boolean.class));
     }
   }
 


### PR DESCRIPTION
Add new table methods to simplify styling: 

1. **setBordersVisible** :  Sets the visible borders of the table. The visible borders are the borders that are drawn around the table and between the rows and columns. The default value is `Border.ROWS` and `Border.AROUND`.

```java
 // enable all borders
  table.setBordersVisible(EnumSet.of(Table.Border.AROUND, Table.Border.COLUMNS, Table.Border.ROWS));
  // no borders
  table.setBordersVisible(EnumSet.noneOf(Table.Border.class));
```

2. **setStriped**:  The striped property is used to apply a background color to every other row in the table, creating a striped effect. This can improve readability by making it easier to distinguish  between adjacent rows of data.

```java
table.setStriped(true);
```
