### PR TITLE
feat: provide API to access `HttpSession.Accessor` and provide `SessionObjectTable`

### DIFF
--- a/webforj-components/webforj-toast/pom.xml
+++ b/webforj-components/webforj-toast/pom.xml
@@ -36,6 +36,12 @@
       <version>5.19.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/webforj-foundation/pom.xml
+++ b/webforj-foundation/pom.xml
@@ -37,6 +37,17 @@
       <artifactId>webforj-engine</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.webforj</groupId>
       <artifactId>webforj-dispatcher</artifactId>
       <version>${project.version}</version>
@@ -54,18 +65,6 @@
     <dependency>
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.typesafe</groupId>
-      <artifactId>config</artifactId>
-    </dependency>
-
-    <!-- Override Engine -->
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.1.0</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/webforj-foundation/pom.xml
+++ b/webforj-foundation/pom.xml
@@ -60,6 +60,14 @@
       <artifactId>config</artifactId>
     </dependency>
 
+    <!-- Override Engine -->
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/webforj-foundation/src/main/java/com/webforj/Environment.java
+++ b/webforj-foundation/src/main/java/com/webforj/Environment.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -393,24 +394,25 @@ public final class Environment {
   }
 
   /**
-   * Returns the HttpSession.Accessor if available.
+   * Returns the {@link HttpSession.Accessor} for the current environment, if available.
    *
-   * @return the HttpSession.Accessor if available, null otherwise
+   * @return an Optional containing the HttpSession.Accessor if available, empty otherwise
    * @since 25.03
    */
-  public HttpSession.Accessor getSessionAccessor() {
+  public Optional<HttpSession.Accessor> getSessionAccessor() {
     try {
-      Map<String, Object> channelData = api.getChannelData();
+      Map<String, Object> channelData = getBBjAPI().getChannelData();
       if (channelData != null) {
         Object accessor = channelData.get("session.accessor");
         if (accessor instanceof HttpSession.Accessor) {
-          return (HttpSession.Accessor) accessor;
+          return Optional.of((HttpSession.Accessor) accessor);
         }
       }
     } catch (BBjException e) {
       logger.log(Level.DEBUG, "Failed to get channel data: {0}", e.getMessage());
     }
-    return null;
+
+    return Optional.empty();
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/Environment.java
+++ b/webforj-foundation/src/main/java/com/webforj/Environment.java
@@ -13,6 +13,7 @@ import com.webforj.environment.StringTable;
 import com.webforj.error.ErrorHandler;
 import com.webforj.error.GlobalErrorHandler;
 import com.webforj.exceptions.WebforjWebManagerException;
+import jakarta.servlet.http.HttpSession;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.lang.reflect.InvocationTargetException;
@@ -389,6 +390,27 @@ public final class Environment {
    */
   public BBjSysGui getSysGui() {
     return this.sysgui;
+  }
+
+  /**
+   * Returns the HttpSession.Accessor if available.
+   *
+   * @return the HttpSession.Accessor if available, null otherwise
+   * @since 25.03
+   */
+  public HttpSession.Accessor getSessionAccessor() {
+    try {
+      Map<String, Object> channelData = api.getChannelData();
+      if (channelData != null) {
+        Object accessor = channelData.get("session.accessor");
+        if (accessor instanceof HttpSession.Accessor) {
+          return (HttpSession.Accessor) accessor;
+        }
+      }
+    } catch (BBjException e) {
+      logger.log(Level.DEBUG, "Failed to get channel data: {0}", e.getMessage());
+    }
+    return null;
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/Environment.java
+++ b/webforj-foundation/src/main/java/com/webforj/Environment.java
@@ -404,8 +404,8 @@ public final class Environment {
       Map<String, Object> channelData = getBBjAPI().getChannelData();
       if (channelData != null) {
         Object accessor = channelData.get("session.accessor");
-        if (accessor instanceof HttpSession.Accessor) {
-          return Optional.of((HttpSession.Accessor) accessor);
+        if (accessor instanceof HttpSession.Accessor sessionAccessor) {
+          return Optional.of(sessionAccessor);
         }
       }
     } catch (BBjException e) {

--- a/webforj-foundation/src/main/java/com/webforj/environment/SessionObjectTable.java
+++ b/webforj-foundation/src/main/java/com/webforj/environment/SessionObjectTable.java
@@ -2,6 +2,7 @@ package com.webforj.environment;
 
 import com.webforj.Environment;
 import jakarta.servlet.http.HttpSession;
+import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -88,6 +89,23 @@ public final class SessionObjectTable {
   public static void clear(String key) {
     Optional<HttpSession.Accessor> accessor = getAccessor();
     accessor.ifPresent(a -> a.access(session -> session.removeAttribute(key)));
+  }
+
+  /**
+   * Returns the number of key-value mappings in the session.
+   *
+   * @return the number of key-value mappings in the session
+   */
+  public static int size() {
+    Optional<HttpSession.Accessor> accessor = getAccessor();
+    if (accessor.isEmpty()) {
+      return 0;
+    }
+
+    AtomicReference<Integer> sizeRef = new AtomicReference<>(0);
+    accessor.get()
+        .access(session -> sizeRef.set(Collections.list(session.getAttributeNames()).size()));
+    return sizeRef.get();
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/environment/SessionObjectTable.java
+++ b/webforj-foundation/src/main/java/com/webforj/environment/SessionObjectTable.java
@@ -1,0 +1,132 @@
+package com.webforj.environment;
+
+import com.webforj.Environment;
+import jakarta.servlet.http.HttpSession;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Provides access to the HttpSession attributes.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+public final class SessionObjectTable {
+
+  private SessionObjectTable() {}
+
+  /**
+   * Places a key/value pair into the session.
+   *
+   * @param key the attribute name
+   * @param value the attribute value to set
+   *
+   * @return the value that was set
+   * @throws IllegalStateException if no session accessor is available
+   */
+  public static Object put(String key, Object value) {
+    HttpSession.Accessor accessor = getAccessor();
+    if (accessor == null) {
+      throw new IllegalStateException("No session available. Session is only available when "
+          + "running in a servlet environment with Jakarta Servlet 6.1+ support.");
+    }
+
+    accessor.access(session -> session.setAttribute(key, value));
+    return value;
+  }
+
+  /**
+   * Access a value in the session.
+   *
+   * @param key the attribute name to access
+   * @return the attribute value
+   *
+   * @throws NoSuchElementException if the session attribute does not exist
+   * @throws IllegalStateException if no session accessor is available
+   */
+  public static Object get(String key) {
+    HttpSession.Accessor accessor = getAccessor();
+    if (accessor == null) {
+      throw new IllegalStateException("No session available. Session is only available when "
+          + "running in a servlet environment with Jakarta Servlet 6.1+ support.");
+    }
+
+    AtomicReference<Object> valueRef = new AtomicReference<>();
+    accessor.access(session -> valueRef.set(session.getAttribute(key)));
+
+    Object value = valueRef.get();
+    if (value == null) {
+      throw new NoSuchElementException("Session attribute '" + key + "' does not exist!");
+    }
+
+    return value;
+  }
+
+  /**
+   * Checks if the session contains an attribute.
+   *
+   * @param key the attribute name to check
+   * @return true if the session contains the attribute, false otherwise
+   */
+  public static boolean contains(String key) {
+    HttpSession.Accessor accessor = getAccessor();
+    if (accessor == null) {
+      return false;
+    }
+
+    AtomicReference<Boolean> existsRef = new AtomicReference<>(false);
+    accessor.access(session -> existsRef.set(session.getAttribute(key) != null));
+    return existsRef.get();
+  }
+
+  /**
+   * Removes an attribute from the session.
+   *
+   * @param key the attribute name to remove
+   */
+  public static void clear(String key) {
+    HttpSession.Accessor accessor = getAccessor();
+    if (accessor != null) {
+      accessor.access(session -> session.removeAttribute(key));
+    }
+  }
+
+  /**
+   * Returns the session ID if available.
+   *
+   * @return the session ID, or null if no session is available
+   */
+  public static String getSessionId() {
+    HttpSession.Accessor accessor = getAccessor();
+    if (accessor == null) {
+      return null;
+    }
+
+    AtomicReference<String> idRef = new AtomicReference<>();
+    accessor.access(session -> idRef.set(session.getId()));
+    return idRef.get();
+  }
+
+  /**
+   * Checks if a session is available.
+   *
+   * @return true if a session accessor is available, false otherwise
+   */
+  public static boolean isAvailable() {
+    return getAccessor() != null;
+  }
+
+  /**
+   * Gets the HttpSession.Accessor from the current Environment.
+   *
+   * @return the HttpSession.Accessor if available, null otherwise
+   */
+  private static HttpSession.Accessor getAccessor() {
+    Environment env = Environment.getCurrent();
+    if (env == null) {
+      return null;
+    }
+
+    return env.getSessionAccessor();
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/environment/SessionObjectTableTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/environment/SessionObjectTableTest.java
@@ -1,0 +1,171 @@
+package com.webforj.environment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.basis.bbj.proxies.BBjAPI;
+import com.basis.startup.type.BBjException;
+import com.webforj.Environment;
+import com.webforj.bridge.WebforjBBjBridge;
+import jakarta.servlet.http.HttpSession;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class SessionObjectTableTest {
+
+  private HttpSession mockSession;
+  private HttpSession.Accessor mockAccessor;
+  private BBjAPI mockApi;
+  private Map<String, Object> channelData;
+
+  private final String testKey = "testKey";
+  private final Object testValue = "testValue";
+  private final String nonExistentKey = "nonExistentKey";
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() throws BBjException {
+    mockSession = mock(HttpSession.class);
+    mockAccessor = mock(HttpSession.Accessor.class);
+    mockApi = mock(BBjAPI.class);
+    channelData = new HashMap<>();
+
+    // Setup the accessor to invoke the consumer with the mock session
+    doAnswer(invocation -> {
+      Consumer<HttpSession> consumer = invocation.getArgument(0);
+      consumer.accept(mockSession);
+      return null;
+    }).when(mockAccessor).access(any(Consumer.class));
+
+    // Setup channel data with the accessor
+    channelData.put("session.accessor", mockAccessor);
+    when(mockApi.getChannelData()).thenReturn(channelData);
+
+    // Initialize environment
+    Environment.init(mockApi, mock(WebforjBBjBridge.class), 0);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Environment.cleanup();
+  }
+
+  @Test
+  void shouldPutValue() {
+    Object result = SessionObjectTable.put(testKey, testValue);
+
+    assertEquals(testValue, result);
+
+    // Verify the session setAttribute was called
+    ArgumentCaptor<Consumer<HttpSession>> captor = ArgumentCaptor.forClass(Consumer.class);
+    verify(mockAccessor).access(captor.capture());
+    verify(mockSession).setAttribute(testKey, testValue);
+  }
+
+  @Test
+  void shouldGetValue() {
+    when(mockSession.getAttribute(testKey)).thenReturn(testValue);
+
+    Object actualValue = SessionObjectTable.get(testKey);
+
+    assertEquals(testValue, actualValue);
+    verify(mockSession).getAttribute(testKey);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenKeyNotFound() {
+    when(mockSession.getAttribute(nonExistentKey)).thenReturn(null);
+    assertThrows(NoSuchElementException.class, () -> SessionObjectTable.get(nonExistentKey));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenNoSessionAvailable() throws BBjException {
+    channelData.clear();
+
+    assertThrows(IllegalStateException.class, () -> SessionObjectTable.put(testKey, testValue));
+    assertThrows(IllegalStateException.class, () -> SessionObjectTable.get(testKey));
+  }
+
+  @Test
+  void shouldReturnTrueIfKeyExists() {
+    when(mockSession.getAttribute(testKey)).thenReturn(testValue);
+
+    assertTrue(SessionObjectTable.contains(testKey));
+    verify(mockSession).getAttribute(testKey);
+  }
+
+  @Test
+  void shouldReturnFalseIfKeyNotFound() {
+    when(mockSession.getAttribute(nonExistentKey)).thenReturn(null);
+
+    assertFalse(SessionObjectTable.contains(nonExistentKey));
+    verify(mockSession).getAttribute(nonExistentKey);
+  }
+
+  @Test
+  void shouldReturnFalseWhenNoSessionAvailable() throws BBjException {
+    channelData.clear();
+    assertFalse(SessionObjectTable.contains(testKey));
+  }
+
+  @Test
+  void shouldClearValueFromSession() {
+    SessionObjectTable.clear(testKey);
+
+    verify(mockAccessor).access(any(Consumer.class));
+    verify(mockSession).removeAttribute(testKey);
+  }
+
+  @Test
+  void shouldNotThrowWhenClearingWithNoSession() throws BBjException {
+    channelData.clear();
+    SessionObjectTable.clear(testKey);
+
+    verify(mockSession, never()).removeAttribute(testKey);
+  }
+
+  @Test
+  void shouldHandleNoEnvironment() {
+    Environment.cleanup();
+
+    assertThrows(IllegalStateException.class, () -> SessionObjectTable.put(testKey, testValue));
+    assertThrows(IllegalStateException.class, () -> SessionObjectTable.get(testKey));
+    assertFalse(SessionObjectTable.contains(testKey));
+
+    // clear should not throw
+    SessionObjectTable.clear(testKey);
+  }
+
+  @Test
+  void shouldHandleBBjException() throws BBjException {
+    when(mockApi.getChannelData()).thenThrow(new BBjException("Test exception", 0));
+
+    assertThrows(IllegalStateException.class, () -> SessionObjectTable.put(testKey, testValue));
+    assertThrows(IllegalStateException.class, () -> SessionObjectTable.get(testKey));
+    assertFalse(SessionObjectTable.contains(testKey));
+  }
+
+  @Test
+  void shouldHandleNonAccessorInChannelData() throws BBjException {
+    // Put something else in channel data instead of accessor
+    channelData.put("session.accessor", "not an accessor");
+
+    assertThrows(IllegalStateException.class, () -> SessionObjectTable.put(testKey, testValue));
+    assertThrows(IllegalStateException.class, () -> SessionObjectTable.get(testKey));
+    assertFalse(SessionObjectTable.contains(testKey));
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/environment/SessionObjectTableTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/environment/SessionObjectTableTest.java
@@ -71,6 +71,7 @@ class SessionObjectTableTest {
     assertEquals(testValue, result);
 
     // Verify the session setAttribute was called
+    @SuppressWarnings("unchecked")
     ArgumentCaptor<Consumer<HttpSession>> captor = ArgumentCaptor.forClass(Consumer.class);
     verify(mockAccessor).access(captor.capture());
     verify(mockSession).setAttribute(testKey, testValue);
@@ -122,6 +123,7 @@ class SessionObjectTableTest {
     assertFalse(SessionObjectTable.contains(testKey));
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void shouldClearValueFromSession() {
     SessionObjectTable.clear(testKey);
@@ -151,7 +153,7 @@ class SessionObjectTableTest {
   }
 
   @Test
-  void shouldHandleBBjException() throws BBjException {
+  void shouldHandleBbjException() throws BBjException {
     when(mockApi.getChannelData()).thenThrow(new BBjException("Test exception", 0));
 
     assertThrows(IllegalStateException.class, () -> SessionObjectTable.put(testKey, testValue));

--- a/webforj-foundation/src/test/java/com/webforj/environment/SessionObjectTableTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/environment/SessionObjectTableTest.java
@@ -16,7 +16,10 @@ import com.basis.startup.type.BBjException;
 import com.webforj.Environment;
 import com.webforj.bridge.WebforjBBjBridge;
 import jakarta.servlet.http.HttpSession;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
@@ -150,6 +153,42 @@ class SessionObjectTableTest {
 
     // clear should not throw
     SessionObjectTable.clear(testKey);
+  }
+
+  @Test
+  void shouldReturnCorrectSize() {
+    // Setup mock attribute names
+    List<String> attributeNames = new ArrayList<>();
+    when(mockSession.getAttributeNames())
+        .thenAnswer(invocation -> Collections.enumeration(attributeNames));
+
+    // Initially empty
+    assertEquals(0, SessionObjectTable.size());
+
+    // Add some items (we need to track them in our test list)
+    doAnswer(invocation -> {
+      String key = invocation.getArgument(0);
+      if (!attributeNames.contains(key)) {
+        attributeNames.add(key);
+      }
+      return null;
+    }).when(mockSession).setAttribute(any(String.class), any());
+
+    doAnswer(invocation -> {
+      String key = invocation.getArgument(0);
+      attributeNames.remove(key);
+      return null;
+    }).when(mockSession).removeAttribute(any(String.class));
+
+    SessionObjectTable.put("key1", "value1");
+    SessionObjectTable.put("key2", "value2");
+    SessionObjectTable.put("key3", "value3");
+
+    assertEquals(3, SessionObjectTable.size());
+
+    // Clear one item
+    SessionObjectTable.clear("key2");
+    assertEquals(2, SessionObjectTable.size());
   }
 
   @Test

--- a/webforj-spring/webforj-spring-integration/pom.xml
+++ b/webforj-spring/webforj-spring-integration/pom.xml
@@ -87,5 +87,11 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
webforJ applications can now access HTTP session data when running in Jakarta 
Servlet 6.1+ containers. Store and retrieve user-specific state across requests.

`SessionObjectTable` follows the `ObjectTable` pattern for consistent storage API.
