### PR TITLE
feat: Allow to configure webforj using spring properties file

### DIFF
--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringAutoConfiguration.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringAutoConfiguration.java
@@ -1,5 +1,6 @@
 package com.webforj.spring;
 
+import com.typesafe.config.Config;
 import com.webforj.servlet.WebforjServlet;
 import java.lang.System.Logger;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -25,6 +26,19 @@ public class SpringAutoConfiguration {
   private static Logger logger = System.getLogger(SpringAutoConfiguration.class.getName());
 
   /**
+   * Creates the webforJ configuration from Spring properties.
+   *
+   * @param properties the Spring configuration properties
+   * @return the webforJ configuration
+   */
+  @Bean(name = "webforjConfig")
+  Config webforjConfig(SpringConfigurationProperties properties) {
+    Config config = WebforjConfigBuilder.buildConfig(properties);
+    logger.log(Logger.Level.DEBUG, "Built webforJ configuration from Spring properties");
+    return config;
+  }
+
+  /**
    * Registers the {@link WebforjServlet}.
    *
    * <p>
@@ -35,10 +49,14 @@ public class SpringAutoConfiguration {
    * @return the {@link ServletRegistrationBean} for the {@link WebforjServlet}
    */
   @Bean
-  public ServletRegistrationBean<WebforjServlet> webforjServletRegistration(
-      SpringConfigurationProperties properties) {
+  ServletRegistrationBean<WebforjServlet> webforjServletRegistration(
+      SpringConfigurationProperties properties, Config webforjConfig) {
     logger.log(Logger.Level.DEBUG,
         "Registering WebforjServlet with mapping " + properties.getServletMapping());
+
+    // Set the configuration for the servlet
+    WebforjServlet.setConfig(webforjConfig);
+    logger.log(Logger.Level.DEBUG, "Set webforj configuration for servlet");
 
     WebforjServlet webforjServlet = new WebforjServlet();
 
@@ -69,7 +87,7 @@ public class SpringAutoConfiguration {
    * @return the {@link ComponentRegistrar}
    */
   @Bean
-  public static ComponentRegistrar webforjComponentRegistrar() {
+  static ComponentRegistrar webforjComponentRegistrar() {
     return new ComponentRegistrar();
   }
 
@@ -79,7 +97,7 @@ public class SpringAutoConfiguration {
    * @return the {@link ContextInjector}
    */
   @Bean
-  public ContextInjector webforjContextInjector() {
+  ContextInjector webforjContextInjector() {
     return new ContextInjector();
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigMerger.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigMerger.java
@@ -1,0 +1,40 @@
+package com.webforj.spring;
+
+import com.typesafe.config.Config;
+import com.webforj.AppLifecycleListener;
+import com.webforj.Environment;
+import com.webforj.annotation.AppListenerPriority;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Merges Spring Boot configuration into the webforJ environment during application initialization.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+@AppListenerPriority(0)
+public class SpringConfigMerger implements AppLifecycleListener {
+  private static final Logger logger = System.getLogger(SpringConfigMerger.class.getName());
+
+  @Override
+  public void onWillCreate(Environment env) {
+    ApplicationContext context = ContextHolder.getContext();
+
+    if (context != null) {
+      try {
+        // Get the specific webforJ config bean by name
+        Config springConfig = context.getBean("webforjConfig", Config.class);
+
+        logger.log(Level.INFO, "Merging Spring configuration into webforJ environment");
+        env.setConfig(springConfig);
+        logger.log(Level.DEBUG, "Spring configuration successfully merged");
+      } catch (Exception e) {
+        logger.log(Level.DEBUG, "No webforjConfig bean found in Spring context", e);
+      }
+    } else {
+      logger.log(Level.DEBUG, "No Spring ApplicationContext available");
+    }
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
@@ -168,6 +168,17 @@ public class SpringConfigurationProperties {
   private FileUpload fileUpload = new FileUpload();
 
   /**
+   * Servlet configurations for user-provided servlets.
+   *
+   * <p>
+   * Configure additional servlets that will be managed by webforJ. Each servlet can have its own
+   * class, name, and initialization parameters.
+   * </p>
+   */
+  private List<ServletConfig> servlets = new ArrayList<>();
+
+
+  /**
    * Sets the URL mapping for the Webforj servlet.
    *
    * @param servletMapping the URL mapping for the Webforj servlet
@@ -420,6 +431,25 @@ public class SpringConfigurationProperties {
   }
 
   /**
+   * Gets the servlet configurations.
+   *
+   * @return the list of servlet configurations
+   */
+  public List<ServletConfig> getServlets() {
+    return servlets;
+  }
+
+  /**
+   * Sets the servlet configurations.
+   *
+   * @param servlets the list of servlet configurations
+   */
+  public void setServlets(List<ServletConfig> servlets) {
+    this.servlets = servlets;
+  }
+
+
+  /**
    * File upload configuration properties.
    */
   public static class FileUpload {
@@ -486,6 +516,80 @@ public class SpringConfigurationProperties {
      */
     public void setMaxSize(Long maxSize) {
       this.maxSize = maxSize;
+    }
+  }
+
+  /**
+   * Servlet configuration properties.
+   */
+  public static class ServletConfig {
+    /**
+     * The fully qualified class name of the servlet.
+     */
+    private String className;
+
+    /**
+     * The name of the servlet. If not specified, the class name will be used.
+     */
+    private String name;
+
+    /**
+     * Initialization parameters for the servlet.
+     */
+    private Map<String, String> config = new HashMap<>();
+
+    /**
+     * Gets the servlet class name.
+     *
+     * @return the fully qualified class name
+     */
+    public String getClassName() {
+      return className;
+    }
+
+    /**
+     * Sets the servlet class name.
+     *
+     * @param className the fully qualified class name
+     */
+    public void setClassName(String className) {
+      this.className = className;
+    }
+
+    /**
+     * Gets the servlet name.
+     *
+     * @return the servlet name
+     */
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * Sets the servlet name.
+     *
+     * @param name the servlet name
+     */
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    /**
+     * Gets the servlet initialization parameters.
+     *
+     * @return the initialization parameters map
+     */
+    public Map<String, String> getConfig() {
+      return config;
+    }
+
+    /**
+     * Sets the servlet initialization parameters.
+     *
+     * @param config the initialization parameters map
+     */
+    public void setConfig(Map<String, String> config) {
+      this.config = config;
     }
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
@@ -77,17 +77,46 @@ public class SpringConfigurationProperties {
   private String locale;
 
   /**
-   * String table for application strings.
+   * Controls whether to display the loading image.
    *
    * <p>
-   * The string table is a map of key-value pairs that can be used to store strings for use in the
-   * application.
+   * Set to {@code true} to disable the loading image during application startup.
    * </p>
-   *
-   * @see <a href=
-   *      "https://docs.webforj.com/docs/advanced/object-string-tables#stringtable">StringTable</a>
    */
-  private Map<String, String> stringTable = new HashMap<>();
+  private Boolean quiet;
+
+  /**
+   * When using hot redeploy, the whole WAR file will be swapped.
+   *
+   * <p>
+   * If the client tries to send a request to the server while it is restarting, an error occurs.
+   * This setting allows the client to attempt a page reload if the server is temporarily
+   * unavailable, hoping it will be back online shortly. This only applies to development
+   * environments and only handles errors specific to hot redeployment, not other types of errors.
+   * </p>
+   */
+  private Boolean reloadOnServerError;
+
+  /**
+   * Sets the interval at which the client pings the server to see if it's still alive.
+   *
+   * <p>
+   * This helps maintain communication. For development, set this to a shorter interval, for example
+   * {@code 8s}, to quickly detect server availability. For production environments, it's
+   * recommended to use values of 50 seconds or higher to minimize server load.
+   * </p>
+   */
+  private String clientHeartbeatRate;
+
+  /**
+   * Session timeout in seconds.
+   *
+   * <p>
+   * Sets the session timeout duration in seconds. If not specified, defaults to 60 seconds. This
+   * controls how long a session remains active without any client activity before being terminated.
+   * </p>
+   */
+  private Integer sessionTimeout;
 
   /**
    * Specifies the route name used to serve static files.
@@ -141,46 +170,17 @@ public class SpringConfigurationProperties {
   private String iconsDir;
 
   /**
-   * Controls whether to display the loading image.
+   * String table for application strings.
    *
    * <p>
-   * Set to {@code true} to disable the loading image during application startup.
+   * The string table is a map of key-value pairs that can be used to store strings for use in the
+   * application.
    * </p>
-   */
-  private Boolean quiet;
-
-  /**
-   * When using hot redeploy, the whole WAR file will be swapped.
    *
-   * <p>
-   * If the client tries to send a request to the server while it is restarting, an error occurs.
-   * This setting allows the client to attempt a page reload if the server is temporarily
-   * unavailable, hoping it will be back online shortly. This only applies to development
-   * environments and only handles errors specific to hot redeployment, not other types of errors.
-   * </p>
+   * @see <a href=
+   *      "https://docs.webforj.com/docs/advanced/object-string-tables#stringtable">StringTable</a>
    */
-  private Boolean reloadOnServerError;
-
-  /**
-   * Sets the interval at which the client pings the server to see if it's still alive.
-   *
-   * <p>
-   * This helps maintain communication. For development, set this to a shorter interval, for example
-   * {@code 8s}, to quickly detect server availability. For production environments, it's
-   * recommended to use values of 50 seconds or higher to minimize server load.
-   * </p>
-   */
-  private String clientHeartbeatRate;
-
-  /**
-   * Session timeout in seconds.
-   *
-   * <p>
-   * Sets the session timeout duration in seconds. If not specified, defaults to 60 seconds. This
-   * controls how long a session remains active without any client activity before being terminated.
-   * </p>
-   */
-  private Integer sessionTimeout;
+  private Map<String, String> stringTable = new HashMap<>();
 
   /**
    * File upload configuration.

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
@@ -173,6 +173,16 @@ public class SpringConfigurationProperties {
   private String clientHeartbeatRate;
 
   /**
+   * Session timeout in seconds.
+   *
+   * <p>
+   * Sets the session timeout duration in seconds. If not specified, defaults to 60 seconds. This
+   * controls how long a session remains active without any client activity before being terminated.
+   * </p>
+   */
+  private Integer sessionTimeout;
+
+  /**
    * File upload configuration.
    */
   private FileUpload fileUpload = new FileUpload();
@@ -461,6 +471,24 @@ public class SpringConfigurationProperties {
    */
   public void setIconsDir(String iconsDir) {
     this.iconsDir = iconsDir;
+  }
+
+  /**
+   * Gets the session timeout in seconds.
+   *
+   * @return the session timeout in seconds
+   */
+  public Integer getSessionTimeout() {
+    return sessionTimeout;
+  }
+
+  /**
+   * Sets the session timeout in seconds.
+   *
+   * @param sessionTimeout the session timeout in seconds
+   */
+  public void setSessionTimeout(Integer sessionTimeout) {
+    this.sessionTimeout = sessionTimeout;
   }
 
   /**

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
@@ -1,5 +1,9 @@
 package com.webforj.spring;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -20,6 +24,148 @@ public class SpringConfigurationProperties {
    */
   private String servletMapping = "/*";
 
+  /**
+   * The application's entry point class.
+   *
+   * <p>
+   * Define the application's entry point by specifying the fully qualified name of the class that
+   * extends {@code com.webforj.App}. If no entry point is defined, webforJ will automatically scan
+   * the classpath for classes that extend {@code com.webforj.App}. If multiple classes are found,
+   * an error will occur. When a package includes more than one potential entry point, setting this
+   * explicitly is required to prevent ambiguity, or alternatively, the {@code AppEntry} annotation
+   * can be used to specify the entry point at runtime.
+   * </p>
+   */
+  private String entry;
+
+  /**
+   * Debug mode configuration.
+   *
+   * <p>
+   * Set to true to enable debug mode. In debug mode, webforJ will print additional information to
+   * the console and show all exceptions in the browser. Debug mode is disabled by default.
+   * </p>
+   */
+  private Boolean debug;
+
+  /**
+   * Base path for loading DWC components.
+   *
+   * <p>
+   * When specified, the base path determines where DWC components are loaded from. By default,
+   * components are loaded from the server hosting the application. However, setting a custom base
+   * path allows components to be loaded from an alternate server or CDN. For example, to load
+   * components from jsdelivr.com, set the base path to:
+   * {@code https://cdn.jsdelivr.net/gh/webforj/dwc-dist@1.0.0-${webforj.version}}
+   * </p>
+   *
+   * <p>
+   * It's important that the loaded components are compatible with the version of the webforJ
+   * framework in use; otherwise, the application may not function as expected.
+   * </p>
+   */
+  private String components;
+
+  /**
+   * Application locale configuration.
+   *
+   * <p>
+   * Define the locale for the application. The locale determines the language and region settings
+   * used by the application as well as the format of dates, times, and numbers.
+   * </p>
+   */
+  private String locale;
+
+  /**
+   * String table for application strings.
+   *
+   * <p>
+   * The string table is a map of key-value pairs that can be used to store strings for use in the
+   * application.
+   * </p>
+   *
+   * @see <a href=
+   *      "https://docs.webforj.com/docs/advanced/object-string-tables#stringtable">StringTable</a>
+   */
+  private Map<String, String> stringTable = new HashMap<>();
+
+  /**
+   * Specifies the route name used to serve static files.
+   *
+   * <p>
+   * While the physical folder name remains {@code static}, this configuration is helpful if the
+   * default static route conflicts with a route defined in your app, allowing you to change the
+   * route name without renaming the folder itself.
+   * </p>
+   */
+  private String assetsDir;
+
+  /**
+   * Cache control header for static assets.
+   *
+   * <p>
+   * Sets the {@code Cache-Control} header for static resources. For example:
+   * {@code max-age=3600, public} or {@code no-cache}.
+   * </p>
+   */
+  private String assetsCacheControl;
+
+  /**
+   * Default file extension for static files.
+   *
+   * <p>
+   * The file extension to use when serving files from the static folder.
+   * </p>
+   */
+  private String assetsExt;
+
+  /**
+   * Icons directory endpoint name.
+   *
+   * <p>
+   * By default, webforJ serves icons from the {@code resources/icons/} directory. This property
+   * changes the URL endpoint used to access the icons, not the actual folder name. The default
+   * endpoint is {@code icons/}.
+   * </p>
+   */
+  private String iconsDir;
+
+  /**
+   * Controls whether to display the loading image.
+   *
+   * <p>
+   * Set to {@code true} to disable the loading image during application startup.
+   * </p>
+   */
+  private Boolean quiet;
+
+  /**
+   * When using hot redeploy, the whole WAR file will be swapped.
+   *
+   * <p>
+   * If the client tries to send a request to the server while it is restarting, an error occurs.
+   * This setting allows the client to attempt a page reload if the server is temporarily
+   * unavailable, hoping it will be back online shortly. This only applies to development
+   * environments and only handles errors specific to hot redeployment, not other types of errors.
+   * </p>
+   */
+  private Boolean reloadOnServerError;
+
+  /**
+   * Sets the interval at which the client pings the server to see if it's still alive.
+   *
+   * <p>
+   * This helps maintain communication. For development, set this to a shorter interval, for example
+   * {@code 8s}, to quickly detect server availability. For production environments, it's
+   * recommended to use values of 50 seconds or higher to minimize server load.
+   * </p>
+   */
+  private String clientHeartbeatRate;
+
+  /**
+   * File upload configuration.
+   */
+  private FileUpload fileUpload = new FileUpload();
 
   /**
    * Sets the URL mapping for the Webforj servlet.
@@ -37,5 +183,309 @@ public class SpringConfigurationProperties {
    */
   public String getServletMapping() {
     return servletMapping;
+  }
+
+  /**
+   * Gets the application entry point.
+   *
+   * @return the fully qualified class name of the entry point
+   */
+  public String getEntry() {
+    return entry;
+  }
+
+  /**
+   * Sets the application entry point.
+   *
+   * @param entry the fully qualified class name of the entry point
+   */
+  public void setEntry(String entry) {
+    this.entry = entry;
+  }
+
+  /**
+   * Gets the debug mode setting.
+   *
+   * @return true if debug mode is enabled, false otherwise, null if not set
+   */
+  public Boolean getDebug() {
+    return debug;
+  }
+
+  /**
+   * Sets the debug mode.
+   *
+   * @param debug true to enable debug mode, false to disable
+   */
+  public void setDebug(Boolean debug) {
+    this.debug = debug;
+  }
+
+  /**
+   * Gets the components base path.
+   *
+   * @return the base path for loading DWC components
+   */
+  public String getComponents() {
+    return components;
+  }
+
+  /**
+   * Sets the components base path.
+   *
+   * @param components the base path for loading DWC components
+   */
+  public void setComponents(String components) {
+    this.components = components;
+  }
+
+  /**
+   * Gets the application locale.
+   *
+   * @return the locale string
+   */
+  public String getLocale() {
+    return locale;
+  }
+
+  /**
+   * Sets the application locale.
+   *
+   * @param locale the locale string
+   */
+  public void setLocale(String locale) {
+    this.locale = locale;
+  }
+
+  /**
+   * Gets the string table.
+   *
+   * @return the string table map
+   */
+  public Map<String, String> getStringTable() {
+    return stringTable;
+  }
+
+  /**
+   * Sets the string table.
+   *
+   * @param stringTable the string table map
+   */
+  public void setStringTable(Map<String, String> stringTable) {
+    this.stringTable = stringTable;
+  }
+
+  /**
+   * Gets the file upload configuration.
+   *
+   * @return the file upload configuration
+   */
+  public FileUpload getFileUpload() {
+    return fileUpload;
+  }
+
+  /**
+   * Sets the file upload configuration.
+   *
+   * @param fileUpload the file upload configuration
+   */
+  public void setFileUpload(FileUpload fileUpload) {
+    this.fileUpload = fileUpload;
+  }
+
+  /**
+   * Gets the reload on server error setting.
+   *
+   * @return true if reload on server error is enabled, false otherwise, null if not set
+   */
+  public Boolean getReloadOnServerError() {
+    return reloadOnServerError;
+  }
+
+  /**
+   * Sets the reload on server error setting.
+   *
+   * @param reloadOnServerError true to enable reload on server error, false to disable
+   */
+  public void setReloadOnServerError(Boolean reloadOnServerError) {
+    this.reloadOnServerError = reloadOnServerError;
+  }
+
+  /**
+   * Gets the client heartbeat rate.
+   *
+   * @return the client heartbeat rate interval
+   */
+  public String getClientHeartbeatRate() {
+    return clientHeartbeatRate;
+  }
+
+  /**
+   * Sets the client heartbeat rate.
+   *
+   * @param clientHeartbeatRate the client heartbeat rate interval
+   */
+  public void setClientHeartbeatRate(String clientHeartbeatRate) {
+    this.clientHeartbeatRate = clientHeartbeatRate;
+  }
+
+  /**
+   * Gets the assets directory route name.
+   *
+   * @return the assets directory route name
+   */
+  public String getAssetsDir() {
+    return assetsDir;
+  }
+
+  /**
+   * Sets the assets directory route name.
+   *
+   * @param assetsDir the assets directory route name
+   */
+  public void setAssetsDir(String assetsDir) {
+    this.assetsDir = assetsDir;
+  }
+
+  /**
+   * Gets the quiet mode setting.
+   *
+   * @return true if loading image is disabled, false otherwise, null if not set
+   */
+  public Boolean getQuiet() {
+    return quiet;
+  }
+
+  /**
+   * Sets the quiet mode.
+   *
+   * @param quiet true to disable loading image, false to enable
+   */
+  public void setQuiet(Boolean quiet) {
+    this.quiet = quiet;
+  }
+
+  /**
+   * Gets the assets cache control header.
+   *
+   * @return the cache control header value
+   */
+  public String getAssetsCacheControl() {
+    return assetsCacheControl;
+  }
+
+  /**
+   * Sets the assets cache control header.
+   *
+   * @param assetsCacheControl the cache control header value
+   */
+  public void setAssetsCacheControl(String assetsCacheControl) {
+    this.assetsCacheControl = assetsCacheControl;
+  }
+
+  /**
+   * Gets the assets file extension.
+   *
+   * @return the default file extension
+   */
+  public String getAssetsExt() {
+    return assetsExt;
+  }
+
+  /**
+   * Sets the assets file extension.
+   *
+   * @param assetsExt the default file extension
+   */
+  public void setAssetsExt(String assetsExt) {
+    this.assetsExt = assetsExt;
+  }
+
+  /**
+   * Gets the icons directory endpoint name.
+   *
+   * @return the icons endpoint name
+   */
+  public String getIconsDir() {
+    return iconsDir;
+  }
+
+  /**
+   * Sets the icons directory endpoint name.
+   *
+   * @param iconsDir the icons endpoint name
+   */
+  public void setIconsDir(String iconsDir) {
+    this.iconsDir = iconsDir;
+  }
+
+  /**
+   * File upload configuration properties.
+   */
+  public static class FileUpload {
+    /**
+     * Allowed file types for file uploads.
+     *
+     * <p>
+     * The allowed file types for file uploads. By default, all file types are allowed.
+     * </p>
+     *
+     * <p>
+     * Example values:
+     * <ul>
+     * <li>{@code image/*}</li>
+     * <li>{@code application/pdf}</li>
+     * <li>{@code text/plain}</li>
+     * <li>{@code *.txt}</li>
+     * </ul>
+     * </p>
+     */
+    private List<String> accept = new ArrayList<>();
+
+    /**
+     * Maximum file size for uploads in bytes.
+     *
+     * <p>
+     * The maximum file size allowed for file uploads, in bytes. By default, there is no limit on
+     * the file size.
+     * </p>
+     */
+    private Long maxSize;
+
+    /**
+     * Gets the accepted file types.
+     *
+     * @return list of accepted file types
+     */
+    public List<String> getAccept() {
+      return accept;
+    }
+
+    /**
+     * Sets the accepted file types.
+     *
+     * @param accept list of accepted file types
+     */
+    public void setAccept(List<String> accept) {
+      this.accept = accept;
+    }
+
+    /**
+     * Gets the maximum file size.
+     *
+     * @return maximum file size in bytes
+     */
+    public Long getMaxSize() {
+      return maxSize;
+    }
+
+    /**
+     * Sets the maximum file size.
+     *
+     * @param maxSize maximum file size in bytes
+     */
+    public void setMaxSize(Long maxSize) {
+      this.maxSize = maxSize;
+    }
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
@@ -120,6 +120,16 @@ public class SpringConfigurationProperties {
   private String assetsExt;
 
   /**
+   * Index file for static assets.
+   *
+   * <p>
+   * The default file to serve when a directory is requested from the static assets folder. For
+   * example, {@code index.html}.
+   * </p>
+   */
+  private String assetsIndex;
+
+  /**
    * Icons directory endpoint name.
    *
    * <p>
@@ -176,6 +186,11 @@ public class SpringConfigurationProperties {
    * </p>
    */
   private List<ServletConfig> servlets = new ArrayList<>();
+
+  /**
+   * License configuration.
+   */
+  private License license = new License();
 
 
   /**
@@ -413,6 +428,24 @@ public class SpringConfigurationProperties {
   }
 
   /**
+   * Gets the assets index file.
+   *
+   * @return the index file name
+   */
+  public String getAssetsIndex() {
+    return assetsIndex;
+  }
+
+  /**
+   * Sets the assets index file.
+   *
+   * @param assetsIndex the index file name
+   */
+  public void setAssetsIndex(String assetsIndex) {
+    this.assetsIndex = assetsIndex;
+  }
+
+  /**
    * Gets the icons directory endpoint name.
    *
    * @return the icons endpoint name
@@ -448,6 +481,23 @@ public class SpringConfigurationProperties {
     this.servlets = servlets;
   }
 
+  /**
+   * Gets the license configuration.
+   *
+   * @return the license configuration
+   */
+  public License getLicense() {
+    return license;
+  }
+
+  /**
+   * Sets the license configuration.
+   *
+   * @param license the license configuration
+   */
+  public void setLicense(License license) {
+    this.license = license;
+  }
 
   /**
    * File upload configuration properties.
@@ -590,6 +640,57 @@ public class SpringConfigurationProperties {
      */
     public void setConfig(Map<String, String> config) {
       this.config = config;
+    }
+  }
+
+  /**
+   * License configuration properties.
+   */
+  public static class License {
+    /**
+     * Path to the license configuration dir.
+     */
+    private String cfg;
+
+    /**
+     * License startup timeout.
+     */
+    private Integer startupTimeout;
+
+    /**
+     * Gets the license configuration directory path.
+     *
+     * @return the license configuration directory path
+     */
+    public String getCfg() {
+      return cfg;
+    }
+
+    /**
+     * Sets the license configuration directory path.
+     *
+     * @param cfg the license configuration directory path
+     */
+    public void setCfg(String cfg) {
+      this.cfg = cfg;
+    }
+
+    /**
+     * Gets the license startup timeout.
+     *
+     * @return the startup timeout
+     */
+    public Integer getStartupTimeout() {
+      return startupTimeout;
+    }
+
+    /**
+     * Sets the license startup timeout.
+     *
+     * @param startupTimeout the startup timeout
+     */
+    public void setStartupTimeout(Integer startupTimeout) {
+      this.startupTimeout = startupTimeout;
     }
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
@@ -39,7 +39,8 @@ class WebforjConfigBuilder {
         .add("webforj.reloadOnServerError", properties::getReloadOnServerError, false);
 
     // Client configuration
-    builder.add("webforj.clientHeartbeatRate", properties::getClientHeartbeatRate);
+    builder.add("webforj.clientHeartbeatRate", properties::getClientHeartbeatRate)
+        .add("webforj.sessionTimeout", properties::getSessionTimeout, 60);
 
     // Assets configurations
     builder.add("webforj.assetsDir", properties::getAssetsDir)

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
@@ -1,0 +1,101 @@
+package com.webforj.spring;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builder for creating Typesafe Config objects from Spring configuration properties.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+class WebforjConfigBuilder {
+
+  /**
+   * Builds a Typesafe Config object from Spring configuration properties.
+   *
+   * @param properties the Spring configuration properties
+   * @return a Config object with all configured values
+   */
+  public static Config buildConfig(SpringConfigurationProperties properties) {
+    Map<String, Object> configMap = new HashMap<>();
+
+    // Add entry point configuration
+    if (properties.getEntry() != null) {
+      configMap.put("webforj.entry", properties.getEntry());
+    }
+
+    // Add debug configuration - always provide a value to avoid null issues
+    configMap.put("webforj.debug",
+        properties.getDebug() != null ? properties.getDebug().booleanValue() : false);
+
+    // Add components configuration
+    if (properties.getComponents() != null) {
+      configMap.put("webforj.components", properties.getComponents());
+    }
+
+    // Add locale configuration
+    if (properties.getLocale() != null) {
+      configMap.put("webforj.locale", properties.getLocale());
+    }
+
+    // Add string table configuration
+    if (properties.getStringTable() != null && !properties.getStringTable().isEmpty()) {
+      for (Map.Entry<String, String> entry : properties.getStringTable().entrySet()) {
+        configMap.put("webforj.stringTable." + entry.getKey(), entry.getValue());
+      }
+    }
+
+    // Add file upload configuration
+    if (properties.getFileUpload() != null) {
+      SpringConfigurationProperties.FileUpload fileUpload = properties.getFileUpload();
+
+      if (fileUpload.getAccept() != null && !fileUpload.getAccept().isEmpty()) {
+        configMap.put("webforj.fileUpload.accept", fileUpload.getAccept());
+      }
+
+      if (fileUpload.getMaxSize() != null) {
+        configMap.put("webforj.fileUpload.maxSize", fileUpload.getMaxSize());
+      }
+    }
+
+    // Add reload on server error configuration - provide default to avoid null
+    configMap.put("webforj.reloadOnServerError",
+        properties.getReloadOnServerError() != null
+            ? properties.getReloadOnServerError().booleanValue()
+            : false);
+
+    // Add client heartbeat rate configuration
+    if (properties.getClientHeartbeatRate() != null) {
+      configMap.put("webforj.clientHeartbeatRate", properties.getClientHeartbeatRate());
+    }
+
+    // Add assets directory configuration
+    if (properties.getAssetsDir() != null) {
+      configMap.put("webforj.assetsDir", properties.getAssetsDir());
+    }
+
+    // Add assets cache control configuration
+    if (properties.getAssetsCacheControl() != null) {
+      configMap.put("webforj.assetsCacheControl", properties.getAssetsCacheControl());
+    }
+
+    // Add assets extension configuration
+    if (properties.getAssetsExt() != null) {
+      configMap.put("webforj.assetsExt", properties.getAssetsExt());
+    }
+
+    // Add icons directory configuration
+    if (properties.getIconsDir() != null) {
+      configMap.put("webforj.iconsDir", properties.getIconsDir());
+    }
+
+    // Add quiet mode configuration - provide default to avoid null
+    configMap.put("webforj.quiet",
+        properties.getQuiet() != null ? properties.getQuiet().booleanValue() : false);
+
+    return ConfigFactory.parseMap(configMap);
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
@@ -2,7 +2,10 @@ package com.webforj.spring;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -92,10 +95,42 @@ class WebforjConfigBuilder {
       configMap.put("webforj.iconsDir", properties.getIconsDir());
     }
 
+    // Add servlet configurations
+    List<Map<String, Object>> servletConfigs = new ArrayList<>();
+
+    // Add user-defined servlet configurations
+    if (properties.getServlets() != null && !properties.getServlets().isEmpty()) {
+      for (SpringConfigurationProperties.ServletConfig servletConfig : properties.getServlets()) {
+        Map<String, Object> servlet = new HashMap<>();
+
+        if (servletConfig.getClassName() != null) {
+          servlet.put("class", servletConfig.getClassName());
+        }
+
+        if (servletConfig.getName() != null) {
+          servlet.put("name", servletConfig.getName());
+        }
+
+        if (servletConfig.getConfig() != null && !servletConfig.getConfig().isEmpty()) {
+          servlet.put("config", servletConfig.getConfig());
+        }
+
+        servletConfigs.add(servlet);
+      }
+    }
+
+    // Add servlets to config if any are defined
+    if (!servletConfigs.isEmpty()) {
+      // Add as both prefixed and non-prefixed for backwards compatibility
+      configMap.put("webforj.servlets", servletConfigs);
+      configMap.put("servlets", servletConfigs);
+    }
+
     // Add quiet mode configuration - provide default to avoid null
     configMap.put("webforj.quiet",
         properties.getQuiet() != null ? properties.getQuiet().booleanValue() : false);
 
     return ConfigFactory.parseMap(configMap);
   }
+
 }

--- a/webforj-spring/webforj-spring-integration/src/main/resources/META-INF/services/com.webforj.AppLifecycleListener
+++ b/webforj-spring/webforj-spring-integration/src/main/resources/META-INF/services/com.webforj.AppLifecycleListener
@@ -1,1 +1,2 @@
+com.webforj.spring.SpringConfigMerger
 com.webforj.spring.devtools.livereload.LiveReloadScriptInjector

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringAutoConfigurationTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringAutoConfigurationTest.java
@@ -2,27 +2,29 @@ package com.webforj.spring;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
+import com.typesafe.config.Config;
 import com.webforj.servlet.WebforjServlet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 
-/**
- * Unit tests for {@link SpringAutoConfiguration}.
- *
- * @author Hyyan Abo Fakher
- */
 @ExtendWith(MockitoExtension.class)
 class SpringAutoConfigurationTest {
 
   @Mock
   private SpringConfigurationProperties properties;
+
+  @Mock
+  private Config config;
 
   private SpringAutoConfiguration autoConfiguration;
 
@@ -38,12 +40,17 @@ class SpringAutoConfigurationTest {
     void shouldCreateServletRegistrationBeanWithDefaultMapping() {
       when(properties.getServletMapping()).thenReturn("/*");
 
-      ServletRegistrationBean<WebforjServlet> registrationBean =
-          autoConfiguration.webforjServletRegistration(properties);
+      try (MockedStatic<WebforjServlet> mockedServlet = mockStatic(WebforjServlet.class)) {
+        ServletRegistrationBean<WebforjServlet> registrationBean =
+            autoConfiguration.webforjServletRegistration(properties, config);
 
-      assertNotNull(registrationBean);
-      assertNotNull(registrationBean.getServlet());
-      assertEquals(WebforjServlet.class, registrationBean.getServlet().getClass());
+        assertNotNull(registrationBean);
+        assertNotNull(registrationBean.getServlet());
+        assertEquals(WebforjServlet.class, registrationBean.getServlet().getClass());
+
+        // Verify setConfig was called with the provided config
+        mockedServlet.verify(() -> WebforjServlet.setConfig(config), times(1));
+      }
     }
 
     @Test
@@ -51,26 +58,47 @@ class SpringAutoConfigurationTest {
       String customMapping = "/webforj/*";
       when(properties.getServletMapping()).thenReturn(customMapping);
 
-      ServletRegistrationBean<WebforjServlet> registrationBean =
-          autoConfiguration.webforjServletRegistration(properties);
+      try (MockedStatic<WebforjServlet> mockedServlet = mockStatic(WebforjServlet.class)) {
+        ServletRegistrationBean<WebforjServlet> registrationBean =
+            autoConfiguration.webforjServletRegistration(properties, config);
 
-      assertNotNull(registrationBean);
-      assertNotNull(registrationBean.getServlet());
-      assertEquals(WebforjServlet.class, registrationBean.getServlet().getClass());
+        assertNotNull(registrationBean);
+        assertNotNull(registrationBean.getServlet());
+        assertEquals(WebforjServlet.class, registrationBean.getServlet().getClass());
+
+        // Verify setConfig was called with the provided config
+        mockedServlet.verify(() -> WebforjServlet.setConfig(config), times(1));
+      }
     }
 
     @Test
     void shouldCreateNewWebforjServletInstance() {
       when(properties.getServletMapping()).thenReturn("/*");
 
-      ServletRegistrationBean<WebforjServlet> registrationBean1 =
-          autoConfiguration.webforjServletRegistration(properties);
-      ServletRegistrationBean<WebforjServlet> registrationBean2 =
-          autoConfiguration.webforjServletRegistration(properties);
+      try (MockedStatic<WebforjServlet> mockedServlet = mockStatic(WebforjServlet.class)) {
+        ServletRegistrationBean<WebforjServlet> registrationBean1 =
+            autoConfiguration.webforjServletRegistration(properties, config);
+        ServletRegistrationBean<WebforjServlet> registrationBean2 =
+            autoConfiguration.webforjServletRegistration(properties, config);
 
-      assertNotNull(registrationBean1.getServlet());
-      assertNotNull(registrationBean2.getServlet());
-      assert registrationBean1.getServlet() != registrationBean2.getServlet();
+        assertNotNull(registrationBean1.getServlet());
+        assertNotNull(registrationBean2.getServlet());
+        assert registrationBean1.getServlet() != registrationBean2.getServlet();
+
+        // Verify setConfig was called twice (once for each registration)
+        mockedServlet.verify(() -> WebforjServlet.setConfig(config), times(2));
+      }
+    }
+  }
+
+  @Nested
+  class ConfigBean {
+
+    @Test
+    void shouldCreateWebforjConfigFromProperties() {
+      Config configResult = autoConfiguration.webforjConfig(properties);
+
+      assertNotNull(configResult);
     }
   }
 
@@ -101,7 +129,7 @@ class SpringAutoConfigurationTest {
 
     @Test
     void shouldCreateComponentRegistrarBean() {
-      ComponentRegistrar registrar = autoConfiguration.webforjComponentRegistrar();
+      ComponentRegistrar registrar = SpringAutoConfiguration.webforjComponentRegistrar();
 
       assertNotNull(registrar);
       assertEquals(ComponentRegistrar.class, registrar.getClass());
@@ -109,8 +137,8 @@ class SpringAutoConfigurationTest {
 
     @Test
     void shouldCreateNewComponentRegistrarInstanceEachTime() {
-      ComponentRegistrar registrar1 = autoConfiguration.webforjComponentRegistrar();
-      ComponentRegistrar registrar2 = autoConfiguration.webforjComponentRegistrar();
+      ComponentRegistrar registrar1 = SpringAutoConfiguration.webforjComponentRegistrar();
+      ComponentRegistrar registrar2 = SpringAutoConfiguration.webforjComponentRegistrar();
 
       assertNotNull(registrar1);
       assertNotNull(registrar2);

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigMergerTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigMergerTest.java
@@ -1,0 +1,89 @@
+package com.webforj.spring;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.typesafe.config.Config;
+import com.webforj.Environment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+
+@ExtendWith(MockitoExtension.class)
+class SpringConfigMergerTest {
+
+  @Mock
+  private Environment environment;
+
+  @Mock
+  private ApplicationContext applicationContext;
+
+  @Mock
+  private Config config;
+
+  private SpringConfigMerger merger;
+
+  @BeforeEach
+  void setUp() {
+    merger = new SpringConfigMerger();
+  }
+
+  @Test
+  void shouldMergeConfigWhenSpringContextAvailable() {
+    try (MockedStatic<ContextHolder> contextHolder = mockStatic(ContextHolder.class)) {
+      contextHolder.when(ContextHolder::getContext).thenReturn(applicationContext);
+      when(applicationContext.getBean("webforjConfig", Config.class)).thenReturn(config);
+
+      merger.onWillCreate(environment);
+
+      verify(environment, times(1)).setConfig(config);
+    }
+  }
+
+  @Test
+  void shouldNotMergeConfigWhenSpringContextNotAvailable() {
+    try (MockedStatic<ContextHolder> contextHolder = mockStatic(ContextHolder.class)) {
+      contextHolder.when(ContextHolder::getContext).thenReturn(null);
+
+      merger.onWillCreate(environment);
+
+      verify(environment, never()).setConfig(any());
+    }
+  }
+
+  @Test
+  void shouldHandleExceptionWhenConfigBeanNotFound() {
+    try (MockedStatic<ContextHolder> contextHolder = mockStatic(ContextHolder.class)) {
+      contextHolder.when(ContextHolder::getContext).thenReturn(applicationContext);
+      when(applicationContext.getBean("webforjConfig", Config.class))
+          .thenThrow(new NoSuchBeanDefinitionException("webforjConfig"));
+
+      merger.onWillCreate(environment);
+
+      verify(environment, never()).setConfig(any());
+    }
+  }
+
+  @Test
+  void shouldRetrieveConfigBySpecificBeanName() {
+    try (MockedStatic<ContextHolder> contextHolder = mockStatic(ContextHolder.class)) {
+      contextHolder.when(ContextHolder::getContext).thenReturn(applicationContext);
+      when(applicationContext.getBean("webforjConfig", Config.class)).thenReturn(config);
+
+      merger.onWillCreate(environment);
+
+      verify(applicationContext).getBean(eq("webforjConfig"), eq(Config.class));
+      verify(environment).setConfig(config);
+    }
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigMergerTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigMergerTest.java
@@ -1,7 +1,6 @@
 package com.webforj.spring;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -82,7 +81,7 @@ class SpringConfigMergerTest {
 
       merger.onWillCreate(environment);
 
-      verify(applicationContext).getBean(eq("webforjConfig"), eq(Config.class));
+      verify(applicationContext).getBean("webforjConfig", Config.class);
       verify(environment).setConfig(config);
     }
   }

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigurationPropertiesTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigurationPropertiesTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigurationPropertiesTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigurationPropertiesTest.java
@@ -1,8 +1,14 @@
 package com.webforj.spring;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -20,5 +26,135 @@ class SpringConfigurationPropertiesTest {
   void shouldHandleVariousServletMappingPatterns(String mapping) {
     properties.setServletMapping(mapping);
     assertEquals(mapping, properties.getServletMapping());
+  }
+
+  @Test
+  void shouldHandleEntryProperty() {
+    String entry = "com.example.MyApp";
+    properties.setEntry(entry);
+    assertEquals(entry, properties.getEntry());
+  }
+
+  @Test
+  void shouldHandleDebugProperty() {
+    properties.setDebug(true);
+    assertEquals(Boolean.TRUE, properties.getDebug());
+
+    properties.setDebug(false);
+    assertEquals(Boolean.FALSE, properties.getDebug());
+  }
+
+  @Test
+  void shouldHandleComponentsProperty() {
+    String components = "https://cdn.example.com/webforj-components";
+    properties.setComponents(components);
+    assertEquals(components, properties.getComponents());
+  }
+
+  @Test
+  void shouldHandleLocaleProperty() {
+    String locale = "en-US";
+    properties.setLocale(locale);
+    assertEquals(locale, properties.getLocale());
+  }
+
+  @Test
+  void shouldHandleStringTableProperty() {
+    Map<String, String> stringTable = new HashMap<>();
+    stringTable.put("app.title", "My Application");
+    stringTable.put("app.version", "1.0.0");
+
+    properties.setStringTable(stringTable);
+    assertEquals(stringTable, properties.getStringTable());
+    assertEquals("My Application", properties.getStringTable().get("app.title"));
+  }
+
+  @Test
+  void shouldInitializeEmptyStringTable() {
+    assertNotNull(properties.getStringTable());
+    assertTrue(properties.getStringTable().isEmpty());
+  }
+
+  @Test
+  void shouldHandleFileUploadAcceptProperty() {
+    SpringConfigurationProperties.FileUpload fileUpload =
+        new SpringConfigurationProperties.FileUpload();
+    fileUpload.setAccept(Arrays.asList("image/*", "application/pdf", "*.txt"));
+
+    properties.setFileUpload(fileUpload);
+    assertNotNull(properties.getFileUpload());
+    assertEquals(3, properties.getFileUpload().getAccept().size());
+    assertTrue(properties.getFileUpload().getAccept().contains("image/*"));
+  }
+
+  @Test
+  void shouldHandleFileUploadMaxSizeProperty() {
+    SpringConfigurationProperties.FileUpload fileUpload =
+        new SpringConfigurationProperties.FileUpload();
+    fileUpload.setMaxSize(10485760L); // 10MB
+
+    properties.setFileUpload(fileUpload);
+    assertNotNull(properties.getFileUpload());
+    assertEquals(10485760L, properties.getFileUpload().getMaxSize());
+  }
+
+  @Test
+  void shouldInitializeFileUploadWithDefaults() {
+    assertNotNull(properties.getFileUpload());
+    assertNotNull(properties.getFileUpload().getAccept());
+    assertTrue(properties.getFileUpload().getAccept().isEmpty());
+  }
+
+  @Test
+  void shouldHandleReloadOnServerErrorProperty() {
+    properties.setReloadOnServerError(true);
+    assertEquals(Boolean.TRUE, properties.getReloadOnServerError());
+
+    properties.setReloadOnServerError(false);
+    assertEquals(Boolean.FALSE, properties.getReloadOnServerError());
+  }
+
+  @Test
+  void shouldHandleClientHeartbeatRateProperty() {
+    String heartbeatRate = "8s";
+    properties.setClientHeartbeatRate(heartbeatRate);
+    assertEquals(heartbeatRate, properties.getClientHeartbeatRate());
+  }
+
+  @Test
+  void shouldHandleAssetsDirProperty() {
+    String assetsDir = "static-files";
+    properties.setAssetsDir(assetsDir);
+    assertEquals(assetsDir, properties.getAssetsDir());
+  }
+
+  @Test
+  void shouldHandleQuietProperty() {
+    properties.setQuiet(true);
+    assertEquals(Boolean.TRUE, properties.getQuiet());
+
+    properties.setQuiet(false);
+    assertEquals(Boolean.FALSE, properties.getQuiet());
+  }
+
+  @Test
+  void shouldHandleAssetsCacheControlProperty() {
+    String cacheControl = "max-age=3600, public";
+    properties.setAssetsCacheControl(cacheControl);
+    assertEquals(cacheControl, properties.getAssetsCacheControl());
+  }
+
+  @Test
+  void shouldHandleAssetsExtProperty() {
+    String assetsExt = ".html";
+    properties.setAssetsExt(assetsExt);
+    assertEquals(assetsExt, properties.getAssetsExt());
+  }
+
+  @Test
+  void shouldHandleIconsDirProperty() {
+    String iconsDir = "icons/";
+    properties.setIconsDir(iconsDir);
+    assertEquals(iconsDir, properties.getIconsDir());
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigurationPropertiesTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigurationPropertiesTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,5 +157,34 @@ class SpringConfigurationPropertiesTest {
     String iconsDir = "icons/";
     properties.setIconsDir(iconsDir);
     assertEquals(iconsDir, properties.getIconsDir());
+  }
+
+
+  @Test
+  void shouldHandleServletConfigProperty() {
+    SpringConfigurationProperties.ServletConfig servletConfig =
+        new SpringConfigurationProperties.ServletConfig();
+    servletConfig.setClassName("com.example.MyServlet");
+    servletConfig.setName("myServlet");
+
+    Map<String, String> config = new HashMap<>();
+    config.put("param1", "value1");
+    config.put("param2", "value2");
+    servletConfig.setConfig(config);
+
+    properties.setServlets(Arrays.asList(servletConfig));
+
+    assertNotNull(properties.getServlets());
+    assertEquals(1, properties.getServlets().size());
+    assertEquals("com.example.MyServlet", properties.getServlets().get(0).getClassName());
+    assertEquals("myServlet", properties.getServlets().get(0).getName());
+    assertEquals(2, properties.getServlets().get(0).getConfig().size());
+    assertEquals("value1", properties.getServlets().get(0).getConfig().get("param1"));
+  }
+
+  @Test
+  void shouldInitializeEmptyServletsList() {
+    assertNotNull(properties.getServlets());
+    assertTrue(properties.getServlets().isEmpty());
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.typesafe.config.Config;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
@@ -118,6 +118,18 @@ class WebforjConfigBuilderTest {
 
       assertFalse(config.hasPath("webforj.clientHeartbeatRate"));
     }
+
+    @Test
+    void shouldSetSessionTimeoutWithDefault() {
+      // Test null (should use default 60)
+      Config config1 = WebforjConfigBuilder.buildConfig(properties);
+      assertEquals(60, config1.getInt("webforj.sessionTimeout"));
+
+      // Test explicit value
+      properties.setSessionTimeout(300);
+      Config config2 = WebforjConfigBuilder.buildConfig(properties);
+      assertEquals(300, config2.getInt("webforj.sessionTimeout"));
+    }
   }
 
   @Nested
@@ -461,6 +473,7 @@ class WebforjConfigBuilderTest {
 
       // Client
       properties.setClientHeartbeatRate("10s");
+      properties.setSessionTimeout(120);
 
       // Assets
       properties.setAssetsDir("assets");
@@ -504,6 +517,7 @@ class WebforjConfigBuilderTest {
       assertFalse(config.getBoolean("webforj.quiet"));
       assertTrue(config.getBoolean("webforj.reloadOnServerError"));
       assertEquals("10s", config.getString("webforj.clientHeartbeatRate"));
+      assertEquals(120, config.getInt("webforj.sessionTimeout"));
       assertEquals("assets", config.getString("webforj.assetsDir"));
       assertEquals("no-cache", config.getString("webforj.assetsCacheControl"));
       assertEquals(".htm", config.getString("webforj.assetsExt"));
@@ -529,6 +543,7 @@ class WebforjConfigBuilderTest {
       assertFalse(config.getBoolean("webforj.debug"));
       assertFalse(config.getBoolean("webforj.quiet"));
       assertFalse(config.getBoolean("webforj.reloadOnServerError"));
+      assertEquals(60, config.getInt("webforj.sessionTimeout"));
 
       // Everything else should be missing
       assertFalse(config.hasPath("webforj.entry"));

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
@@ -1,6 +1,7 @@
 package com.webforj.spring;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -10,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class WebforjConfigBuilderTest {
@@ -21,69 +23,518 @@ class WebforjConfigBuilderTest {
     properties = new SpringConfigurationProperties();
   }
 
-  @Test
-  void shouldBuildConfigWithDefaults() {
-    Config config = WebforjConfigBuilder.buildConfig(properties);
+  @Nested
+  class BasicProperties {
 
-    assertNotNull(config);
-    assertTrue(config.hasPath("webforj"));
+    @Test
+    void shouldSetEntry() {
+      properties.setEntry("com.example.App");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("com.example.App", config.getString("webforj.entry"));
+    }
+
+    @Test
+    void shouldHandleNullEntry() {
+      properties.setEntry(null);
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.entry"));
+    }
+
+    @Test
+    void shouldSetDebugWithDefault() {
+      // Test null (should use default false)
+      Config config1 = WebforjConfigBuilder.buildConfig(properties);
+      assertFalse(config1.getBoolean("webforj.debug"));
+
+      // Test explicit true
+      properties.setDebug(true);
+      Config config2 = WebforjConfigBuilder.buildConfig(properties);
+      assertTrue(config2.getBoolean("webforj.debug"));
+
+      // Test explicit false
+      properties.setDebug(false);
+      Config config3 = WebforjConfigBuilder.buildConfig(properties);
+      assertFalse(config3.getBoolean("webforj.debug"));
+    }
+
+    @Test
+    void shouldSetComponents() {
+      properties.setComponents("https://cdn.example.com/components");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("https://cdn.example.com/components", config.getString("webforj.components"));
+    }
+
+    @Test
+    void shouldSetLocale() {
+      properties.setLocale("en-US");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("en-US", config.getString("webforj.locale"));
+    }
+
+    @Test
+    void shouldSetQuietWithDefault() {
+      // Test null (should use default false)
+      Config config1 = WebforjConfigBuilder.buildConfig(properties);
+      assertFalse(config1.getBoolean("webforj.quiet"));
+
+      // Test explicit true
+      properties.setQuiet(true);
+      Config config2 = WebforjConfigBuilder.buildConfig(properties);
+      assertTrue(config2.getBoolean("webforj.quiet"));
+    }
+
+    @Test
+    void shouldSetReloadOnServerErrorWithDefault() {
+      // Test null (should use default false)
+      Config config1 = WebforjConfigBuilder.buildConfig(properties);
+      assertFalse(config1.getBoolean("webforj.reloadOnServerError"));
+
+      // Test explicit true
+      properties.setReloadOnServerError(true);
+      Config config2 = WebforjConfigBuilder.buildConfig(properties);
+      assertTrue(config2.getBoolean("webforj.reloadOnServerError"));
+    }
   }
 
-  @Test
-  void shouldBuildConfigWithBasicProperties() {
-    properties.setEntry("com.example.MyApp");
-    properties.setDebug(true);
-    properties.setComponents("https://cdn.example.com/components");
-    properties.setLocale("de-DE");
+  @Nested
+  class ClientConfiguration {
 
-    Config config = WebforjConfigBuilder.buildConfig(properties);
+    @Test
+    void shouldSetClientHeartbeatRate() {
+      properties.setClientHeartbeatRate("30s");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
 
-    assertEquals("com.example.MyApp", config.getString("webforj.entry"));
-    assertTrue(config.getBoolean("webforj.debug"));
-    assertEquals("https://cdn.example.com/components", config.getString("webforj.components"));
-    assertEquals("de-DE", config.getString("webforj.locale"));
+      assertEquals("30s", config.getString("webforj.clientHeartbeatRate"));
+    }
+
+    @Test
+    void shouldHandleNullClientHeartbeatRate() {
+      properties.setClientHeartbeatRate(null);
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.clientHeartbeatRate"));
+    }
   }
 
-  @Test
-  void shouldBuildConfigWithStringTable() {
-    Map<String, String> stringTable = new HashMap<>();
-    stringTable.put("app.title", "Test Application");
-    stringTable.put("app.version", "2.0.0");
-    properties.setStringTable(stringTable);
+  @Nested
+  class AssetsConfiguration {
 
-    Config config = WebforjConfigBuilder.buildConfig(properties);
+    @Test
+    void shouldSetAssetsDir() {
+      properties.setAssetsDir("static");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
 
-    assertEquals("Test Application", config.getString("webforj.stringTable.app.title"));
-    assertEquals("2.0.0", config.getString("webforj.stringTable.app.version"));
+      assertEquals("static", config.getString("webforj.assetsDir"));
+    }
+
+    @Test
+    void shouldSetAssetsCacheControl() {
+      properties.setAssetsCacheControl("max-age=3600");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("max-age=3600", config.getString("webforj.assetsCacheControl"));
+    }
+
+    @Test
+    void shouldSetAssetsExt() {
+      properties.setAssetsExt(".html");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals(".html", config.getString("webforj.assetsExt"));
+    }
+
+    @Test
+    void shouldSetAssetsIndex() {
+      properties.setAssetsIndex("index.html");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("index.html", config.getString("webforj.assetsIndex"));
+    }
+
+    @Test
+    void shouldSetIconsDir() {
+      properties.setIconsDir("icons");
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("icons", config.getString("webforj.iconsDir"));
+    }
+
+    @Test
+    void shouldHandleNullAssetsProperties() {
+      // All null
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.assetsDir"));
+      assertFalse(config.hasPath("webforj.assetsCacheControl"));
+      assertFalse(config.hasPath("webforj.assetsExt"));
+      assertFalse(config.hasPath("webforj.assetsIndex"));
+      assertFalse(config.hasPath("webforj.iconsDir"));
+    }
   }
 
-  @Test
-  void shouldBuildConfigWithFileUpload() {
-    SpringConfigurationProperties.FileUpload fileUpload =
-        new SpringConfigurationProperties.FileUpload();
-    fileUpload.setAccept(Arrays.asList("image/jpeg", "image/png"));
-    fileUpload.setMaxSize(5242880L);
-    properties.setFileUpload(fileUpload);
+  @Nested
+  class StringTableConfiguration {
 
-    Config config = WebforjConfigBuilder.buildConfig(properties);
+    @Test
+    void shouldSetStringTable() {
+      Map<String, String> stringTable = new HashMap<>();
+      stringTable.put("app.name", "MyApp");
+      stringTable.put("app.version", "1.0.0");
+      stringTable.put("welcome.message", "Hello World");
+      properties.setStringTable(stringTable);
 
-    assertEquals(2, config.getStringList("webforj.fileUpload.accept").size());
-    assertTrue(config.getStringList("webforj.fileUpload.accept").contains("image/jpeg"));
-    assertEquals(5242880L, config.getLong("webforj.fileUpload.maxSize"));
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("MyApp", config.getString("webforj.stringTable.app.name"));
+      assertEquals("1.0.0", config.getString("webforj.stringTable.app.version"));
+      assertEquals("Hello World", config.getString("webforj.stringTable.welcome.message"));
+    }
+
+    @Test
+    void shouldHandleEmptyStringTable() {
+      properties.setStringTable(new HashMap<>());
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.stringTable"));
+    }
+
+    @Test
+    void shouldHandleNullStringTable() {
+      properties.setStringTable(null);
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.stringTable"));
+    }
   }
 
-  @Test
-  void shouldBuildConfigWithAssetsProperties() {
-    properties.setQuiet(true);
-    properties.setAssetsCacheControl("max-age=3600, public");
-    properties.setAssetsExt(".html");
-    properties.setIconsDir("icons/");
+  @Nested
+  class FileUploadConfiguration {
 
-    Config config = WebforjConfigBuilder.buildConfig(properties);
+    @Test
+    void shouldSetFileUploadAccept() {
+      SpringConfigurationProperties.FileUpload fileUpload =
+          new SpringConfigurationProperties.FileUpload();
+      fileUpload.setAccept(Arrays.asList("image/*", "application/pdf", ".txt"));
+      properties.setFileUpload(fileUpload);
 
-    assertTrue(config.getBoolean("webforj.quiet"));
-    assertEquals("max-age=3600, public", config.getString("webforj.assetsCacheControl"));
-    assertEquals(".html", config.getString("webforj.assetsExt"));
-    assertEquals("icons/", config.getString("webforj.iconsDir"));
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      List<String> accept = config.getStringList("webforj.fileUpload.accept");
+      assertEquals(3, accept.size());
+      assertTrue(accept.contains("image/*"));
+      assertTrue(accept.contains("application/pdf"));
+      assertTrue(accept.contains(".txt"));
+    }
+
+    @Test
+    void shouldSetFileUploadMaxSize() {
+      SpringConfigurationProperties.FileUpload fileUpload =
+          new SpringConfigurationProperties.FileUpload();
+      fileUpload.setMaxSize(10485760L);
+      properties.setFileUpload(fileUpload);
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals(10485760L, config.getLong("webforj.fileUpload.maxSize"));
+    }
+
+    @Test
+    void shouldHandleEmptyFileUploadAccept() {
+      SpringConfigurationProperties.FileUpload fileUpload =
+          new SpringConfigurationProperties.FileUpload();
+      fileUpload.setAccept(Arrays.asList());
+      properties.setFileUpload(fileUpload);
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.fileUpload.accept"));
+    }
+
+    @Test
+    void shouldHandleNullFileUpload() {
+      properties.setFileUpload(null);
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.fileUpload"));
+    }
+
+    @Test
+    void shouldHandleFileUploadWithNullValues() {
+      SpringConfigurationProperties.FileUpload fileUpload =
+          new SpringConfigurationProperties.FileUpload();
+      fileUpload.setAccept(null);
+      fileUpload.setMaxSize(null);
+      properties.setFileUpload(fileUpload);
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.fileUpload.accept"));
+      assertFalse(config.hasPath("webforj.fileUpload.maxSize"));
+    }
+  }
+
+  @Nested
+  class LicenseConfiguration {
+
+    @Test
+    void shouldSetLicenseCfg() {
+      SpringConfigurationProperties.License license = new SpringConfigurationProperties.License();
+      license.setCfg("/path/to/license.cfg");
+      properties.setLicense(license);
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("/path/to/license.cfg", config.getString("webforj.license.cfg"));
+    }
+
+    @Test
+    void shouldSetLicenseStartupTimeout() {
+      SpringConfigurationProperties.License license = new SpringConfigurationProperties.License();
+      license.setStartupTimeout(60);
+      properties.setLicense(license);
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals(60, config.getInt("webforj.license.startupTimeout"));
+    }
+
+    @Test
+    void shouldSetBothLicenseProperties() {
+      SpringConfigurationProperties.License license = new SpringConfigurationProperties.License();
+      license.setCfg("/licenses/app.cfg");
+      license.setStartupTimeout(30);
+      properties.setLicense(license);
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals("/licenses/app.cfg", config.getString("webforj.license.cfg"));
+      assertEquals(30, config.getInt("webforj.license.startupTimeout"));
+    }
+
+    @Test
+    void shouldHandleNullLicense() {
+      properties.setLicense(null);
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.license.cfg"));
+      assertFalse(config.hasPath("webforj.license.startupTimeout"));
+    }
+
+    @Test
+    void shouldHandleLicenseWithNullValues() {
+      SpringConfigurationProperties.License license = new SpringConfigurationProperties.License();
+      license.setCfg(null);
+      license.setStartupTimeout(null);
+      properties.setLicense(license);
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.license.cfg"));
+      assertFalse(config.hasPath("webforj.license.startupTimeout"));
+    }
+  }
+
+  @Nested
+  class ServletConfiguration {
+
+    @Test
+    void shouldSetSingleServlet() {
+      SpringConfigurationProperties.ServletConfig servlet =
+          new SpringConfigurationProperties.ServletConfig();
+      servlet.setClassName("org.springframework.web.servlet.DispatcherServlet");
+      servlet.setName("dispatcher");
+
+      Map<String, String> servletConfig = new HashMap<>();
+      servletConfig.put("contextClass",
+          "org.springframework.web.context.support.AnnotationConfigWebApplicationContext");
+      servletConfig.put("contextConfigLocation", "com.example.config.AppConfig");
+      servlet.setConfig(servletConfig);
+
+      properties.setServlets(Arrays.asList(servlet));
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertTrue(config.hasPath("webforj.servlets"));
+      assertEquals(1, config.getConfigList("webforj.servlets").size());
+
+      Config servletConf = config.getConfigList("webforj.servlets").get(0);
+      assertEquals("org.springframework.web.servlet.DispatcherServlet",
+          servletConf.getString("class"));
+      assertEquals("dispatcher", servletConf.getString("name"));
+      assertEquals("org.springframework.web.context.support.AnnotationConfigWebApplicationContext",
+          servletConf.getConfig("config").getString("contextClass"));
+      assertEquals("com.example.config.AppConfig",
+          servletConf.getConfig("config").getString("contextConfigLocation"));
+    }
+
+    @Test
+    void shouldSetMultipleServlets() {
+      SpringConfigurationProperties.ServletConfig servlet1 =
+          new SpringConfigurationProperties.ServletConfig();
+      servlet1.setClassName("com.example.MyServlet");
+      servlet1.setName("myServlet");
+
+      SpringConfigurationProperties.ServletConfig servlet2 =
+          new SpringConfigurationProperties.ServletConfig();
+      servlet2.setClassName("com.example.AnotherServlet");
+      servlet2.setName("anotherServlet");
+
+      properties.setServlets(Arrays.asList(servlet1, servlet2));
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals(2, config.getConfigList("webforj.servlets").size());
+
+      Config firstServlet = config.getConfigList("webforj.servlets").get(0);
+      assertEquals("com.example.MyServlet", firstServlet.getString("class"));
+      assertEquals("myServlet", firstServlet.getString("name"));
+
+      Config secondServlet = config.getConfigList("webforj.servlets").get(1);
+      assertEquals("com.example.AnotherServlet", secondServlet.getString("class"));
+      assertEquals("anotherServlet", secondServlet.getString("name"));
+    }
+
+    @Test
+    void shouldHandleServletWithNullName() {
+      SpringConfigurationProperties.ServletConfig servlet =
+          new SpringConfigurationProperties.ServletConfig();
+      servlet.setClassName("com.example.MyServlet");
+      servlet.setName(null);
+
+      properties.setServlets(Arrays.asList(servlet));
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      Config servletConf = config.getConfigList("webforj.servlets").get(0);
+      assertEquals("com.example.MyServlet", servletConf.getString("class"));
+      assertFalse(servletConf.hasPath("name"));
+    }
+
+    @Test
+    void shouldHandleServletWithEmptyConfig() {
+      SpringConfigurationProperties.ServletConfig servlet =
+          new SpringConfigurationProperties.ServletConfig();
+      servlet.setClassName("com.example.MyServlet");
+      servlet.setConfig(new HashMap<>());
+
+      properties.setServlets(Arrays.asList(servlet));
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      Config servletConf = config.getConfigList("webforj.servlets").get(0);
+      assertFalse(servletConf.hasPath("config"));
+    }
+
+    @Test
+    void shouldHandleEmptyServletsList() {
+      properties.setServlets(Arrays.asList());
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.servlets"));
+    }
+
+    @Test
+    void shouldHandleNullServletsList() {
+      properties.setServlets(null);
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertFalse(config.hasPath("webforj.servlets"));
+    }
+  }
+
+  @Nested
+  class CompleteConfiguration {
+
+    @Test
+    void shouldBuildCompleteConfiguration() {
+      // Basic properties
+      properties.setEntry("com.example.MainApp");
+      properties.setDebug(true);
+      properties.setComponents("https://cdn.example.com/webforj");
+      properties.setLocale("de-DE");
+      properties.setQuiet(false);
+      properties.setReloadOnServerError(true);
+
+      // Client
+      properties.setClientHeartbeatRate("10s");
+
+      // Assets
+      properties.setAssetsDir("assets");
+      properties.setAssetsCacheControl("no-cache");
+      properties.setAssetsExt(".htm");
+      properties.setAssetsIndex("main.html");
+      properties.setIconsDir("img/icons");
+
+      // String table
+      Map<String, String> stringTable = new HashMap<>();
+      stringTable.put("title", "Test App");
+      properties.setStringTable(stringTable);
+
+      // File upload
+      SpringConfigurationProperties.FileUpload fileUpload =
+          new SpringConfigurationProperties.FileUpload();
+      fileUpload.setAccept(Arrays.asList("*"));
+      fileUpload.setMaxSize(1000000L);
+      properties.setFileUpload(fileUpload);
+
+      // License
+      SpringConfigurationProperties.License license = new SpringConfigurationProperties.License();
+      license.setCfg("/opt/license");
+      license.setStartupTimeout(120);
+      properties.setLicense(license);
+
+      // Servlets
+      SpringConfigurationProperties.ServletConfig servlet =
+          new SpringConfigurationProperties.ServletConfig();
+      servlet.setClassName("com.example.TestServlet");
+      servlet.setName("test");
+      properties.setServlets(Arrays.asList(servlet));
+
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      // Verify everything is set
+      assertEquals("com.example.MainApp", config.getString("webforj.entry"));
+      assertTrue(config.getBoolean("webforj.debug"));
+      assertEquals("https://cdn.example.com/webforj", config.getString("webforj.components"));
+      assertEquals("de-DE", config.getString("webforj.locale"));
+      assertFalse(config.getBoolean("webforj.quiet"));
+      assertTrue(config.getBoolean("webforj.reloadOnServerError"));
+      assertEquals("10s", config.getString("webforj.clientHeartbeatRate"));
+      assertEquals("assets", config.getString("webforj.assetsDir"));
+      assertEquals("no-cache", config.getString("webforj.assetsCacheControl"));
+      assertEquals(".htm", config.getString("webforj.assetsExt"));
+      assertEquals("main.html", config.getString("webforj.assetsIndex"));
+      assertEquals("img/icons", config.getString("webforj.iconsDir"));
+      assertEquals("Test App", config.getString("webforj.stringTable.title"));
+      assertEquals(Arrays.asList("*"), config.getStringList("webforj.fileUpload.accept"));
+      assertEquals(1000000L, config.getLong("webforj.fileUpload.maxSize"));
+      assertEquals("/opt/license", config.getString("webforj.license.cfg"));
+      assertEquals(120, config.getInt("webforj.license.startupTimeout"));
+      assertEquals(1, config.getConfigList("webforj.servlets").size());
+      assertEquals("com.example.TestServlet",
+          config.getConfigList("webforj.servlets").get(0).getString("class"));
+    }
+
+    @Test
+    void shouldBuildMinimalConfiguration() {
+      // Build with all nulls/defaults
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertNotNull(config);
+      // Only defaults should be set
+      assertFalse(config.getBoolean("webforj.debug"));
+      assertFalse(config.getBoolean("webforj.quiet"));
+      assertFalse(config.getBoolean("webforj.reloadOnServerError"));
+
+      // Everything else should be missing
+      assertFalse(config.hasPath("webforj.entry"));
+      assertFalse(config.hasPath("webforj.components"));
+      assertFalse(config.hasPath("webforj.locale"));
+      assertFalse(config.hasPath("webforj.servlets"));
+    }
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
@@ -1,0 +1,88 @@
+package com.webforj.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.typesafe.config.Config;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WebforjConfigBuilderTest {
+
+  private SpringConfigurationProperties properties;
+
+  @BeforeEach
+  void setUp() {
+    properties = new SpringConfigurationProperties();
+  }
+
+  @Test
+  void shouldBuildConfigWithDefaults() {
+    Config config = WebforjConfigBuilder.buildConfig(properties);
+
+    assertNotNull(config);
+    assertTrue(config.hasPath("webforj"));
+  }
+
+  @Test
+  void shouldBuildConfigWithBasicProperties() {
+    properties.setEntry("com.example.MyApp");
+    properties.setDebug(true);
+    properties.setComponents("https://cdn.example.com/components");
+    properties.setLocale("de-DE");
+
+    Config config = WebforjConfigBuilder.buildConfig(properties);
+
+    assertEquals("com.example.MyApp", config.getString("webforj.entry"));
+    assertTrue(config.getBoolean("webforj.debug"));
+    assertEquals("https://cdn.example.com/components", config.getString("webforj.components"));
+    assertEquals("de-DE", config.getString("webforj.locale"));
+  }
+
+  @Test
+  void shouldBuildConfigWithStringTable() {
+    Map<String, String> stringTable = new HashMap<>();
+    stringTable.put("app.title", "Test Application");
+    stringTable.put("app.version", "2.0.0");
+    properties.setStringTable(stringTable);
+
+    Config config = WebforjConfigBuilder.buildConfig(properties);
+
+    assertEquals("Test Application", config.getString("webforj.stringTable.app.title"));
+    assertEquals("2.0.0", config.getString("webforj.stringTable.app.version"));
+  }
+
+  @Test
+  void shouldBuildConfigWithFileUpload() {
+    SpringConfigurationProperties.FileUpload fileUpload =
+        new SpringConfigurationProperties.FileUpload();
+    fileUpload.setAccept(Arrays.asList("image/jpeg", "image/png"));
+    fileUpload.setMaxSize(5242880L);
+    properties.setFileUpload(fileUpload);
+
+    Config config = WebforjConfigBuilder.buildConfig(properties);
+
+    assertEquals(2, config.getStringList("webforj.fileUpload.accept").size());
+    assertTrue(config.getStringList("webforj.fileUpload.accept").contains("image/jpeg"));
+    assertEquals(5242880L, config.getLong("webforj.fileUpload.maxSize"));
+  }
+
+  @Test
+  void shouldBuildConfigWithAssetsProperties() {
+    properties.setQuiet(true);
+    properties.setAssetsCacheControl("max-age=3600, public");
+    properties.setAssetsExt(".html");
+    properties.setIconsDir("icons/");
+
+    Config config = WebforjConfigBuilder.buildConfig(properties);
+
+    assertTrue(config.getBoolean("webforj.quiet"));
+    assertEquals("max-age=3600, public", config.getString("webforj.assetsCacheControl"));
+    assertEquals(".html", config.getString("webforj.assetsExt"));
+    assertEquals("icons/", config.getString("webforj.iconsDir"));
+  }
+}


### PR DESCRIPTION
| Property | Type | Description |
|----------|------|-------------|
| `webforj.entry` | String | Fully qualified class name of the application entry point (extends `com.webforj.App`) |
| `webforj.debug` | Boolean | Enable debug mode with additional console output and browser exception display |
| `webforj.components` | String | Base path for loading DWC components (e.g., CDN URL) |
| `webforj.locale` | String | Application locale for language, region, date/time/number formatting |
| `webforj.quiet` | Boolean | Disable the loading image during application startup |
| `webforj.reloadOnServerError` | Boolean | Auto-reload page on server errors during hot redeploy (development only) |
| `webforj.clientHeartbeatRate` | String | Interval for client-server heartbeat (e.g., `8s` for dev, `50s`+ for prod) |
| `webforj.sessionTimeout` | Integer | Session timeout duration in seconds |
| `webforj.assetsDir` | String | Route name for serving static files (physical folder remains `static`) |
| `webforj.assetsCacheControl` | String | Cache-Control header for static resources (e.g., `max-age=3600, public`) |
| `webforj.assetsExt` | String | Default file extension for static files |
| `webforj.assetsIndex` | String | Default file served for directory requests (e.g., `index.html`) |
| `webforj.iconsDir` | String | URL endpoint for icons directory (default serves from `resources/icons/`) |
| `webforj.stringTable.<key>` | Map<String,String> | Key-value pairs for application strings |
| `webforj.fileUpload.accept` | List<String> | Allowed file types for uploads (e.g., `image/*`, `application/pdf`, `*.txt`) |
| `webforj.fileUpload.maxSize` | Long | Maximum file size for uploads in bytes |
| `webforj.license.cfg` | String | Path to the license configuration directory |
| `webforj.license.startupTimeout` | Integer | License startup timeout in seconds |
| `webforj.servlets[n].className` | String | Fully qualified class name of the servlet |
| `webforj.servlets[n].name` | String | Servlet name (uses class name if not specified) |
| `webforj.servlets[n].config.<key>` | Map<String,String> | Servlet initialization parameters |