### PR TITLE
feat: add browser launcher for webforJ Spring Boot apps

### DIFF
--- a/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/browser/BrowserLauncher.java
+++ b/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/browser/BrowserLauncher.java
@@ -1,0 +1,118 @@
+package com.webforj.spring.devtools.browser;
+
+import java.awt.Desktop;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.net.InetAddress;
+import java.net.URI;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.web.context.WebServerInitializedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+
+/**
+ * Launches the OS browser when the application starts in development mode.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+public class BrowserLauncher {
+  private static final Logger LOG = System.getLogger(BrowserLauncher.class.getName());
+  private final Environment environment;
+  private Integer serverPort;
+  private static boolean browserOpened = false;
+
+  BrowserLauncher(Environment environment) {
+    this.environment = environment;
+  }
+
+  /**
+   * Sets the server port when the web server is initialized.
+   *
+   * @param event the web server initialized event
+   */
+  @EventListener
+  public void onWebServerInitialized(WebServerInitializedEvent event) {
+    this.serverPort = event.getWebServer().getPort();
+  }
+
+  /**
+   * Opens the browser when the application is ready.
+   *
+   * @param event the application ready event
+   */
+  @EventListener
+  public void onApplicationReady(ApplicationReadyEvent event) {
+    if (!environment.getProperty("webforj.devtools.browser.open", Boolean.class, false)) {
+      return;
+    }
+
+    // Check if browser was already opened for this application instance
+    if (browserOpened) {
+      LOG.log(Level.DEBUG, "Browser already opened for this application, skipping");
+      return;
+    }
+
+    String url = buildUrl();
+
+    try {
+      if (Desktop.isDesktopSupported()) {
+        Desktop desktop = Desktop.getDesktop();
+        if (desktop.isSupported(Desktop.Action.BROWSE)) {
+          desktop.browse(new URI(url));
+          browserOpened = true;
+          LOG.log(Level.INFO, "Opened browser at: {0}", url);
+        }
+      }
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Could not open browser", e);
+    }
+  }
+
+  String buildUrl() {
+    if (serverPort == null) {
+      serverPort = environment.getProperty("server.port", Integer.class, 8080);
+    }
+
+    // Get the servlet mapping from webforj configuration
+    String servletMapping = environment.getProperty("webforj.servlet-mapping", "/*");
+
+    // Build the URL path
+    String path = "";
+    if (!servletMapping.equals("/*")) {
+      // Remove the wildcard patterns
+      path = servletMapping.replace("/*", "").replace("*", "");
+      if (!path.startsWith("/")) {
+        path = "/" + path;
+      }
+    }
+
+    boolean sslEnabled = environment.getProperty("server.ssl.enabled", Boolean.class, false);
+    String protocol = sslEnabled ? "https" : "http";
+
+    // Determine host to use
+    String host = "localhost";
+    String hostType = environment.getProperty("webforj.devtools.browser.host", "localhost");
+
+    switch (hostType.toUpperCase()) {
+      case "HOSTNAME":
+        try {
+          host = InetAddress.getLocalHost().getHostName();
+        } catch (Exception e) {
+          LOG.log(Level.WARNING, "Could not determine machine hostname, using localhost", e);
+        }
+        break;
+      case "IP-ADDRESS":
+        try {
+          host = InetAddress.getLocalHost().getHostAddress();
+        } catch (Exception e) {
+          LOG.log(Level.WARNING, "Could not determine machine IP address, using localhost", e);
+        }
+        break;
+      default:
+        break;
+    }
+
+    return String.format("%s://%s:%d%s", protocol, host, serverPort, path);
+  }
+}

--- a/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/browser/BrowserLauncherAutoConfiguration.java
+++ b/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/browser/BrowserLauncherAutoConfiguration.java
@@ -1,0 +1,22 @@
+package com.webforj.spring.devtools.browser;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * Auto-configuration for browser launcher.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "webforj.devtools.browser", name = "open", havingValue = "true")
+public class BrowserLauncherAutoConfiguration {
+
+  @Bean
+  BrowserLauncher browserLauncher(Environment environment) {
+    return new BrowserLauncher(environment);
+  }
+}

--- a/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/browser/BrowserProperties.java
+++ b/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/browser/BrowserProperties.java
@@ -1,0 +1,63 @@
+package com.webforj.spring.devtools.browser;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for browser launcher.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+@ConfigurationProperties(prefix = "webforj.devtools.browser")
+public class BrowserProperties {
+
+  /**
+   * Enable automatic browser opening when the application starts.
+   */
+  private boolean open = false;
+
+  /**
+   * Host type to use in the browser URL. Supported values are: localhost, hostname, ip-address
+   */
+  private HostType host = HostType.LOCALHOST;
+
+  public enum HostType {
+    LOCALHOST, HOSTNAME, IP_ADDRESS
+  }
+
+  /**
+   * Returns whether automatic browser opening is enabled.
+   *
+   * @return true if browser opening is enabled, false otherwise
+   */
+  public boolean isOpen() {
+    return open;
+  }
+
+  /**
+   * Sets whether automatic browser opening is enabled.
+   *
+   * @param open true to enable browser opening, false to disable
+   */
+  public void setOpen(boolean open) {
+    this.open = open;
+  }
+
+  /**
+   * Returns the host type to use in the browser URL.
+   *
+   * @return the host type
+   */
+  public HostType getHost() {
+    return host;
+  }
+
+  /**
+   * Sets the host type to use in the browser URL.
+   *
+   * @param host the host type
+   */
+  public void setHost(HostType host) {
+    this.host = host;
+  }
+}

--- a/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/browser/HeadlessModeConfigurer.java
+++ b/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/browser/HeadlessModeConfigurer.java
@@ -1,0 +1,28 @@
+package com.webforj.spring.devtools.browser;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * Configures the JVM headless mode based on browser opening settings. When browser opening is
+ * enabled, this processor disables headless mode to allow Desktop API functionality.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.03
+ */
+public class HeadlessModeConfigurer implements EnvironmentPostProcessor {
+
+  @Override
+  public void postProcessEnvironment(ConfigurableEnvironment environment,
+      SpringApplication application) {
+    // Check if browser opening is enabled
+    Boolean browserOpen =
+        environment.getProperty("webforj.devtools.browser.open", Boolean.class, false);
+
+    if (browserOpen) {
+      // Disable headless mode to enable Desktop API functionality
+      System.setProperty("java.awt.headless", "false");
+    }
+  }
+}

--- a/webforj-spring/webforj-spring-devtools/src/main/resources/META-INF/spring.factories
+++ b/webforj-spring/webforj-spring-devtools/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Environment Post Processors
+org.springframework.boot.env.EnvironmentPostProcessor=\
+com.webforj.spring.devtools.browser.HeadlessModeConfigurer

--- a/webforj-spring/webforj-spring-devtools/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/webforj-spring/webforj-spring-devtools/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 com.webforj.spring.devtools.livereload.LiveReloadSocketConfiguration
+com.webforj.spring.devtools.browser.BrowserLauncherAutoConfiguration

--- a/webforj-spring/webforj-spring-devtools/src/test/java/com/webforj/spring/devtools/browser/BrowserLauncherTest.java
+++ b/webforj-spring/webforj-spring-devtools/src/test/java/com/webforj/spring/devtools/browser/BrowserLauncherTest.java
@@ -1,0 +1,79 @@
+package com.webforj.spring.devtools.browser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import java.net.InetAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.env.Environment;
+
+class BrowserLauncherTest {
+
+  private BrowserLauncher browserLauncher;
+
+  @Mock
+  private Environment mockEnvironment;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    browserLauncher = new BrowserLauncher(mockEnvironment);
+  }
+
+
+  @Test
+  void shouldBuildUrlWithDefaultLocalhostHost() {
+    when(mockEnvironment.getProperty("server.port", Integer.class, 8080)).thenReturn(8080);
+    when(mockEnvironment.getProperty("webforj.servlet-mapping", "/*")).thenReturn("/*");
+    when(mockEnvironment.getProperty("server.ssl.enabled", Boolean.class, false)).thenReturn(false);
+    when(mockEnvironment.getProperty("webforj.devtools.browser.host", "localhost"))
+        .thenReturn("localhost");
+
+    String url = browserLauncher.buildUrl();
+
+    assertEquals("http://localhost:8080", url);
+  }
+
+  @Test
+  void shouldBuildUrlWithHostnameHost() throws Exception {
+    when(mockEnvironment.getProperty("server.port", Integer.class, 8080)).thenReturn(8080);
+    when(mockEnvironment.getProperty("webforj.servlet-mapping", "/*")).thenReturn("/*");
+    when(mockEnvironment.getProperty("server.ssl.enabled", Boolean.class, false)).thenReturn(false);
+    when(mockEnvironment.getProperty("webforj.devtools.browser.host", "localhost"))
+        .thenReturn("hostname");
+
+    String url = browserLauncher.buildUrl();
+    String expectedHostname = InetAddress.getLocalHost().getHostName();
+
+    assertEquals("http://" + expectedHostname + ":8080", url);
+  }
+
+  @Test
+  void shouldBuildUrlWithIpAddressHost() throws Exception {
+    when(mockEnvironment.getProperty("server.port", Integer.class, 8080)).thenReturn(8080);
+    when(mockEnvironment.getProperty("webforj.servlet-mapping", "/*")).thenReturn("/*");
+    when(mockEnvironment.getProperty("server.ssl.enabled", Boolean.class, false)).thenReturn(false);
+    when(mockEnvironment.getProperty("webforj.devtools.browser.host", "localhost"))
+        .thenReturn("ip-address");
+
+    String url = browserLauncher.buildUrl();
+    String expectedIpAddress = InetAddress.getLocalHost().getHostAddress();
+
+    assertEquals("http://" + expectedIpAddress + ":8080", url);
+  }
+
+  @Test
+  void shouldBuildUrlWithAllCustomSettings() {
+    when(mockEnvironment.getProperty("server.port", Integer.class, 8080)).thenReturn(9090);
+    when(mockEnvironment.getProperty("webforj.servlet-mapping", "/*")).thenReturn("/revamped/*");
+    when(mockEnvironment.getProperty("server.ssl.enabled", Boolean.class, false)).thenReturn(true);
+    when(mockEnvironment.getProperty("webforj.devtools.browser.host", "localhost"))
+        .thenReturn("localhost");
+
+    String url = browserLauncher.buildUrl();
+
+    assertEquals("https://localhost:9090/revamped", url);
+  }
+}


### PR DESCRIPTION
Opens browser on application startup. Detects hostname or IP address for remote access.

Settings:
- `webforj.devtools.browser.open`: Enable browser opening (default: false)
- `webforj.devtools.browser.host`: localhost, hostname, or ip-address (default: localhost)