### PR TITLE
feat: support explicit BBj control ID assignment for components

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/button/Button.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/button/Button.java
@@ -116,7 +116,7 @@ public final class Button extends DwcButton<Button> {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addButton(getText(), flags));
+      setControl(w.addButton(resolveControlId(w), getText(), flags));
     } catch (Exception e) {
       throw new WebforjRuntimeException("Failed to create the BBjButton Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/element/Element.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/Element.java
@@ -629,7 +629,7 @@ public final class Element extends DwcContainer<Element>
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addWebComponent(getNodeName(), flags));
+      setControl(w.addWebComponent(resolveControlId(w), getNodeName(), flags));
     } catch (Exception e) {
       throw new WebforjRuntimeException("Failed to create the BBjWebComponent Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/DwcFieldInitializer.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/DwcFieldInitializer.java
@@ -127,7 +127,7 @@ abstract class DwcFieldInitializer<T extends DwcValidatableComponent<T, V> & Has
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addEditBox(getText(), flags));
+      setControl(w.addEditBox(resolveControlId(w), getText(), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjEditBox", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedDateField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedDateField.java
@@ -624,7 +624,7 @@ public sealed class MaskedDateField extends DwcDateTimeMaskedField<MaskedDateFie
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addInputD(flags));
+      setControl(w.addInputD(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjInputD", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedDateFieldSpinner.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedDateFieldSpinner.java
@@ -228,7 +228,7 @@ public final class MaskedDateFieldSpinner extends MaskedDateField
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addInputDSpinner(flags));
+      setControl(w.addInputDSpinner(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjInputDSpinner", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedNumberField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedNumberField.java
@@ -417,7 +417,7 @@ public sealed class MaskedNumberField extends DwcMaskedField<MaskedNumberField, 
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addInputN(flags));
+      setControl(w.addInputN(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjInputN", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedNumberFieldSpinner.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedNumberFieldSpinner.java
@@ -169,7 +169,7 @@ public final class MaskedNumberFieldSpinner extends MaskedNumberField
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addInputNSpinner(flags));
+      setControl(w.addInputNSpinner(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjInputNSpinner", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedTextField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedTextField.java
@@ -242,7 +242,7 @@ public sealed class MaskedTextField extends DwcMaskedField<MaskedTextField, Stri
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addInputE(flags));
+      setControl(w.addInputE(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjInputE", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedTextFieldSpinner.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedTextFieldSpinner.java
@@ -197,7 +197,7 @@ public final class MaskedTextFieldSpinner extends MaskedTextField
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addInputESpinner(flags));
+      setControl(w.addInputESpinner(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjInputESpinner", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedTimeField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedTimeField.java
@@ -370,7 +370,7 @@ public sealed class MaskedTimeField extends DwcDateTimeMaskedField<MaskedTimeFie
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addInputT(flags));
+      setControl(w.addInputT(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjInputT", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedTimeFieldSpinner.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedTimeFieldSpinner.java
@@ -255,7 +255,7 @@ public final class MaskedTimeFieldSpinner extends MaskedTimeField
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addInputTSpinner(flags));
+      setControl(w.addInputTSpinner(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjInputTSpinner", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/TextArea.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/TextArea.java
@@ -761,7 +761,7 @@ public final class TextArea extends DwcField<TextArea, String> implements HasTyp
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addCEdit(getText(), flags));
+      setControl(w.addCEdit(resolveControlId(w), getText(), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjCEdit", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/field/TextFieldSpinner.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/TextFieldSpinner.java
@@ -199,7 +199,7 @@ public final class TextFieldSpinner extends TextField
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(isVisible(), isEnabled());
-      setControl(w.addEditBoxSpinner(getText(), flags));
+      setControl(w.addEditBoxSpinner(resolveControlId(w), getText(), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create BBjEditBoxSpinner", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/ChoiceBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ChoiceBox.java
@@ -148,7 +148,7 @@ public final class ChoiceBox extends DwcSelectDropdown<ChoiceBox>
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(panel);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addListButton("", flags));
+      setControl(w.addListButton(resolveControlId(w), "", flags));
     } catch (Exception e) {
       throw new WebforjRuntimeException("Failed to create the BBjListButton Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/ComboBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ComboBox.java
@@ -260,7 +260,7 @@ public final class ComboBox extends DwcSelectDropdown<ComboBox>
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addListEdit("", flags));
+      setControl(w.addListEdit(resolveControlId(w), "", flags));
     } catch (Exception e) {
       throw new WebforjRuntimeException("Failed to create the BBjListEdit Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/ListBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ListBox.java
@@ -403,7 +403,7 @@ public final class ListBox extends DwcList<ListBox, List<Object>>
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addListBox("", flags));
+      setControl(w.addListBox(resolveControlId(w), "", flags));
     } catch (Exception e) {
       throw new WebforjRuntimeException("Failed to create the BBjListBox Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/navigator/Navigator.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/navigator/Navigator.java
@@ -685,7 +685,7 @@ public final class Navigator extends DwcFocusableComponent<Navigator>
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addNavigator(getText(), flags));
+      setControl(w.addNavigator(resolveControlId(w), getText(), flags));
     } catch (Exception e) {
       throw new WebforjRuntimeException("Failed to create the BBjNavigator Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/optioninput/CheckBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optioninput/CheckBox.java
@@ -141,7 +141,7 @@ public final class CheckBox extends DwcOptionInput<CheckBox> {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(p);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addCheckBox("", flags));
+      setControl(w.addCheckBox(resolveControlId(w), "", flags));
     } catch (IllegalAccessException | BBjException e) {
       throw new WebforjRuntimeException("Failed to create the BBjCheckBox Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/optioninput/RadioButton.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optioninput/RadioButton.java
@@ -430,7 +430,7 @@ public final class RadioButton extends DwcOptionInput<RadioButton> {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(p);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addRadioButton("", flags));
+      setControl(w.addRadioButton(resolveControlId(w), "", flags));
     } catch (IllegalAccessException | BBjException e) {
       throw new WebforjRuntimeException("Failed to create the BBjRadioButton Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/progressbar/ProgressBar.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/progressbar/ProgressBar.java
@@ -459,7 +459,7 @@ public final class ProgressBar extends DwcComponent<ProgressBar>
   protected void onCreate(Window window) {
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
-      setControl(w.addProgressBar());
+      setControl(w.addProgressBar(resolveControlId(w)));
     } catch (Exception e) {
       throw new WebforjRuntimeException("Failed to create the BBjProgressBar Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/slider/Slider.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/slider/Slider.java
@@ -827,7 +827,7 @@ public final class Slider extends DwcFocusableComponent<Slider> implements HasMi
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addHorizontalSlider(flags));
+      setControl(w.addHorizontalSlider(resolveControlId(w), flags));
     } catch (Exception e) {
       throw new WebforjRuntimeException("Failed to create the BBjSlider Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tabbedpane/TabbedPane.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tabbedpane/TabbedPane.java
@@ -1136,7 +1136,7 @@ public final class TabbedPane extends DwcFocusableComponent<TabbedPane> implemen
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      setControl(w.addTabCtrl(flags));
+      setControl(w.addTabCtrl(resolveControlId(w), flags));
     } catch (BBjException | IllegalAccessException e) {
       throw new WebforjRuntimeException("Failed to create the BBjTabCtrl Control", e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/text/Label.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/text/Label.java
@@ -113,7 +113,7 @@ public final class Label extends DwcComponent<Label> implements HasHorizontalAli
     try {
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(p);
       byte[] flags = BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), true);
-      setControl(w.addStaticText(getText(), flags));
+      setControl(w.addStaticText(resolveControlId(w), getText(), flags));
     } catch (Exception e) {
       throw new WebforjRuntimeException(e);
     }

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/Tree.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/Tree.java
@@ -1253,7 +1253,7 @@ public final class Tree extends DwcFocusableComponent<Tree>
       BBjWindow w = WindowAccessor.getDefault().getBBjWindow(window);
       byte[] flags =
           BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-      BBjTree tree = w.addTree(flags);
+      BBjTree tree = w.addTree(resolveControlId(w), flags);
       tree.setRootVisible(false);
       tree.setRoot(root.getUniqueId(), "");
       setControl(tree);

--- a/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.sysgui.BBjEditBox;
+import com.basis.bbj.proxies.sysgui.BBjWindow;
 import com.basis.startup.type.BBjException;
 import com.webforj.component.event.MouseEnterEvent;
 import com.webforj.component.event.MouseExitEvent;
@@ -799,6 +800,73 @@ class DwcComponentTest {
 
       verify(slotAssigner, times(1)).attach();
       verify(slotAssigner, times(1)).attach();
+    }
+  }
+
+  @Nested
+  @DisplayName("BbjId API")
+  class BbjIdApi {
+
+    @Test
+    @DisplayName("Default Bbj ID is -1")
+    void defaultBbjIdIsNegativeOne() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+      assertEquals(-1, component.getBBjId());
+    }
+
+    @Test
+    @DisplayName("Setting and getting Bbj ID before attachment")
+    void settingAndGettingBbjId() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+      component.setBBjId(100);
+      assertEquals(100, component.getBBjId());
+    }
+
+    @Test
+    @DisplayName("setBBjId throws IllegalStateException when already attached")
+    void setBbjIdThrowsWhenAttached() {
+      DwcComponentMock spied = spy(component);
+      doReturn(true).when(spied).isAttached();
+      assertThrows(IllegalStateException.class, () -> spied.setBBjId(100));
+    }
+
+    @Test
+    @DisplayName("setBBjId throws IllegalArgumentException for negative ID")
+    void setBbjIdThrowsForNegativeId() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+      assertThrows(IllegalArgumentException.class, () -> component.setBBjId(-1));
+      assertThrows(IllegalArgumentException.class, () -> component.setBBjId(-100));
+    }
+
+    @Test
+    @DisplayName("setBBjId accepts zero")
+    void setBbjIdAcceptsZero() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+      component.setBBjId(0);
+      assertEquals(0, component.getBBjId());
+    }
+
+    @Test
+    @DisplayName("resolveControlId returns explicit ID when set")
+    void resolveControlIdReturnsExplicitId() throws Exception {
+      ReflectionUtils.nullifyControl(component);
+      component.setBBjId(200);
+
+      BBjWindow window = mock(BBjWindow.class);
+      assertEquals(200, component.resolveControlId(window));
+      verify(window, times(0)).getAvailableControlID();
+    }
+
+    @Test
+    @DisplayName("resolveControlId falls back to window ID when not set")
+    void resolveControlIdFallsBackToWindowId() throws Exception {
+      ReflectionUtils.nullifyControl(component);
+
+      BBjWindow window = mock(BBjWindow.class);
+      when(window.getAvailableControlID()).thenReturn(999);
+
+      assertEquals(999, component.resolveControlId(window));
+      verify(window, times(1)).getAvailableControlID();
     }
   }
 


### PR DESCRIPTION
Allow setting a fixed BBj control ID on webforJ components before they are attached to a window. This enables legacy BBj code to access controls by their known IDs via `BBjWindow.getControl(int)`.