### PR TITLE
feat: include webforj as transitive dependency in spring-boot-starter

### DIFF
--- a/webforj-spring/webforj-spring-boot-starter/pom.xml
+++ b/webforj-spring/webforj-spring-boot-starter/pom.xml
@@ -16,6 +16,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.webforj</groupId>
+      <artifactId>webforj</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>${spring.boot.version}</version>


### PR DESCRIPTION
The `webforj-spring-boot-starter` now includes webforj as a transitive dependency, simplifying the setup. Users no longer need to manually add both dependencies - they can simply include the starter and get everything they need.