### PR TITLE
fix: WebStorage implementations return `null` for non-existent keys

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/webstorage/WebStorage.java
+++ b/webforj-foundation/src/main/java/com/webforj/webstorage/WebStorage.java
@@ -150,16 +150,16 @@ public abstract sealed class WebStorage permits CookieStorage, LocalStorage, Ses
   }
 
   /**
-   * When passed a key name, will return that key's value.
+   * When passed a key name, will return that key's value, or null if the key does not exist.
    *
    * @param key the key name
-   * @return the value of the key
+   * @return the value of the key, or null if the key does not exist
    */
   public String get(String key) {
     try {
       return thinClient.getUserProperty(type.getValue(), key);
     } catch (BBjException e) {
-      return "";
+      return null;
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/webstorage/CookieStorageTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/webstorage/CookieStorageTest.java
@@ -1,6 +1,7 @@
 package com.webforj.webstorage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -87,6 +88,15 @@ class CookieStorageTest {
 
       webStorage.get(keys);
       verify(thinClient).getUserProperties(BBjThinClient.USER_PROPERTIES_COOKIES, keys);
+    }
+
+    @Test
+    void shouldReturnNullForNonExistentKey() throws BBjException {
+      when(thinClient.getUserProperty(anyLong(), eq("nonexistent"))).thenThrow(BBjException.class);
+
+      String result = webStorage.getItem("nonexistent");
+
+      assertNull(result);
     }
   }
 


### PR DESCRIPTION
fixes #1030