### PR TITLE
feat: add minifierConfigurations support to Gradle plugin

### DIFF
--- a/webforj-plugins/webforj-minify/webforj-minify-gradle-plugin/src/main/java/com/webforj/minify/gradle/MinifyExtension.java
+++ b/webforj-plugins/webforj-minify/webforj-minify-gradle-plugin/src/main/java/com/webforj/minify/gradle/MinifyExtension.java
@@ -1,17 +1,24 @@
 package com.webforj.minify.gradle;
 
+import java.util.Map;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 
 /**
  * Configuration extension for the webforJ minify plugin.
  *
  * <p>
- * Usage in build.gradle:
+ * Usage in build.gradle.kts:
  * </p>
  *
  * <pre>
  * webforjMinify {
- *   skip = false
+ *   skip.set(false)
+ *   minifierConfigurations.put("closureJs", mapOf(
+ *     "compilationLevel" to "SIMPLE_OPTIMIZATIONS",
+ *     "languageIn" to "ECMASCRIPT_NEXT",
+ *     "languageOut" to "ECMASCRIPT5"
+ *   ))
  * }
  * </pre>
  *
@@ -25,4 +32,22 @@ public interface MinifyExtension {
    * @return the skip property
    */
   Property<Boolean> getSkip();
+
+  /**
+   * Minifier-specific configuration options.
+   *
+   * <p>
+   * Each entry maps a minifier configuration key (e.g., "closureJs") to a map of key-value option
+   * pairs. The configuration is passed to {@code MinifierRegistry.configureMinifiers()} which
+   * delegates to each minifier's {@code configure()} method.
+   * </p>
+   *
+   * <p>
+   * This mirrors the Maven plugin's {@code <minifierConfigurations>} parameter to ensure
+   * build-system parity.
+   * </p>
+   *
+   * @return the minifier configurations map property
+   */
+  MapProperty<String, Map<String, String>> getMinifierConfigurations();
 }

--- a/webforj-plugins/webforj-minify/webforj-minify-gradle-plugin/src/main/java/com/webforj/minify/gradle/MinifyPlugin.java
+++ b/webforj-plugins/webforj-minify/webforj-minify-gradle-plugin/src/main/java/com/webforj/minify/gradle/MinifyPlugin.java
@@ -94,6 +94,7 @@ public class MinifyPlugin implements Plugin<Project> {
     task.getResourcesDirectory().set(mainSourceSet.getOutput().getResourcesDir());
 
     task.getSkip().set(extension.getSkip());
+    task.getMinifierConfigurations().set(extension.getMinifierConfigurations());
     task.getMinifierClasspath().from(minifierConfig);
 
     // Run after classes task (which includes processResources)


### PR DESCRIPTION
## Summary
- Adds `minifierConfigurations` property to the Gradle plugin extension and task, achieving feature parity with the Maven plugin's `<minifierConfigurations>` parameter
- Gradle users can now pass minifier-specific options (e.g., Closure Compiler compilation level, language settings) via the `webforjMinify` DSL block
- Includes 4 new unit tests covering property existence, defaults, value assignment, and extension-to-task wiring

## Test plan
- [x] Gradle tests pass locally (`gradle test` — 9 tests)
- [x] Formatter reports 0 changes
- [ ] CI pipeline passes (checkstyle, tests, coverage)