### PR TITLE
fix: add webserver:// protocol support to ResourceResolver

### DIFF
--- a/webforj-plugins/webforj-minify/webforj-minify-foundation/src/main/java/com/webforj/minify/common/ResourceResolver.java
+++ b/webforj-plugins/webforj-minify/webforj-minify-foundation/src/main/java/com/webforj/minify/common/ResourceResolver.java
@@ -73,7 +73,7 @@ public class ResourceResolver {
       String path = matcher.group(2);
 
       resolved = switch (protocol) {
-        case "ws" -> resourcesRoot.resolve("static").resolve(path);
+        case "ws", "webserver" -> resourcesRoot.resolve("static").resolve(path);
         case "context" -> resourcesRoot.resolve(path);
         default -> throw new IllegalArgumentException("Unknown protocol: " + protocol);
       };

--- a/webforj-plugins/webforj-minify/webforj-minify-foundation/src/test/java/com/webforj/minify/common/ResourceResolverTest.java
+++ b/webforj-plugins/webforj-minify/webforj-minify-foundation/src/test/java/com/webforj/minify/common/ResourceResolverTest.java
@@ -82,6 +82,40 @@ class ResourceResolverTest {
   }
 
   @Test
+  void testWebserverProtocol() throws IOException {
+    Path staticDir = tempDir.resolve("static");
+    Files.createDirectories(staticDir);
+    Path cssDir = staticDir.resolve("css");
+    Files.createDirectories(cssDir);
+
+    Path resolved = resolver.resolve("webserver://css/app.css");
+
+    assertEquals(cssDir.resolve("app.css").toAbsolutePath().normalize(), resolved);
+  }
+
+  @Test
+  void testWebserverAndWsResolveIdentically() throws IOException {
+    Path staticDir = tempDir.resolve("static");
+    Files.createDirectories(staticDir);
+    Path jsDir = staticDir.resolve("js");
+    Files.createDirectories(jsDir);
+
+    Path wsResolved = resolver.resolve("ws://js/app.js");
+    Path webserverResolved = resolver.resolve("webserver://js/app.js");
+
+    assertEquals(wsResolved, webserverResolved);
+  }
+
+  @Test
+  void testDirectoryTraversalWithWebserver() {
+    SecurityException exception = assertThrows(SecurityException.class, () -> {
+      resolver.resolve("webserver://../../../etc/passwd");
+    });
+
+    assertTrue(exception.getMessage().contains("Path traversal detected"));
+  }
+
+  @Test
   void testUnknownProtocol() {
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
       resolver.resolve("unknown://test.css");


### PR DESCRIPTION
## Summary
- `webserver://` is a documented alias for `ws://` but was missing from `ResourceResolver.resolve()`, causing `IllegalArgumentException`
- Added `"webserver"` case to the switch expression so both protocols resolve to `static/` paths identically
- Added 3 tests: basic resolution, parity with `ws://`, and directory traversal prevention

Closes #1205