### PR TITLE
feat: add App lifecycle listener support

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/App.java
+++ b/webforj-foundation/src/main/java/com/webforj/App.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 /**
@@ -141,7 +142,7 @@ public abstract class App {
    */
   public static final AppCloseAction NONE_ACTION = new NoneAction();
 
-  private static int appCounter = 0;
+  private static final AtomicInteger appCounter = new AtomicInteger(0);
   private final String appId;
   private boolean isInitialized = false;
 
@@ -149,7 +150,7 @@ public abstract class App {
    * Creates a new App instance with a unique ID.
    */
   protected App() {
-    this.appId = String.format("%s-%d", getClass().getSimpleName(), ++appCounter);
+    this.appId = String.format("%s-%d", getClass().getSimpleName(), appCounter.incrementAndGet());
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/App.java
+++ b/webforj-foundation/src/main/java/com/webforj/App.java
@@ -496,14 +496,14 @@ public abstract class App {
       frame.destroy();
     }
 
-    Environment.getCurrent().getBBjAPI().postPriorityCustomEvent("webforjTerminateSignal", null);
-
     // Notify listeners after termination but before onDidTerminate hook
     notifyListeners(listener -> listener.onDidTerminate(this));
     onDidTerminate();
 
     // Clean up listeners
     AppLifecycleListenerRegistry.unregisterListeners(this);
+
+    Environment.getCurrent().getBBjAPI().postPriorityCustomEvent("webforjTerminateSignal", null);
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/App.java
+++ b/webforj-foundation/src/main/java/com/webforj/App.java
@@ -199,9 +199,9 @@ public abstract class App {
       initializeRouter();
       initializeLifecycleListeners();
 
-      // Notify listeners before onWillRun
-      notifyListeners(listener -> listener.onWillRun(this));
+      // Notify listeners after onWillRun
       onWillRun();
+      notifyListeners(listener -> listener.onWillRun(this));
 
       AnnotationProcessor processor = new AnnotationProcessor();
       processor.processAppAnnotations(this);

--- a/webforj-foundation/src/main/java/com/webforj/App.java
+++ b/webforj-foundation/src/main/java/com/webforj/App.java
@@ -472,9 +472,10 @@ public abstract class App {
   public final void terminate() {
     logger.log(Logger.Level.INFO, String.format("Terminating %s", appId));
 
-    // Notify listeners before onWillTerminate
-    notifyListeners(listener -> listener.onWillTerminate(this));
+    // Invoke onWillTerminate hook
     onWillTerminate();
+    // Notify listeners after onWillTerminate
+    notifyListeners(listener -> listener.onWillTerminate(this));
 
     // dispose the page
     Page page = Page.getCurrent();

--- a/webforj-foundation/src/main/java/com/webforj/AppLifecycleListener.java
+++ b/webforj-foundation/src/main/java/com/webforj/AppLifecycleListener.java
@@ -1,0 +1,101 @@
+package com.webforj;
+
+/**
+ * Listener interface for App lifecycle events.
+ *
+ * <p>
+ * Implementations of this interface will be automatically discovered and notified of key lifecycle
+ * events during the execution of a webforj {@link App}. To control the order of listener execution,
+ * annotate your implementation class with {@link com.webforj.annotation.AppListenerPriority}.
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>{@code
+ * &#64;AppListenerPriority(5)
+ * public class MyLifecycleListener implements AppLifecycleListener {
+ *
+ *   &#64;Override
+ *   public void onWillRun(App app) {
+ *     // Called before app.run()
+ *   }
+ *
+ *   &#64;Override
+ *   public void onDidRun(App app) {
+ *     // Called after app.run()
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>
+ * All methods in this interface have default empty implementations, allowing implementations to
+ * only override the methods they are interested in.
+ * </p>
+ *
+ * @see com.webforj.annotation.AppListenerPriority
+ * @see App
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.02
+ */
+public interface AppLifecycleListener {
+
+  /**
+   * Called before the app's {@code run()} method is invoked.
+   *
+   * <p>
+   * This method is called after the app has been initialized but before the main application logic
+   * in {@code run()} is executed.
+   * </p>
+   *
+   * @param app the app instance that is about to run
+   */
+  default void onWillRun(App app) {
+    // Default empty implementation
+  }
+
+  /**
+   * Called after the app's {@code run()} method completes successfully.
+   *
+   * <p>
+   * This method is called after the app's {@code run()} method has completed without throwing an
+   * exception.
+   * </p>
+   *
+   * @param app the app instance that has finished running
+   */
+  default void onDidRun(App app) {
+    // Default empty implementation
+  }
+
+  /**
+   * Called before the app is terminated.
+   *
+   * <p>
+   * This method is called when the app is about to be terminated, either due to normal completion
+   * or an error condition. It provides an opportunity to perform cleanup operations before the app
+   * shuts down.
+   * </p>
+   *
+   * @param app the app instance that is about to terminate
+   */
+  default void onWillTerminate(App app) {
+    // Default empty implementation
+  }
+
+  /**
+   * Called after the app is terminated.
+   *
+   * <p>
+   * This method is called after the app has been terminated. At this point, app resources may no
+   * longer be available, so this method should only perform minimal cleanup or logging operations.
+   * </p>
+   *
+   * @param app the app instance that has been terminated
+   */
+  default void onDidTerminate(App app) {
+    // Default empty implementation
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/AppLifecycleListenerRegistry.java
+++ b/webforj-foundation/src/main/java/com/webforj/AppLifecycleListenerRegistry.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Hyyan Abo Fakher
  * @since 25.02
  */
-public final class AppLifecycleListenerRegistry {
+final class AppLifecycleListenerRegistry {
   private static final Logger logger =
       System.getLogger(AppLifecycleListenerRegistry.class.getName());
 
@@ -56,7 +56,7 @@ public final class AppLifecycleListenerRegistry {
    *
    * @param app the App instance to register listeners for
    */
-  public static void registerListeners(App app) {
+  static void registerListeners(App app) {
     if (app == null) {
       return;
     }
@@ -102,7 +102,7 @@ public final class AppLifecycleListenerRegistry {
    * @param app the App instance
    * @return a collection of listeners, or an empty collection if none are registered
    */
-  public static Collection<AppLifecycleListener> getListeners(App app) {
+  static Collection<AppLifecycleListener> getListeners(App app) {
     if (app == null) {
       return Collections.emptyList();
     }
@@ -119,7 +119,7 @@ public final class AppLifecycleListenerRegistry {
    *
    * @param app the App instance to unregister listeners for
    */
-  public static void unregisterListeners(App app) {
+  static void unregisterListeners(App app) {
     List<AppLifecycleListener> removed = appListeners.remove(app);
     if (removed != null && !removed.isEmpty()) {
       logger.log(Level.INFO,

--- a/webforj-foundation/src/main/java/com/webforj/AppLifecycleListenerRegistry.java
+++ b/webforj-foundation/src/main/java/com/webforj/AppLifecycleListenerRegistry.java
@@ -1,0 +1,142 @@
+package com.webforj;
+
+import com.webforj.annotation.AppListenerPriority;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry for App lifecycle listeners using Java ServiceLoader mechanism.
+ *
+ * <p>
+ * This class manages the discovery and lifecycle of {@link AppLifecycleListener} implementations
+ * using the standard Java {@link ServiceLoader} mechanism. Each App instance gets its own set of
+ * listener instances to ensure proper isolation.
+ * </p>
+ *
+ * <p>
+ * To register a listener, implementations must:
+ * <ol>
+ * <li>Implement the {@link AppLifecycleListener} interface</li>
+ * <li>Be listed in {@code META-INF/services/com.webforj.AppLifecycleListener}</li>
+ * <li>Optionally use {@link AppListenerPriority} annotation to control execution order</li>
+ * </ol>
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.02
+ */
+public final class AppLifecycleListenerRegistry {
+  private static final Logger logger =
+      System.getLogger(AppLifecycleListenerRegistry.class.getName());
+
+  // Track which App instances have which listeners
+  private static final Map<App, List<AppLifecycleListener>> appListeners =
+      new ConcurrentHashMap<>();
+
+  private AppLifecycleListenerRegistry() {
+    // Prevent instantiation
+  }
+
+  /**
+   * Discovers and registers lifecycle listeners for the given App.
+   *
+   * <p>
+   * This method uses the {@link ServiceLoader} mechanism to discover implementations of
+   * {@link AppLifecycleListener}, instantiates them, and associates them with the given App
+   * instance.
+   * </p>
+   *
+   * @param app the App instance to register listeners for
+   */
+  public static void registerListeners(App app) {
+    if (app == null) {
+      return;
+    }
+
+    List<ListenerEntry> entries = new ArrayList<>();
+
+    // Use ServiceLoader to discover listener implementations
+    ServiceLoader<AppLifecycleListener> loader = ServiceLoader.load(AppLifecycleListener.class);
+
+    for (AppLifecycleListener listener : loader) {
+      // Check for priority annotation
+      int priority = 10; // default priority
+      AppListenerPriority priorityAnnotation =
+          listener.getClass().getAnnotation(AppListenerPriority.class);
+      if (priorityAnnotation != null) {
+        priority = priorityAnnotation.value();
+      }
+
+      entries.add(new ListenerEntry(listener, priority));
+      logger.log(Level.DEBUG, String.format("Discovered lifecycle listener: %s [Priority: %d]",
+          listener.getClass().getName(), priority));
+    }
+
+    // Sort by priority (lower values first)
+    entries.sort(Comparator.comparingInt(e -> e.priority));
+
+    // Extract sorted listeners
+    List<AppLifecycleListener> sortedListeners = new ArrayList<>();
+    for (ListenerEntry entry : entries) {
+      sortedListeners.add(entry.listener);
+    }
+
+    if (!sortedListeners.isEmpty()) {
+      appListeners.put(app, sortedListeners);
+      logger.log(Level.INFO, String.format("Registered %d lifecycle listeners for %s",
+          sortedListeners.size(), app.getId()));
+    }
+  }
+
+  /**
+   * Gets the lifecycle listeners associated with the given App instance.
+   *
+   * @param app the App instance
+   * @return a collection of listeners, or an empty collection if none are registered
+   */
+  public static Collection<AppLifecycleListener> getListeners(App app) {
+    if (app == null) {
+      return Collections.emptyList();
+    }
+
+    return appListeners.getOrDefault(app, Collections.emptyList());
+  }
+
+  /**
+   * Removes all listeners associated with the given App instance.
+   *
+   * <p>
+   * This method should be called when an App is terminated to prevent memory leaks.
+   * </p>
+   *
+   * @param app the App instance to unregister listeners for
+   */
+  public static void unregisterListeners(App app) {
+    List<AppLifecycleListener> removed = appListeners.remove(app);
+    if (removed != null && !removed.isEmpty()) {
+      logger.log(Level.INFO,
+          String.format("Unregistered %d lifecycle listeners for %s", removed.size(), app.getId()));
+    }
+  }
+
+  /**
+   * Hold listener with priority for sorting.
+   */
+  private static class ListenerEntry {
+    final AppLifecycleListener listener;
+    final int priority;
+
+    ListenerEntry(AppLifecycleListener listener, int priority) {
+      this.listener = listener;
+      this.priority = priority;
+    }
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/annotation/AppListenerPriority.java
+++ b/webforj-foundation/src/main/java/com/webforj/annotation/AppListenerPriority.java
@@ -1,0 +1,62 @@
+package com.webforj.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies the priority for an {@link com.webforj.AppLifecycleListener} implementation.
+ *
+ * <p>
+ * This annotation is optional and used to control the order in which lifecycle listeners are
+ * invoked. Listeners with lower priority values are invoked before listeners with higher priority
+ * values. If this annotation is not present, a default priority of 10 is used.
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>{@code
+ * &#64;AppListenerPriority(5)
+ * public class HighPriorityListener implements AppLifecycleListener {
+ *   &#64;Override
+ *   public void onDidRun(App app) {
+ *     // This will be called before listeners with higher priority values
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>
+ * Common priority values:
+ * </p>
+ * <ul>
+ * <li>1-9: High priority (framework-level listeners)</li>
+ * <li>10-50: Normal priority (application-level listeners)</li>
+ * <li>50-100: Low priority (logging, metrics, etc.)</li>
+ * </ul>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.02
+ *
+ * @see com.webforj.AppLifecycleListener
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AppListenerPriority {
+
+  /**
+   * The priority value for this listener.
+   *
+   * <p>
+   * Lower values indicate higher priority. The default value is 10 if this annotation is not
+   * present on the listener class.
+   * </p>
+   *
+   * @return the priority value
+   */
+  int value();
+}

--- a/webforj-foundation/src/test/java/com/webforj/AppLifecycleListenerTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/AppLifecycleListenerTest.java
@@ -1,0 +1,206 @@
+package com.webforj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.webforj.annotation.AppListenerPriority;
+import com.webforj.exceptions.WebforjException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class AppLifecycleListenerTest {
+
+  @BeforeAll
+  static void setupLocaleProviders() {
+    // Set locale providers to avoid CLDR issues during testing
+    System.setProperty("java.locale.providers", "COMPAT,SPI");
+  }
+
+  @Test
+  void shouldInvokeListenersInPriorityOrder() {
+    TestApp app = new TestApp();
+
+    // Create listeners with different priorities
+    HighPriorityListener highPriority = new HighPriorityListener();
+    DefaultPriorityListener defaultPriority = new DefaultPriorityListener();
+    LowPriorityListener lowPriority = new LowPriorityListener();
+
+    // Add in random order
+    List<AppLifecycleListener> listeners = new ArrayList<>();
+    listeners.add(lowPriority);
+    listeners.add(highPriority);
+    listeners.add(defaultPriority);
+
+    // Mock ServiceLoader to return our test listeners
+    try (@SuppressWarnings("rawtypes")
+    MockedStatic<ServiceLoader> serviceLoaderMock = mockStatic(ServiceLoader.class)) {
+      @SuppressWarnings("unchecked")
+      ServiceLoader<AppLifecycleListener> mockLoader = mock(ServiceLoader.class);
+      when(mockLoader.iterator()).thenReturn(listeners.iterator());
+      serviceLoaderMock.when(() -> ServiceLoader.load(AppLifecycleListener.class))
+          .thenReturn(mockLoader);
+
+      // Register listeners
+      AppLifecycleListenerRegistry.registerListeners(app);
+
+      // Get registered listeners
+      Collection<AppLifecycleListener> registeredListeners =
+          AppLifecycleListenerRegistry.getListeners(app);
+
+      // Verify count
+      assertEquals(3, registeredListeners.size());
+
+      // Verify order (should be sorted by priority: 5, 10, 20)
+      List<AppLifecycleListener> sortedList = new ArrayList<>(registeredListeners);
+      assertTrue(sortedList.get(0) instanceof HighPriorityListener);
+      assertTrue(sortedList.get(1) instanceof DefaultPriorityListener);
+      assertTrue(sortedList.get(2) instanceof LowPriorityListener);
+    }
+  }
+
+  @Test
+  void shouldHandleListenersWithoutPriorityAnnotation() {
+    TestApp app = new TestApp();
+    ListenerWithoutPriority listener = new ListenerWithoutPriority();
+
+    List<AppLifecycleListener> listeners = List.of(listener);
+
+    try (@SuppressWarnings("rawtypes")
+    MockedStatic<ServiceLoader> serviceLoaderMock = mockStatic(ServiceLoader.class)) {
+      @SuppressWarnings("unchecked")
+      ServiceLoader<AppLifecycleListener> mockLoader = mock(ServiceLoader.class);
+      when(mockLoader.iterator()).thenReturn(listeners.iterator());
+      serviceLoaderMock.when(() -> ServiceLoader.load(AppLifecycleListener.class))
+          .thenReturn(mockLoader);
+
+      AppLifecycleListenerRegistry.registerListeners(app);
+
+      Collection<AppLifecycleListener> registeredListeners =
+          AppLifecycleListenerRegistry.getListeners(app);
+
+      assertEquals(1, registeredListeners.size());
+      // Default priority should be applied
+      assertTrue(registeredListeners.contains(listener));
+    }
+  }
+
+  @Test
+  void shouldReturnEmptyCollectionWhenNoListenersRegistered() {
+    TestApp app = new TestApp();
+    Collection<AppLifecycleListener> listeners = AppLifecycleListenerRegistry.getListeners(app);
+
+    assertNotNull(listeners);
+    assertTrue(listeners.isEmpty());
+  }
+
+  @Test
+  void shouldUnregisterListeners() {
+    TestApp app = new TestApp();
+    TestListener listener = new TestListener(10);
+    List<AppLifecycleListener> listeners = List.of(listener);
+
+    try (@SuppressWarnings("rawtypes")
+    MockedStatic<ServiceLoader> serviceLoaderMock = mockStatic(ServiceLoader.class)) {
+      @SuppressWarnings("unchecked")
+      ServiceLoader<AppLifecycleListener> mockLoader = mock(ServiceLoader.class);
+      when(mockLoader.iterator()).thenReturn(listeners.iterator());
+      serviceLoaderMock.when(() -> ServiceLoader.load(AppLifecycleListener.class))
+          .thenReturn(mockLoader);
+
+      // Register listeners
+      AppLifecycleListenerRegistry.registerListeners(app);
+
+      // Verify listener is registered
+      Collection<AppLifecycleListener> registeredListeners =
+          AppLifecycleListenerRegistry.getListeners(app);
+      assertEquals(1, registeredListeners.size());
+
+      // Unregister listeners
+      AppLifecycleListenerRegistry.unregisterListeners(app);
+
+      // Verify no listeners remain
+      Collection<AppLifecycleListener> afterUnregister =
+          AppLifecycleListenerRegistry.getListeners(app);
+      assertTrue(afterUnregister.isEmpty());
+    }
+  }
+
+
+  // Test implementation of App
+  static class TestApp extends App {
+    @Override
+    public void run() throws WebforjException {
+      // Test implementation
+    }
+  }
+
+  // Test listener without priority annotation - uses priority from constructor for testing
+  static class TestListener implements AppLifecycleListener {
+    private final int priority;
+    private final List<String> events = new ArrayList<>();
+
+    TestListener(int expectedPriority) {
+      this.priority = expectedPriority;
+    }
+
+    @Override
+    public void onWillRun(App app) {
+      events.add("onWillRun");
+    }
+
+    @Override
+    public void onDidRun(App app) {
+      events.add("onDidRun");
+    }
+
+    @Override
+    public void onWillTerminate(App app) {
+      events.add("onWillTerminate");
+    }
+
+    @Override
+    public void onDidTerminate(App app) {
+      events.add("onDidTerminate");
+    }
+
+    int getPriority() {
+      return priority;
+    }
+
+    List<String> getEvents() {
+      return events;
+    }
+  }
+
+  // Test listener without priority annotation
+  static class ListenerWithoutPriority implements AppLifecycleListener {
+    // Uses default priority of 10
+  }
+
+  // High priority listener
+  @AppListenerPriority(5)
+  static class HighPriorityListener implements AppLifecycleListener {
+    // Priority 5
+  }
+
+  // Default priority listener
+  @AppListenerPriority(10)
+  static class DefaultPriorityListener implements AppLifecycleListener {
+    // Priority 10
+  }
+
+  // Low priority listener
+  @AppListenerPriority(20)
+  static class LowPriorityListener implements AppLifecycleListener {
+    // Priority 20
+  }
+}


### PR DESCRIPTION
Implement ServiceLoader-based lifecycle listener mechanism for App instances, allowing external components to observe and react to App lifecycle events.

This enables plugins and extensions to hook into the App lifecycle without modifying core App code, using standard Java ServiceLoader mechanism.

Listeners are called outside of App hook methods (before onDidRun/onDidTerminate, after onWillRun/onWillTerminate) to ensure backward compatibility.