### PR TITLE
feat: add Router `Activate` lifecycle event for cached component reactivation

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/router/Router.java
+++ b/webforj-foundation/src/main/java/com/webforj/router/Router.java
@@ -10,6 +10,7 @@ import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.environment.ObjectTable;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.concern.HasFrameTitle;
+import com.webforj.router.event.ActivateEvent;
 import com.webforj.router.event.DidEnterEvent;
 import com.webforj.router.event.DidLeaveEvent;
 import com.webforj.router.event.NavigateEvent;
@@ -589,6 +590,31 @@ public class Router {
    */
   public ListenerRegistration<DidLeaveEvent> onDidLeave(EventListener<DidLeaveEvent> listener) {
     return addDidLeaveListener(listener);
+  }
+
+  /**
+   * Adds an {@link ActivateEvent} listener for the component.
+   *
+   * @param listener the event listener to be added
+   * @return A registration object for removing the event listener
+   *
+   * @since 25.03
+   */
+  public ListenerRegistration<ActivateEvent> addActivateListener(
+      EventListener<ActivateEvent> listener) {
+    return getEventDispatcher().addListener(ActivateEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addActivateListener(EventListener)}.
+   *
+   * @param listener the event listener to be added
+   * @return A registration object for removing the event listener
+   *
+   * @since 25.03
+   */
+  public ListenerRegistration<ActivateEvent> onActivate(EventListener<ActivateEvent> listener) {
+    return addActivateListener(listener);
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/router/event/ActivateEvent.java
+++ b/webforj-foundation/src/main/java/com/webforj/router/event/ActivateEvent.java
@@ -1,0 +1,24 @@
+package com.webforj.router.event;
+
+import com.webforj.router.NavigationContext;
+
+/**
+ * {@code ActivateEvent} is an event object which is fired when the router activates (reuses) a
+ * cached component instead of creating a new one.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ *
+ * @see DidEnterEvent
+ */
+public class ActivateEvent extends RouteEvent {
+
+  /**
+   * Creates a new {@code ActivateEvent} instance with the given {@code NavigationContext}.
+   *
+   * @param context the navigation context
+   */
+  public ActivateEvent(NavigationContext context) {
+    super(context);
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/router/observer/ActivateObserver.java
+++ b/webforj-foundation/src/main/java/com/webforj/router/observer/ActivateObserver.java
@@ -1,0 +1,25 @@
+package com.webforj.router.observer;
+
+import com.webforj.router.event.ActivateEvent;
+import com.webforj.router.history.ParametersBag;
+
+/**
+ * {@code ActivateObserver} is an interface that is used to observe when a cached route component is
+ * activated (reused) by the router.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ *
+ * @see ActivateEvent
+ */
+@FunctionalInterface
+public interface ActivateObserver {
+
+  /**
+   * This method is called when a cached route component is activated (reused).
+   *
+   * @param event the event object
+   * @param parameters the route parameters bag
+   */
+  void onActivate(ActivateEvent event, ParametersBag parameters);
+}

--- a/webforj-foundation/src/main/java/com/webforj/router/observer/RouteRendererObserver.java
+++ b/webforj-foundation/src/main/java/com/webforj/router/observer/RouteRendererObserver.java
@@ -43,7 +43,12 @@ public interface RouteRendererObserver {
     /**
      * After the component has been destroyed.
      */
-    AFTER_DESTROY
+    AFTER_DESTROY,
+
+    /**
+     * When a cached component is activated (reused).
+     */
+    ACTIVATE
   }
 
   /**

--- a/webforj-foundation/src/test/java/com/webforj/router/RouteRendererTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/router/RouteRendererTest.java
@@ -373,6 +373,29 @@ class RouteRendererTest {
         });
       });
     }
+
+    @Test
+    void shouldInvokeLifecycleObserversActivate() {
+      routeRegistry.register("/test", TestComponent.class);
+      routeRegistry.register("/contact", ContactView.class);
+
+      routeRenderer.render(TestComponent.class);
+
+      AtomicBoolean observerCalled = new AtomicBoolean(false);
+      routeRenderer.addObserver((component, event, context, cb) -> {
+        if (event == RouteRendererObserver.LifecycleEvent.ACTIVATE) {
+          observerCalled.set(true);
+        }
+        cb.accept(true);
+      });
+
+      // Navigate away then back to trigger ACTIVATE
+      routeRenderer.render(ContactView.class);
+      routeRenderer.render(TestComponent.class, result -> {
+        assertTrue(observerCalled.get());
+        assertTrue(result.isPresent());
+      });
+    }
   }
 
   @NodeName("test-component")


### PR DESCRIPTION
Introduces `Activate`  event that fires when navigating to the same route with different parameters, allowing cached components to refresh their data without being recreated. Includes ActivateObserver interface and global event listeners.


```java

@Route(value = "/:counter?", outlet = ParentView.class)
public class CounterView extends Composite<FlexLayout> implements ActivateObserver, DidEnterObserver {

  private int counter = 0;
  private FlexLayout self = getBoundComponent();
  private Button btn = new Button("Increment Counter", ButtonTheme.PRIMARY);
  private Paragraph p = new Paragraph();

  public CounterView() {
    self.setDirection(FlexDirection.COLUMN);
    self.setMaxWidth(300);
    self.setStyle("margin", "1em auto");

    btn.onClick(e -> {
      Router.getCurrent().navigate(CounterView.class, ParametersBag.of(
          String.format("counter=%d", ++counter)));
    });

    self.add(btn, p);
  }

  // Called only once when the view is first entered
  @Override
  public void onDidEnter(DidEnterEvent ev, ParametersBag params) {
    console().log("CounterView did enter with params", true);
    updateText(params);
  }

  // Called every time the view is activated, routed by the router
  @Override
  public void onActivate(ActivateEvent ev, ParametersBag params) {
    console().log("CounterView activated with params", true);
    updateText(params);
  }

  private void updateText(ParametersBag params) {
    counter = params.getInt("counter").orElse(0);
    p.setText("Counter: " + counter);
  }
}
```