### PR TITLE
fix: change message parameter type from String to Object in `InputDialog` and `OptionDialog`

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/optiondialog/InputDialog.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optiondialog/InputDialog.java
@@ -147,7 +147,7 @@ public final class InputDialog extends DwcPromptMsgBox<InputDialog> {
    * @param messageType The type of dialog style.
    * @param inputType the type of input field
    */
-  public InputDialog(String message, String title, String defaultValue, MessageType messageType,
+  public InputDialog(Object message, String title, String defaultValue, MessageType messageType,
       InputType inputType) {
     this(message, title, defaultValue, messageType, inputType,
         detectDialogThemeFromMessageType(messageType));

--- a/webforj-foundation/src/main/java/com/webforj/component/optiondialog/OptionDialog.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optiondialog/OptionDialog.java
@@ -161,7 +161,7 @@ public final class OptionDialog {
    * @param messageType The type of dialog style.
    * @param inputType the type of input field
    */
-  public static String showInputDialog(String message, String title, String defaultValue,
+  public static String showInputDialog(Object message, String title, String defaultValue,
       MessageType messageType, InputType inputType) {
     return new InputDialog(message, title, defaultValue, messageType, inputType).show();
   }


### PR DESCRIPTION
fix #1177