### PR TITLE
feat: add missing getters for Kotlin synthetic property support

### DIFF
--- a/webforj-components/webforj-dialog/src/main/java/com/webforj/component/dialog/Dialog.java
+++ b/webforj-components/webforj-dialog/src/main/java/com/webforj/component/dialog/Dialog.java
@@ -327,6 +327,17 @@ public class Dialog extends ElementCompositeContainer
   }
 
   /**
+   * Gets whether closing the dialog by clicking outside or pressing the esc key is enabled.
+   *
+   * @return {@code true} if the dialog is closeable, {@code false} otherwise
+   * @see #isCancelOnOutsideClick()
+   * @see #isCancelOnEscKey()
+   */
+  public boolean isCloseable() {
+    return isCancelOnOutsideClick() && isCancelOnEscKey();
+  }
+
+  /**
    * Sets the dialog to be fullscreen.
    *
    * <p>

--- a/webforj-components/webforj-dialog/src/test/java/com/webforj/component/dialog/DialogTest.java
+++ b/webforj-components/webforj-dialog/src/test/java/com/webforj/component/dialog/DialogTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.dialog;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
@@ -67,6 +68,25 @@ class DialogTest {
 
       verify(spy, times(1)).setCancelOnOutsideClick(closeable);
       verify(spy, times(1)).setCancelOnEscKey(closeable);
+    }
+
+    @Test
+    void shouldReturnCloseableTrue() {
+      component.setCloseable(true);
+      assertTrue(component.isCloseable());
+    }
+
+    @Test
+    void shouldReturnCloseableFalse() {
+      component.setCloseable(false);
+      assertFalse(component.isCloseable());
+    }
+
+    @Test
+    void shouldReturnCloseableFalseWhenPartial() {
+      component.setCancelOnOutsideClick(true);
+      component.setCancelOnEscKey(false);
+      assertFalse(component.isCloseable());
     }
   }
 

--- a/webforj-components/webforj-html-elements/src/main/java/com/webforj/component/html/elements/Iframe.java
+++ b/webforj-components/webforj-html-elements/src/main/java/com/webforj/component/html/elements/Iframe.java
@@ -204,6 +204,15 @@ public class Iframe extends HtmlComponent<Iframe> {
   }
 
   /**
+   * Gets the sandbox attribute values for the iframe.
+   *
+   * @return the list of sandbox attribute values
+   */
+  public List<Sandbox> getSandbox() {
+    return Collections.unmodifiableList(sandboxValues);
+  }
+
+  /**
    * Removes a specific sandbox attribute value from the iframe.
    *
    * @param sandboxValue the sandbox attribute value to remove
@@ -219,9 +228,11 @@ public class Iframe extends HtmlComponent<Iframe> {
    * Gets the sandbox attribute values for the iframe.
    *
    * @return the list of sandbox attribute values
+   * @deprecated Use {@link #getSandbox()} instead.
    */
+  @Deprecated(since = "25.12", forRemoval = true)
   public List<Sandbox> getSandboxValues() {
-    return Collections.unmodifiableList(sandboxValues);
+    return getSandbox();
   }
 
   /**


### PR DESCRIPTION
Dialog: Add `isCloseable()` getter that returns isCancelOnOutsideClick() && isCancelOnEscKey(). Without this getter, Kotlin users must call setCloseable(false) instead of closeable = false.

Iframe: Rename `getSandboxValues()` to `getSandbox()` to match setSandbox() setter. The old getSandboxValues() is kept as @Deprecated(forRemoval = true) delegate.