### PR TITLE
feat: add Spring MVC integration for root path mapping

### DIFF
--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/ServletMappingCondition.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/ServletMappingCondition.java
@@ -1,0 +1,65 @@
+package com.webforj.spring;
+
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition that evaluates the webforJ servlet mapping configuration.
+ *
+ * <p>
+ * This condition checks if webforJ is configured with a root context mapping ({@code /*}). When
+ * this condition is met, the application enables Spring MVC integration mode where
+ * {@code DispatcherServlet} acts as the primary request handler and selectively forwards requests
+ * to the webforJ servlet based on URL patterns.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+public class ServletMappingCondition implements Condition {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    Environment env = context.getEnvironment();
+
+    // Use Binder to properly bind properties with relaxed naming
+    // (supports both camelCase and kebab-case)
+    Binder binder = Binder.get(env);
+    SpringConfigurationProperties properties =
+        binder.bind("webforj", Bindable.of(SpringConfigurationProperties.class))
+            .orElseGet(SpringConfigurationProperties::new);
+
+    String mapping = properties.getServletMapping();
+    return isRootMapping(mapping);
+  }
+
+  /**
+   * Returns {@code true} if {@code mapping} represents the root mapping.
+   *
+   * <p>
+   * The mapping is considered a root mapping if it's {@code /*} or becomes empty after removing
+   * trailing slashes and wildcards. This is controlled via the {@code webforj.servletMapping}
+   * property value, which defaults to {@code /*}.
+   * </p>
+   *
+   * @param mapping the mapping string to check
+   * @return {@code true} if {@code mapping} is the root mapping, {@code false} otherwise
+   */
+  static boolean isRootMapping(String mapping) {
+    if (mapping == null) {
+      // Default is "/*"
+      return true;
+    }
+
+    // Check if it's exactly "/*" or becomes empty after removing trailing slashes/wildcards
+    String trimmed = mapping.trim();
+    return "/*".equals(trimmed) || trimmed.replaceAll("(/\\**)?$", "").isEmpty();
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
@@ -202,6 +202,26 @@ public class SpringConfigurationProperties {
    */
   private License license = new License();
 
+  /**
+   * URL patterns that should not be handled by webforJ when mapped to root.
+   *
+   * <p>
+   * When webforJ is mapped to the root context ({@code /*}), these URL patterns will be excluded
+   * from webforJ handling and can be handled by Spring MVC controllers instead. This allows REST
+   * endpoints and other Spring MVC mappings to coexist with webforJ routes.
+   * </p>
+   *
+   * <p>
+   * Example patterns:
+   * <ul>
+   * <li>{@code /api/**} - All paths under /api</li>
+   * <li>{@code /actuator/**} - Spring Boot actuator endpoints</li>
+   * </ul>
+   * </p>
+   *
+   * @since 25.03
+   */
+  private List<String> excludeUrls = new ArrayList<>();
 
   /**
    * Sets the URL mapping for the Webforj servlet.
@@ -525,6 +545,24 @@ public class SpringConfigurationProperties {
    */
   public void setLicense(License license) {
     this.license = license;
+  }
+
+  /**
+   * Gets the excluded URL patterns.
+   *
+   * @return the list of URL patterns to exclude from webforJ handling
+   */
+  public List<String> getExcludeUrls() {
+    return excludeUrls;
+  }
+
+  /**
+   * Sets the excluded URL patterns.
+   *
+   * @param excludeUrls the list of URL patterns to exclude from webforJ handling
+   */
+  public void setExcludeUrls(List<String> excludeUrls) {
+    this.excludeUrls = excludeUrls;
   }
 
   /**

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjRequestHandler.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjRequestHandler.java
@@ -1,0 +1,102 @@
+package com.webforj.spring;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.servlet.mvc.Controller;
+import org.springframework.web.util.UrlPathHelper;
+
+/**
+ * Handler for routing requests between Spring MVC and webforJ.
+ *
+ * <p>
+ * This handler implements the logic to determine whether a request should be handled by Spring MVC
+ * controllers or forwarded to the webforJ servlet. It checks incoming requests against the
+ * configured excluded URL patterns.
+ * </p>
+ *
+ * <p>
+ * Requests matching excluded URL patterns are handled by Spring MVC, while all other requests are
+ * forwarded to the webforJ servlet.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+class WebforjRequestHandler extends SimpleUrlHandlerMapping {
+  private final List<String> excludeUrls;
+  private final PathMatcher pathMatcher = new AntPathMatcher();
+  private final UrlPathHelper urlPathHelper = new UrlPathHelper();
+  private static final Logger logger = System.getLogger(WebforjRequestHandler.class.getName());
+
+  /**
+   * Constructs a new request handler.
+   *
+   * @param excludeUrls URL patterns to exclude from webforJ handling
+   * @param forwardingController the controller that forwards to webforJ servlet
+   * @param resourceHandlerMapping Spring's resource handler mapping
+   */
+  public WebforjRequestHandler(List<String> excludeUrls, Controller forwardingController,
+      HandlerMapping resourceHandlerMapping) {
+    this.excludeUrls = excludeUrls;
+
+    // Set HIGH priority to intercept requests before RequestMappingHandlerMapping
+    // RequestMappingHandlerMapping typically has order 0, so we use -1
+    setOrder(-1);
+
+    // Map all URLs to the forwarding controller by default
+    setUrlMap(Collections.singletonMap("/**", forwardingController));
+
+    logger.log(Level.DEBUG, "Initialized WebforjRequestHandler with "
+        + (excludeUrls != null ? excludeUrls.size() : 0) + " excluded URL patterns");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * Checks if the request matches any excluded URL patterns. If it does, returns {@code null} to
+   * let Spring MVC handle it. Otherwise, forwards the request to the webforJ servlet.
+   * </p>
+   */
+  @Override
+  protected Object getHandlerInternal(HttpServletRequest request) throws Exception {
+    String requestPath = urlPathHelper.getPathWithinApplication(request);
+
+    if (isPathExcluded(requestPath)) {
+      logger.log(Level.TRACE,
+          "Request to " + requestPath + " matches excluded pattern, " + "delegating to Spring MVC");
+      return null; // Let Spring MVC handle it
+    }
+
+    logger.log(Level.TRACE, "Request to " + requestPath + " will be forwarded to webforJ");
+
+    // Forward to webforJ servlet
+    return super.getHandlerInternal(request);
+  }
+
+  /**
+   * Checks if a request path matches any of the excluded URL patterns. This method is
+   * package-private for testing purposes.
+   *
+   * @param requestPath the path to check
+   * @return true if the path is excluded, false otherwise
+   */
+  boolean isPathExcluded(String requestPath) {
+    if (excludeUrls != null && !excludeUrls.isEmpty()) {
+      for (String pattern : excludeUrls) {
+        if (pathMatcher.match(pattern, requestPath)) {
+          logger.log(Level.TRACE, "Path " + requestPath + " matches excluded pattern " + pattern);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjServletConfiguration.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjServletConfiguration.java
@@ -1,0 +1,91 @@
+package com.webforj.spring;
+
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.mvc.Controller;
+import org.springframework.web.servlet.mvc.ServletForwardingController;
+
+/**
+ * Configuration for webforJ servlet when mapped to the root context.
+ *
+ * <p>
+ * This configuration is active only when webforJ is mapped to {@code /*}. It enables Spring MVC
+ * integration by registering the webforJ servlet at an internal path ({@code /webforjServlet/*})
+ * and setting up a request handler that manages forwarding between Spring MVC and webforJ.
+ * </p>
+ *
+ * <p>
+ * The handler forwards all HTTP methods (GET, POST, PUT, DELETE, etc.) to webforJ, except for URLs
+ * matching patterns in {@code webforj.exclude-urls}, which are handled by Spring MVC.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+@Configuration
+@Conditional(ServletMappingCondition.class)
+public class WebforjServletConfiguration {
+  private static final Logger logger =
+      System.getLogger(WebforjServletConfiguration.class.getName());
+
+  /**
+   * The internal servlet path where webforJ servlet is registered when root mapping is used.
+   */
+  public static final String WEBFORJ_SERVLET_MAPPING = "/webforjServlet/*";
+
+  /**
+   * The name of the webforJ servlet used for forwarding.
+   */
+  public static final String WEBFORJ_SERVLET_NAME = "webforjServlet";
+
+  /**
+   * Creates a request handler that manages forwarding to webforJ servlet.
+   *
+   * <p>
+   * This handler checks incoming requests against the excluded URL patterns defined in
+   * {@code webforj.exclude-urls}. Requests matching excluded patterns are passed to Spring MVC
+   * controllers, while all other requests (regardless of HTTP method) are forwarded to the webforJ
+   * servlet.
+   * </p>
+   *
+   * @param properties the Spring configuration properties containing excluded URLs
+   * @param resourceHandlerMapping the Spring resource handler mapping, if available
+   *
+   * @return the configured request handler
+   */
+  // @formatter:off
+  @Bean
+  WebforjRequestHandler webforjRequestHandler(
+      SpringConfigurationProperties properties,
+      @Autowired(required = false)
+      @Qualifier("resourceHandlerMapping")
+      HandlerMapping resourceHandlerMapping
+  ) {
+    // @formatter:on
+
+    logger.log(Level.DEBUG, "Creating webforJ request handler for root mapping");
+
+    return new WebforjRequestHandler(properties.getExcludeUrls(), webforjForwardingController(),
+        resourceHandlerMapping);
+  }
+
+  /**
+   * Creates a forwarding controller that forwards requests to the webforJ servlet.
+   *
+   * @return the configured forwarding controller
+   */
+  @Bean
+  Controller webforjForwardingController() {
+    ServletForwardingController controller = new ServletForwardingController();
+    controller.setServletName(WEBFORJ_SERVLET_NAME);
+    logger.log(Level.DEBUG, "Created forwarding controller for servlet: " + WEBFORJ_SERVLET_NAME);
+
+    return controller;
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/scope/annotation/EnvironmentScope.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/scope/annotation/EnvironmentScope.java
@@ -12,8 +12,8 @@ import org.springframework.context.annotation.ScopedProxyMode;
  * Indicates that a bean should be scoped to the webforJ Environment lifecycle.
  *
  * <p>
- * Beans with this scope will be created once per browser window or tab and destroyed when the 
- * Environment is cleaned up (when the user closes the tab or the session expires). Each browser 
+ * Beans with this scope will be created once per browser window or tab and destroyed when the
+ * Environment is cleaned up (when the user closes the tab or the session expires). Each browser
  * window or tab receives its own isolated instance of environment-scoped beans.
  * </p>
  *

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/ServletMappingConditionTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/ServletMappingConditionTest.java
@@ -1,0 +1,49 @@
+package com.webforj.spring;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.mock.env.MockEnvironment;
+
+@ExtendWith(MockitoExtension.class)
+class ServletMappingConditionTest {
+
+  @Mock
+  private ConditionContext conditionContext;
+
+  @Mock
+  private AnnotatedTypeMetadata metadata;
+
+  private MockEnvironment environment;
+  private ServletMappingCondition condition;
+
+  @BeforeEach
+  void setUp() {
+    condition = new ServletMappingCondition();
+    environment = new MockEnvironment();
+  }
+
+  @Test
+  void shouldMatchWhenMappingIsRootDefault() {
+    when(conditionContext.getEnvironment()).thenReturn(environment);
+    environment.setProperty("webforj.servletMapping", "/*");
+
+    assertTrue(condition.matches(conditionContext, metadata));
+  }
+
+  @Test
+  void shouldNotMatchWhenMappingIsNotRoot() {
+    when(conditionContext.getEnvironment()).thenReturn(environment);
+    environment.setProperty("webforj.servletMapping", "/app/*");
+
+    assertFalse(condition.matches(conditionContext, metadata));
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringAutoConfigurationTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringAutoConfigurationTest.java
@@ -37,7 +37,7 @@ class SpringAutoConfigurationTest {
   class ServletRegistration {
 
     @Test
-    void shouldCreateServletRegistrationBeanWithDefaultMapping() {
+    void shouldCreateServletRegistrationBeanWithRootMapping() {
       when(properties.getServletMapping()).thenReturn("/*");
 
       try (MockedStatic<WebforjServlet> mockedServlet = mockStatic(WebforjServlet.class)) {
@@ -47,6 +47,10 @@ class SpringAutoConfigurationTest {
         assertNotNull(registrationBean);
         assertNotNull(registrationBean.getServlet());
         assertEquals(WebforjServlet.class, registrationBean.getServlet().getClass());
+
+        // Should use servlet name for forwarding
+        assertEquals(WebforjServletConfiguration.WEBFORJ_SERVLET_NAME,
+            registrationBean.getServletName());
 
         // Verify setConfig was called with the provided config
         mockedServlet.verify(() -> WebforjServlet.setConfig(config), times(1));
@@ -65,6 +69,10 @@ class SpringAutoConfigurationTest {
         assertNotNull(registrationBean);
         assertNotNull(registrationBean.getServlet());
         assertEquals(WebforjServlet.class, registrationBean.getServlet().getClass());
+
+        // Should still use servlet name for consistency
+        assertEquals(WebforjServletConfiguration.WEBFORJ_SERVLET_NAME,
+            registrationBean.getServletName());
 
         // Verify setConfig was called with the provided config
         mockedServlet.verify(() -> WebforjServlet.setConfig(config), times(1));

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigurationPropertiesTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringConfigurationPropertiesTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -185,5 +186,16 @@ class SpringConfigurationPropertiesTest {
   void shouldInitializeEmptyServletsList() {
     assertNotNull(properties.getServlets());
     assertTrue(properties.getServlets().isEmpty());
+  }
+
+  @Test
+  void shouldSetExcludeUrls() {
+    List<String> excludeUrls = Arrays.asList("/api/**", "/login");
+
+    properties.setExcludeUrls(excludeUrls);
+    assertNotNull(properties.getExcludeUrls());
+    assertEquals(2, properties.getExcludeUrls().size());
+    assertTrue(properties.getExcludeUrls().contains("/api/**"));
+    assertTrue(properties.getExcludeUrls().contains("/login"));
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjRequestHandlerTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjRequestHandlerTest.java
@@ -1,0 +1,78 @@
+package com.webforj.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.Controller;
+
+class WebforjRequestHandlerTest {
+
+  @Test
+  void shouldExcludePathsWithWildcardPatterns() {
+    Controller mockController = mock(Controller.class);
+    WebforjRequestHandler handler =
+        new WebforjRequestHandler(Arrays.asList("/api/**", "/static/**"), mockController, null);
+
+    // Should exclude paths matching /api/**
+    assertTrue(handler.isPathExcluded("/api/users"));
+    assertTrue(handler.isPathExcluded("/api/v1/products"));
+    assertTrue(handler.isPathExcluded("/api/"));
+    assertTrue(handler.isPathExcluded("/api"));
+
+    // Should exclude paths matching /static/**
+    assertTrue(handler.isPathExcluded("/static/css/style.css"));
+    assertTrue(handler.isPathExcluded("/static/js/app.js"));
+    assertTrue(handler.isPathExcluded("/static/"));
+
+    // Should NOT exclude non-matching paths
+    assertFalse(handler.isPathExcluded("/app/page"));
+    assertFalse(handler.isPathExcluded("/"));
+    assertFalse(handler.isPathExcluded("/login"));
+  }
+
+  @Test
+  void shouldExcludePathsWithExactPatterns() {
+    Controller mockController = mock(Controller.class);
+    WebforjRequestHandler handler = new WebforjRequestHandler(
+        Arrays.asList("/login", "/logout", "/health"), mockController, null);
+
+    // Should exclude exact matches
+    assertTrue(handler.isPathExcluded("/login"));
+    assertTrue(handler.isPathExcluded("/logout"));
+    assertTrue(handler.isPathExcluded("/health"));
+
+    // Should NOT exclude partial matches
+    assertFalse(handler.isPathExcluded("/login/page"));
+    assertFalse(handler.isPathExcluded("/healthcare"));
+    assertFalse(handler.isPathExcluded("/"));
+  }
+
+  @Test
+  void shouldExcludePathsWithComplexPatterns() {
+    Controller mockController = mock(Controller.class);
+    WebforjRequestHandler handler = new WebforjRequestHandler(
+        Arrays.asList("/api/*/users", "/files/**/*.pdf", "/admin/**"), mockController, null);
+
+    // Single wildcard
+    assertTrue(handler.isPathExcluded("/api/v1/users"));
+    assertFalse(handler.isPathExcluded("/api/v1/v2/users"));
+
+    // Double wildcard
+    assertTrue(handler.isPathExcluded("/files/doc.pdf"));
+    assertTrue(handler.isPathExcluded("/files/path/to/doc.pdf"));
+    assertFalse(handler.isPathExcluded("/files/doc.txt"));
+  }
+
+  @Test
+  void shouldHaveHighPriorityToInterceptRequests() {
+    Controller mockController = mock(Controller.class);
+    WebforjRequestHandler handler = new WebforjRequestHandler(null, mockController, null);
+
+    // The handler should have high priority (-1) to intercept before Spring MVC
+    assertEquals(-1, handler.getOrder());
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjServletConfigurationTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjServletConfigurationTest.java
@@ -1,0 +1,48 @@
+package com.webforj.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.mvc.Controller;
+import org.springframework.web.servlet.mvc.ServletForwardingController;
+
+class WebforjServletConfigurationTest {
+
+  private WebforjServletConfiguration configuration;
+  private SpringConfigurationProperties properties;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new WebforjServletConfiguration();
+    properties = new SpringConfigurationProperties();
+  }
+
+  @Test
+  void shouldCreateWebforjRequestHandler() {
+    List<String> excludeUrls = Arrays.asList("/api/**", "/static/**");
+    properties.setExcludeUrls(excludeUrls);
+    HandlerMapping resourceHandlerMapping = mock(HandlerMapping.class);
+
+    WebforjRequestHandler handler =
+        configuration.webforjRequestHandler(properties, resourceHandlerMapping);
+
+    assertNotNull(handler);
+    assertEquals(-1, handler.getOrder());
+    assertTrue(handler.isPathExcluded("/api/test"));
+    assertTrue(handler.isPathExcluded("/static/css/style.css"));
+  }
+
+  @Test
+  void shouldCreateWebforjForwardingController() {
+    Controller controller = configuration.webforjForwardingController();
+    assertNotNull(controller);
+    assertTrue(controller instanceof ServletForwardingController);
+  }
+}


### PR DESCRIPTION
Enables webforJ applications to work seamlessly with Spring MVC when deployed at the root path ("/"). Instead of registering the servlet directly at root, which conflicts with Spring's DispatcherServlet, the servlet is registered at an internal path and requests are forwarded through Spring MVC's handler chain.

This maintains full compatibility with Spring features like filters, interceptors, and other handler mappings while preserving webforJ's routing capabilities. Applications can now leverage both Spring MVC endpoints and webforJ routes in the same application without conflicts.