### PR TITLE
feat: add Debouncer utility class

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/Debouncer.java
+++ b/webforj-foundation/src/main/java/com/webforj/Debouncer.java
@@ -1,0 +1,128 @@
+package com.webforj;
+
+import com.webforj.dispatcher.EventListener;
+import java.util.Objects;
+
+/**
+ * A debouncer delays executing an action until a specified time has elapsed since the last call.
+ *
+ * <p>
+ * Debouncing is useful for scenarios like search-as-you-type where you want to wait until the user
+ * stops typing before executing a search.
+ * </p>
+ *
+ * <h2>Usage Example</h2>
+ *
+ * <pre>{@code
+ * Debouncer debounce = new Debouncer(0.3f);
+ *
+ * textField.onModify(e -> {
+ *   debounce.run(() -> search(textField.getText()));
+ * });
+ * }</pre>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 25.11
+ *
+ * @see Interval
+ */
+public final class Debouncer {
+
+  private final float delay;
+  private Interval interval;
+  private Runnable pendingAction;
+
+  /**
+   * Creates a new debouncer.
+   *
+   * @param delay the debounce delay in seconds
+   * @throws IllegalArgumentException if delay is negative
+   */
+  public Debouncer(float delay) {
+    if (delay < 0) {
+      throw new IllegalArgumentException("Delay must be >= 0");
+    }
+    this.delay = delay;
+  }
+
+  /**
+   * Schedules the action to run after the delay.
+   *
+   * <p>
+   * If called again before the delay elapses, the previous action is cancelled and the timer
+   * restarts.
+   * </p>
+   *
+   * @param action the action to execute
+   * @throws NullPointerException if action is null
+   */
+  public void run(Runnable action) {
+    Objects.requireNonNull(action, "Action cannot be null");
+    pendingAction = action;
+
+    if (interval != null) {
+      interval.stop();
+    }
+
+    interval = createInterval(delay, e -> {
+      interval.stop();
+      if (pendingAction != null) {
+        pendingAction.run();
+        pendingAction = null;
+      }
+    });
+
+    interval.start();
+  }
+
+  /**
+   * Cancels any pending action.
+   */
+  public void cancel() {
+    if (interval != null) {
+      interval.stop();
+    }
+
+    pendingAction = null;
+  }
+
+  /**
+   * Immediately executes the pending action if one exists.
+   */
+  public void flush() {
+    if (pendingAction != null) {
+      if (interval != null) {
+        interval.stop();
+      }
+
+      Runnable action = pendingAction;
+      pendingAction = null;
+      action.run();
+    }
+  }
+
+  /**
+   * Checks if there's a pending action.
+   *
+   * @return {@code true} if an action is pending
+   */
+  public boolean isPending() {
+    return pendingAction != null;
+  }
+
+  /**
+   * Gets the delay in seconds.
+   *
+   * @return the delay
+   */
+  public float getDelay() {
+    return delay;
+  }
+
+  /**
+   * Creates an interval instance. Package-private for testing.
+   */
+  Interval createInterval(float delay, EventListener<Interval.ElapsedEvent> listener) {
+    return new Interval(delay, listener);
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/DebouncerTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/DebouncerTest.java
@@ -1,0 +1,147 @@
+package com.webforj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.webforj.dispatcher.EventListener;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DebouncerTest {
+
+  private TestableDebouncer createTestable(float delay) {
+    Debouncer debouncer = spy(new Debouncer(delay));
+    AtomicReference<EventListener<Interval.ElapsedEvent>> capturedListener =
+        new AtomicReference<>();
+
+    doAnswer(invocation -> {
+      capturedListener.set(invocation.getArgument(1));
+      return mock(Interval.class);
+    }).when(debouncer).createInterval(anyFloat(), any());
+
+    return new TestableDebouncer(debouncer, capturedListener);
+  }
+
+  private static class TestableDebouncer {
+    final Debouncer debouncer;
+    final AtomicReference<EventListener<Interval.ElapsedEvent>> listener;
+
+    TestableDebouncer(Debouncer debouncer,
+        AtomicReference<EventListener<Interval.ElapsedEvent>> listener) {
+      this.debouncer = debouncer;
+      this.listener = listener;
+    }
+
+    void triggerTimer() {
+      EventListener<Interval.ElapsedEvent> l = listener.get();
+      if (l != null) {
+        l.onEvent(mock(Interval.ElapsedEvent.class));
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("should create debouncer with valid delay")
+  void shouldCreate() {
+    Debouncer debouncer = new Debouncer(0.5f);
+    assertEquals(0.5f, debouncer.getDelay());
+  }
+
+  @Test
+  @DisplayName("should throw on negative delay")
+  void shouldThrowOnNegativeDelay() {
+    assertThrows(IllegalArgumentException.class, () -> new Debouncer(-1f));
+  }
+
+  @Test
+  @DisplayName("should throw on null action")
+  void shouldThrowOnNullAction() {
+    Debouncer debouncer = new Debouncer(0.5f);
+    assertThrows(NullPointerException.class, () -> debouncer.run(null));
+  }
+
+  @Test
+  @DisplayName("should not invoke immediately on run")
+  void shouldNotInvokeImmediately() {
+    AtomicInteger counter = new AtomicInteger(0);
+    TestableDebouncer testable = createTestable(0.5f);
+
+    testable.debouncer.run(counter::incrementAndGet);
+
+    assertEquals(0, counter.get());
+    assertTrue(testable.debouncer.isPending());
+  }
+
+  @Test
+  @DisplayName("should invoke on timer elapsed")
+  void shouldInvokeOnTimerElapsed() {
+    AtomicInteger counter = new AtomicInteger(0);
+    TestableDebouncer testable = createTestable(0.5f);
+
+    testable.debouncer.run(counter::incrementAndGet);
+    testable.triggerTimer();
+
+    assertEquals(1, counter.get());
+    assertFalse(testable.debouncer.isPending());
+  }
+
+  @Test
+  @DisplayName("should use last action")
+  void shouldUseLastAction() {
+    AtomicInteger counter = new AtomicInteger(0);
+    TestableDebouncer testable = createTestable(0.5f);
+
+    testable.debouncer.run(() -> counter.addAndGet(1));
+    testable.debouncer.run(() -> counter.addAndGet(10));
+    testable.debouncer.run(() -> counter.addAndGet(100));
+    testable.triggerTimer();
+
+    assertEquals(100, counter.get());
+  }
+
+  @Test
+  @DisplayName("should cancel pending action")
+  void shouldCancel() {
+    AtomicInteger counter = new AtomicInteger(0);
+    TestableDebouncer testable = createTestable(0.5f);
+
+    testable.debouncer.run(counter::incrementAndGet);
+    testable.debouncer.cancel();
+
+    assertFalse(testable.debouncer.isPending());
+    testable.triggerTimer();
+    assertEquals(0, counter.get());
+  }
+
+  @Test
+  @DisplayName("should flush pending action")
+  void shouldFlush() {
+    AtomicInteger counter = new AtomicInteger(0);
+    TestableDebouncer testable = createTestable(0.5f);
+
+    testable.debouncer.run(counter::incrementAndGet);
+    testable.debouncer.flush();
+
+    assertEquals(1, counter.get());
+    assertFalse(testable.debouncer.isPending());
+  }
+
+  @Test
+  @DisplayName("flush should do nothing when not pending")
+  void flushShouldDoNothingWhenNotPending() {
+    AtomicInteger counter = new AtomicInteger(0);
+    TestableDebouncer testable = createTestable(0.5f);
+
+    testable.debouncer.flush();
+    assertEquals(0, counter.get());
+  }
+}


### PR DESCRIPTION
Debouncing waits until activity stops before executing. Useful for search-as-you-type where you don't want to fire a request on every keystroke, only after the user pauses.

Built on webforJ's Interval, so it runs on the UI thread with no thread synchronization needed.

```java
Debouncer debounce = new Debouncer(0.3f);

textField.onModify(e -> {
  debounce.run(() -> search(textField.getText()));
});
```