### PR TITLE
Kotlin/dsl fix

### DIFF
--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/MultiSlotSetter.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/MultiSlotSetter.kt
@@ -24,7 +24,6 @@ class MultiSlotSetter(block: @WebforjDsl HasComponents.() -> Unit): HasComponent
    * @param component The [Component] whose slot is going to be set.
    * @param setter The steps to set the `Components`.
    */
-  @WebforjDsl
   fun <T: Component> setSlot(component: T, setter: @WebforjDsl T.(Array<Component?>) -> Unit) {
     component.setter(backingList.toTypedArray())
   }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/SingleSlotSetter.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/SingleSlotSetter.kt
@@ -7,7 +7,6 @@ import com.webforj.concern.HasComponents
 class SingleSlotSetter(block: @WebforjDsl HasComponents.() -> Component): HasComponents {
   val component: Component = block()
 
-  @WebforjDsl
   fun <T> setSlot(instance: T, setter: @WebforjDsl T.(Component) -> Unit) {
     instance.setter(component)
   }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/WebforjDsl.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/WebforjDsl.kt
@@ -8,7 +8,8 @@ import com.webforj.concern.HasComponents
  * called inside the wrong scope.
  * It prevents an implicit receiver from an outer scope unless explicitly specified with `this@`.
  */
-@Target(AnnotationTarget.TYPE, AnnotationTarget.TYPEALIAS, AnnotationTarget.CLASS)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
 @DslMarker
 annotation class WebforjDsl
 

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/WebforjDsl.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/WebforjDsl.kt
@@ -8,7 +8,7 @@ import com.webforj.concern.HasComponents
  * called inside the wrong scope.
  * It prevents an implicit receiver from an outer scope unless explicitly specified with `this@`.
  */
-@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS, AnnotationTarget.TYPE_PARAMETER, AnnotationTarget.TYPEALIAS)
 @Retention(AnnotationRetention.BINARY)
 @DslMarker
 annotation class WebforjDsl
@@ -28,3 +28,14 @@ fun <T: Component> (@WebforjDsl HasComponents).init(component: T, block: (@Webfo
   return component
 }
 
+/**
+ * Builds the component by executing the initialization [block].
+ *
+ * This is a convenience function that allows for a fluent initialization pattern
+ * where the component is configured within its own scope.
+ *
+ * @param block The initialization block for the component.
+ */
+fun <T: Component> @WebforjDsl T.build(block: @WebforjDsl T.() -> Unit) {
+  block()
+}

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/WebforjDsl.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/WebforjDsl.kt
@@ -8,7 +8,7 @@ import com.webforj.concern.HasComponents
  * called inside the wrong scope.
  * It prevents an implicit receiver from an outer scope unless explicitly specified with `this@`.
  */
-@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.TYPEALIAS, AnnotationTarget.CLASS)
 @DslMarker
 annotation class WebforjDsl
 
@@ -21,7 +21,6 @@ annotation class WebforjDsl
  * @param block The initialization block of the `component`.
  * @return The initialized [Component].
  */
-@WebforjDsl
 fun <T: Component> (@WebforjDsl HasComponents).init(component: T, block: (@WebforjDsl T).() -> Unit): T {
   add(component)
   component.block()

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/accordion/Accordion.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/accordion/Accordion.kt
@@ -26,7 +26,6 @@ import com.webforj.kotlin.dsl.init
  * @see Accordion
  * @see accordionPanel
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.accordion(
   block: @WebforjDsl Accordion.() -> Unit = {}
 ): Accordion {

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/accordion/AccordionPanel.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/accordion/AccordionPanel.kt
@@ -25,7 +25,6 @@ import com.webforj.kotlin.dsl.init
  * @see AccordionPanel
  * @see accordion
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.accordionPanel(
   label: String? = null,
   block: @WebforjDsl AccordionPanel.() -> Unit = {}
@@ -48,7 +47,6 @@ fun @WebforjDsl HasComponents.accordionPanel(
  *
  * @param block The initialization steps of the header components.
  */
-@WebforjDsl
 fun @WebforjDsl AccordionPanel.headerSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, AccordionPanel::addToHeader)
 }
@@ -65,7 +63,6 @@ fun @WebforjDsl AccordionPanel.headerSlot(block: @WebforjDsl HasComponents.() ->
  *
  * @param block The initialization of the icon [Component].
  */
-@WebforjDsl
 fun @WebforjDsl AccordionPanel.iconSlot(block: @WebforjDsl HasComponents.() -> Component) {
   SingleSlotSetter(block).setSlot(this, AccordionPanel::setIcon)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/alert/Alert.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/alert/Alert.kt
@@ -25,7 +25,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Alert`.
  * @see Alert
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.alert(
   text: String? = null,
   theme: Theme? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/avatar/Avatar.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/avatar/Avatar.kt
@@ -23,7 +23,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Avatar`.
  * @see Avatar
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.avatar(
   label: String? = null,
   initials: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/badge/Badge.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/badge/Badge.kt
@@ -23,7 +23,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Badge`.
  * @see Badge
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.badge(
   text: String? = null,
   theme: BadgeTheme? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/button/Button.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/button/Button.kt
@@ -32,7 +32,6 @@ import com.webforj.kotlin.extension.suffixSlot
  * @return The configured `Button`.
  * @see Button
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.button(
     text: String? = null,
     theme: ButtonTheme? = null,
@@ -60,7 +59,6 @@ fun @WebforjDsl HasComponents.button(
  *
  * @param block The initialization steps of the icon `Component`.
  */
-@WebforjDsl
 fun @WebforjDsl Button.iconSlot(block: @WebforjDsl HasComponents.() -> Component) {
   SingleSlotSetter(block).setSlot(this, Button::setIcon)
 }
@@ -77,7 +75,6 @@ fun @WebforjDsl Button.iconSlot(block: @WebforjDsl HasComponents.() -> Component
  *
  * @param block The initialization steps of the badge `Component`.
  */
-@WebforjDsl
 fun <T : DwcButton<T>> @WebforjDsl DwcButton<T>.badgeSlot(
   block: @WebforjDsl HasComponents.() -> Component
 ) {

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/dialog/Dialog.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/dialog/Dialog.kt
@@ -43,7 +43,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Dialog`.
  * @see Dialog
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.dialog(block: @WebforjDsl Dialog.() -> Unit = {}): Dialog {
   val dialog = Dialog()
   return init(dialog, block)
@@ -62,7 +61,6 @@ fun @WebforjDsl HasComponents.dialog(block: @WebforjDsl Dialog.() -> Unit = {}):
  *
  * @param block The initialization steps of the header components.
  */
-@WebforjDsl
 fun @WebforjDsl Dialog.headerSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Dialog::addToHeader)
 }
@@ -82,7 +80,6 @@ fun @WebforjDsl Dialog.headerSlot(block: @WebforjDsl HasComponents.() -> Unit) {
  *
  * @param block The initialization steps of the footer components.
  */
-@WebforjDsl
 fun @WebforjDsl Dialog.footerSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Dialog::addToFooter)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/drawer/Drawer.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/drawer/Drawer.kt
@@ -60,7 +60,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Drawer`.
  * @see Drawer
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.drawer(
   label: String? = null,
   block: @WebforjDsl Drawer.() -> Unit = {}
@@ -82,7 +81,6 @@ fun @WebforjDsl HasComponents.drawer(
  *
  * @param block The initialization steps of the title components.
  */
-@WebforjDsl
 fun @WebforjDsl Drawer.titleSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Drawer::addToTitle)
 }
@@ -102,7 +100,6 @@ fun @WebforjDsl Drawer.titleSlot(block: @WebforjDsl HasComponents.() -> Unit) {
  *
  * @param block The initialization steps of header action components.
  */
-@WebforjDsl
 fun @WebforjDsl Drawer.headerActionsSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Drawer::addToHeaderActions)
 }
@@ -123,7 +120,6 @@ fun @WebforjDsl Drawer.headerActionsSlot(block: @WebforjDsl HasComponents.() -> 
  *
  * @param block The initialization steps of the footer components.
  */
-@WebforjDsl
 fun @WebforjDsl Drawer.footerSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Drawer::addToFooter)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/element/Element.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/element/Element.kt
@@ -25,7 +25,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Element` instance.
  * @see Element
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.element(node: String? = null, html: String? = null, block: @WebforjDsl Element.() -> Unit = {}): Element {
   val element = when {
     node != null && html != null -> Element(node, html)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/ColorField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/ColorField.kt
@@ -30,7 +30,6 @@ import java.awt.Color
  * @see ColorField
  * @see Color
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.colorField(
     label: String? = null,
     value: Color? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/DateField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/DateField.kt
@@ -30,7 +30,6 @@ import java.time.LocalDate
  * @see DateField
  * @see LocalDate
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.dateField(
   label: String? = null,
   value: LocalDate? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/DateTimeField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/DateTimeField.kt
@@ -30,7 +30,6 @@ import java.time.LocalDateTime
  * @see DateTimeField
  * @see LocalDateTime
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.dateTimeField(
   label: String? = null,
   value: LocalDateTime? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedDateField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedDateField.kt
@@ -28,7 +28,6 @@ import java.time.LocalDate
  * @see MaskedDateField
  * @see LocalDate
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.maskedDateField(
   label: String? = null,
   value: LocalDate? = null,
@@ -63,6 +62,5 @@ fun @WebforjDsl HasComponents.maskedDateField(
  * @return The configured `DatePicker` instance.
  * @see DatePicker
  */
-@WebforjDsl
 fun @WebforjDsl MaskedDateField.picker(block: @WebforjDsl DatePicker.() -> Unit = {}): DatePicker =
   picker.apply(block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedDateFieldSpinner.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedDateFieldSpinner.kt
@@ -32,7 +32,6 @@ import java.time.LocalDate
  * @see MaskedDateFieldSpinner
  * @see LocalDate
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.maskedDateFieldSpinner(
   label: String? = null,
   value: LocalDate? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedNumberField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedNumberField.kt
@@ -25,7 +25,6 @@ import com.webforj.kotlin.KotlinFactory.newMaskedNumberField
  * @return The configured `MaskedNumberField` instance.
  * @see MaskedNumberField
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.maskedNumberField(
   label: String? = null,
   value: Double? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedNumberFieldSpinner.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedNumberFieldSpinner.kt
@@ -30,7 +30,6 @@ import com.webforj.kotlin.extension.suffixSlot
  * @return The configured `MaskedNumberFieldSpinner` instance.
  * @see MaskedNumberFieldSpinner
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.maskedNumberFieldSpinner(
   label: String? = null,
   value: Double? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedTextField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedTextField.kt
@@ -25,7 +25,6 @@ import com.webforj.kotlin.KotlinFactory.newMaskedTextField
  * @return The configured `MaskedTextField` instance.
  * @see MaskedTextField
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.maskedTextField(
   label: String? = null,
   value: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedTextFieldSpinner.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedTextFieldSpinner.kt
@@ -30,7 +30,6 @@ import com.webforj.kotlin.extension.suffixSlot
  * @return The configured `MaskedTextFieldSpinner` instance.
  * @see MaskedTextFieldSpinner
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.maskedTextFieldSpinner(
   label: String? = null,
   value: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedTimeField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedTimeField.kt
@@ -28,7 +28,6 @@ import java.time.LocalTime
  * @see MaskedTimeField
  * @see LocalTime
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.maskedTimeField(
   label: String? = null,
   value: LocalTime? = null,
@@ -63,6 +62,5 @@ fun @WebforjDsl HasComponents.maskedTimeField(
  * @return The configured `TimePicker` instance.
  * @see TimePicker
  */
-@WebforjDsl
 fun @WebforjDsl MaskedTimeField.picker(block: @WebforjDsl TimePicker.() -> Unit = {}): TimePicker =
   picker.apply(block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedTimeFieldSpinner.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/MaskedTimeFieldSpinner.kt
@@ -32,7 +32,6 @@ import java.time.LocalTime
  * @see MaskedTimeFieldSpinner
  * @see LocalTime
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.maskedTimeFieldSpinner(
   label: String? = null,
   value: LocalTime? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/NumberField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/NumberField.kt
@@ -33,7 +33,6 @@ import com.webforj.kotlin.extension.suffixSlot
  * @see NumberField
  * @see Double
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.numberField(
   label: String? = null,
   value: Double? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/PasswordField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/PasswordField.kt
@@ -32,7 +32,6 @@ import com.webforj.kotlin.extension.suffixSlot
  * @return The configured `PasswordField` instance.
  * @see PasswordField
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.passwordField(
   label: String? = null,
   value: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/TextArea.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/TextArea.kt
@@ -32,7 +32,6 @@ import com.webforj.kotlin.extension.suffixSlot
  * @return The configured `TextArea` instance.
  * @see TextArea
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.textArea(
   label: String? = null,
   value: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/TextField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/TextField.kt
@@ -33,7 +33,6 @@ import com.webforj.kotlin.extension.suffixSlot
  * @return The configured `TextField` instance.
  * @see TextField
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.textField(
   label: String? = null,
   value: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/TextFieldSpinner.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/TextFieldSpinner.kt
@@ -32,7 +32,6 @@ import com.webforj.kotlin.extension.suffixSlot
  * @return The configured `TextFieldSpinner` instance.
  * @see TextFieldSpinner
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.textFieldSpinner(
   label: String? = null,
   value: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/TimeField.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/field/TimeField.kt
@@ -30,7 +30,6 @@ import java.time.LocalTime
  * @see TimeField
  * @see LocalTime
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.timeField(
   label: String? = null,
   value: LocalTime? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/googlecharts/GoogleChart.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/googlecharts/GoogleChart.kt
@@ -48,7 +48,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `GoogleChart`.
  * @see GoogleChart
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.googleChart(type: GoogleChart.Type? = null, block: @WebforjDsl GoogleChart.() -> Unit = {}): GoogleChart {
   val chart = type?.let { GoogleChart(it) } ?: GoogleChart()
   return init(chart, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Anchor.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Anchor.kt
@@ -28,7 +28,6 @@ import com.webforj.kotlin.dsl.init
  * @see Anchor
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">Html a Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.anchor(
     href: String? = null,
     text: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Article.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Article.kt
@@ -18,7 +18,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Article` instance.
  * @see Article
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.article(text: String? = null, block: @WebforjDsl Article.() -> Unit = {}): Article  {
   val article = text?.let { Article(it) } ?: Article()
   return init(article, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Aside.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Aside.kt
@@ -19,7 +19,6 @@ import com.webforj.kotlin.dsl.init
  * @see Aside
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside">HTML aside Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.aside(text: String? = null, block: @WebforjDsl Aside.() -> Unit = {}): Aside {
     val aside = text?.let { Aside(text) } ?: Aside()
     return init(aside, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Break.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Break.kt
@@ -16,7 +16,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Break` instance.
  * @see Break
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.`break`(block:  @WebforjDsl Break.() -> Unit = {}): Break {
   val `break` = Break()
   return init(`break`, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Div.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Div.kt
@@ -18,7 +18,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Div` instance.
  * @see Div
  */
-@WebforjDsl
 fun  @WebforjDsl HasComponents.div(text: String? = null, block:  @WebforjDsl Div.() -> Unit = {}): Div {
   val div = text?.let { Div(it) } ?: Div()
   return init(div, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Emphasis.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Emphasis.kt
@@ -19,7 +19,6 @@ import com.webforj.kotlin.dsl.init
  * @see Emphasis
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em">HTML em Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.emphasis(text: String? = null, block: @WebforjDsl Emphasis.() -> Unit = {}): Emphasis {
     val emphasis = text?.let { Emphasis(text) } ?: Emphasis()
     return init(emphasis, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/FieldSet.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/FieldSet.kt
@@ -22,7 +22,6 @@ import com.webforj.kotlin.dsl.init
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset">Html fieldset
  *       Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.fieldset(text: String? = null, block: @WebforjDsl Fieldset.() -> Unit = {}): Fieldset {
     val fieldSet = text?.let { Fieldset(text) } ?: Fieldset()
     return init(fieldSet, block)
@@ -44,7 +43,6 @@ fun @WebforjDsl HasComponents.fieldset(text: String? = null, block: @WebforjDsl 
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend">HTML legend
  *      Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl Fieldset.legend(text: String? = null, block: @WebforjDsl Legend.() -> Unit = {}): Legend {
     val legend = text?.let { Legend(text) } ?: Legend()
     return init(legend, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Footer.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Footer.kt
@@ -18,7 +18,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Footer` instance.
  * @see Footer
  */
-@WebforjDsl
 fun  @WebforjDsl HasComponents.footer(text: String? = null, block:  @WebforjDsl Footer.() -> Unit = {}): Footer {
   val footer = text?.let { Footer(it) } ?: Footer()
   return init(footer, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/FormattedText.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/FormattedText.kt
@@ -19,7 +19,6 @@ import com.webforj.kotlin.dsl.init
  * @see FormattedText
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre">HTML pre Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.formattedText(text: String? = null, block: @WebforjDsl FormattedText.() -> Unit = {}): FormattedText {
     val formattedText = text?.let { FormattedText(text) } ?: FormattedText()
     return init(formattedText, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H1.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H1.kt
@@ -13,7 +13,6 @@ import com.webforj.kotlin.dsl.init
  *   H1("text") // h1 element with text
  * }
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.h1(text: String? = null, block: @WebforjDsl H1.() -> Unit = {}): H1 {
     val h1 = text?.let { H1(text) } ?: H1()
     return init(h1, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H2.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H2.kt
@@ -13,7 +13,6 @@ import com.webforj.kotlin.dsl.init
  *   H2("text") // h2 element with text
  * }
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.h2(text: String? = null, block: @WebforjDsl H2.() -> Unit = {}): H2 {
     val h2 = text?.let { H2(text) } ?: H2()
     return init(h2, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H3.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H3.kt
@@ -13,7 +13,6 @@ import com.webforj.kotlin.dsl.init
  *   H3("text") // h3 element with text
  * }
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.h3(text: String? = null, block: @WebforjDsl H3.() -> Unit = {}): H3 {
     val h3 = text?.let { H3(text) } ?: H3()
     return init(h3, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H4.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H4.kt
@@ -13,7 +13,6 @@ import com.webforj.kotlin.dsl.init
  *   H4("text") // h4 element with text
  * }
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.h4(text: String? = null, block: @WebforjDsl H4.() -> Unit = {}): H4 {
     val h4 = text?.let { H4(text) } ?: H4()
     return init(h4, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H5.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H5.kt
@@ -13,7 +13,6 @@ import com.webforj.kotlin.dsl.init
  *   H5("text") // h5 element with text
  * }
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.h5(text: String? = null, block: @WebforjDsl H5.() -> Unit = {}): H5 {
     val h5 = text?.let { H5(text) } ?: H5()
     return init(h5, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H6.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/H6.kt
@@ -13,7 +13,6 @@ import com.webforj.kotlin.dsl.init
  *   H6("text") // h6 element with text
  * }
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.h6(text: String? = null, block: @WebforjDsl H6.() -> Unit = {}): H6 {
     val h6 = text?.let { H6(text) } ?: H6()
     return init(h6, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Header.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Header.kt
@@ -18,7 +18,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Header` instance.
  * @see Header
  */
-@WebforjDsl
 fun  @WebforjDsl HasComponents.header(text: String? = null, block:  @WebforjDsl Header.() -> Unit = {}): Header {
   val header = text?.let { Header(it) } ?: Header()
   return init(header, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Iframe.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Iframe.kt
@@ -19,7 +19,6 @@ import com.webforj.kotlin.dsl.init
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe">HTML iframe
  *      Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.iframe(block: @WebforjDsl Iframe.() -> Unit = {}): Iframe {
     return init(Iframe(), block)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Img.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Img.kt
@@ -22,7 +22,6 @@ import com.webforj.kotlin.dsl.init
  * @see Img
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img">HTML img Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.img(src: String? = null, alt: String? = null, block: @WebforjDsl Img.() -> Unit = {}): Img {
     val img = if (alt != null && src != null) {
         Img(src, alt)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Main.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Main.kt
@@ -18,7 +18,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Main` instance.
  * @see Main
  */
-@WebforjDsl
 fun  @WebforjDsl HasComponents.main(text: String? = null, block:  @WebforjDsl Main.() -> Unit = {}): Main {
   val main = text?.let { Main(it) } ?: Main()
   return init(main, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/NativeButton.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/NativeButton.kt
@@ -21,7 +21,6 @@ import com.webforj.kotlin.dsl.init
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">HTML button
  *       Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.nativeButton(text: String? = null, block: @WebforjDsl NativeButton.() -> Unit = {}): NativeButton {
     val button = text?.let { NativeButton(text) } ?: NativeButton()
     return init(button, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Nav.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Nav.kt
@@ -20,7 +20,6 @@ import com.webforj.kotlin.dsl.init
  * @see Nav
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav">HTML nav Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.nav(text: String? = null, block: @WebforjDsl Nav.() -> Unit = {}): Nav {
     val nav = text?.let { Nav(it) } ?: Nav()
     return init(nav, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/OrderedList.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/OrderedList.kt
@@ -20,7 +20,6 @@ import com.webforj.kotlin.dsl.init
  * @see OrderedList
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol">HTML ol Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.orderedList(text: String? = null, block: @WebforjDsl OrderedList.() -> Unit = {}): OrderedList {
     val ul = text?.let { OrderedList(text) } ?: OrderedList()
     return init(ul, block)
@@ -41,7 +40,6 @@ fun @WebforjDsl HasComponents.orderedList(text: String? = null, block: @WebforjD
  * @see ListEntry
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li">HTML li Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl OrderedList.listEntry(text: String? = null, block: @WebforjDsl ListEntry.() -> Unit = {}): ListEntry {
     val li = text?.let { ListEntry(text) } ?: ListEntry()
     return init(li, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Paragraph.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Paragraph.kt
@@ -19,7 +19,6 @@ import com.webforj.kotlin.dsl.init
  * @see Paragraph
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p">HTML p Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.paragraph(text: String? = null, block: @WebforjDsl Paragraph.() -> Unit = {}): Paragraph {
     val paragraph = text?.let { Paragraph(text) } ?: Paragraph()
     return init(paragraph, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Section.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Section.kt
@@ -18,7 +18,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Section` instance.
  * @see Section
  */
-@WebforjDsl
 fun  @WebforjDsl HasComponents.section(text: String? = null, block:  @WebforjDsl Section.() -> Unit = {}): Section {
   val section = text?.let { Section(it) } ?: Section()
   return init(section, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Span.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Span.kt
@@ -19,7 +19,6 @@ import com.webforj.kotlin.dsl.init
  * @see Span
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span">HTML span Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.span(text: String? = null, block: @WebforjDsl Span.() -> Unit = {}): Span {
     val span = text?.let { Span(text) } ?: Span()
     return init(span, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Strong.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/Strong.kt
@@ -20,7 +20,6 @@ import com.webforj.kotlin.dsl.init
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong">Html strong
  *      Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.strong(text: String? = null, block: @WebforjDsl Strong.() -> Unit = {}): Strong {
     val strong = text?.let { Strong(text) } ?: Strong()
     return init(strong, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/UnorderedList.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/html/elements/UnorderedList.kt
@@ -20,7 +20,6 @@ import com.webforj.kotlin.dsl.init
  * @see UnorderedList
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul">HTML ul Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.unorderedList(text: String? = null, block: @WebforjDsl UnorderedList.() -> Unit = {}): UnorderedList {
     val ul = text?.let { UnorderedList(text) } ?: UnorderedList()
     return init(ul, block)
@@ -41,7 +40,6 @@ fun @WebforjDsl HasComponents.unorderedList(text: String? = null, block: @Webfor
  * @see ListEntry
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li">HTML li Tag</a>
  */
-@WebforjDsl
 fun @WebforjDsl UnorderedList.listEntry(text: String? = null, block: @WebforjDsl ListEntry.() -> Unit = {}): ListEntry {
     val li = text?.let { ListEntry(text) } ?: ListEntry()
     return init(li, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/DwcIcon.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/DwcIcon.kt
@@ -22,5 +22,4 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Icon`.
  * @see DwcIcon
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.dwcIcon(icon: DwcIcon, block: @WebforjDsl Icon.() -> Unit = {}): Icon = init(icon.create(), block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/FeatherIcon.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/FeatherIcon.kt
@@ -22,5 +22,4 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Icon`.
  * @see FeatherIcon
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.featherIcon(icon: FeatherIcon, block: @WebforjDsl Icon.() -> Unit = {}): Icon = init(icon.create(), block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/FontAwesomeIcon.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/FontAwesomeIcon.kt
@@ -26,7 +26,6 @@ import com.webforj.kotlin.dsl.init
  * @see FontAwesomeIcon
  * @see Icon
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.fontAwesomeIcon(
   name: String,
   variate: FontAwesomeIcon.Variate? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/Icon.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/Icon.kt
@@ -22,7 +22,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Icon` instance.
  * @see Icon
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.icon(
   name: String,
   pool: String,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/IconButton.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/IconButton.kt
@@ -21,7 +21,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `IconButton` instance.
  * @see IconButton
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.iconButton(
   name: String,
   pool: String,
@@ -44,7 +43,6 @@ fun @WebforjDsl HasComponents.iconButton(
  * @see IconButton
  * @see Icon
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.iconButton(
   icon: Icon,
   block: @WebforjDsl IconButton.() -> Unit = {}

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/TablerIcon.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/icons/TablerIcon.kt
@@ -26,7 +26,6 @@ import com.webforj.kotlin.dsl.init
  * @see TablerIcon
  * @see Icon
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.tablerIcon(
   name: String,
   variate: TablerIcon.Variate? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/infiniitescroll/InfiniteScroll.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/infiniitescroll/InfiniteScroll.kt
@@ -25,7 +25,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `InfiniteScroll`.
  * @see InfiniteScroll
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.infiniteScroll(text: String? = null, block: @WebforjDsl InfiniteScroll.() -> Unit = {}): InfiniteScroll {
   val scroll = text?.let { InfiniteScroll(it) } ?: InfiniteScroll()
   return init(scroll, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/applayout/AppDrawerToggle.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/applayout/AppDrawerToggle.kt
@@ -21,7 +21,6 @@ import com.webforj.kotlin.dsl.init
  * @see AppDrawerToggle
  * @see Icon
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.appDrawerToggle(
   icon: Pair<String, String>? = null,
   block: @WebforjDsl AppDrawerToggle.() -> Unit = {}
@@ -45,7 +44,6 @@ fun @WebforjDsl HasComponents.appDrawerToggle(
  * @see AppDrawerToggle
  * @see Icon
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.appDrawerToggle(
   icon: Icon,
   block: @WebforjDsl AppDrawerToggle.() -> Unit = {}

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/applayout/AppLayout.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/applayout/AppLayout.kt
@@ -49,7 +49,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `AppLayout`.
  * @see AppLayout
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.appLayout(block: @WebforjDsl AppLayout.() -> Unit = {}): AppLayout {
   val layout = AppLayout()
   return init(layout, block)
@@ -68,7 +67,6 @@ fun @WebforjDsl HasComponents.appLayout(block: @WebforjDsl AppLayout.() -> Unit 
  *
  * @param block The initialization steps of the header components.
  */
-@WebforjDsl
 fun @WebforjDsl AppLayout.headerSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, AppLayout::addToHeader)
 }
@@ -86,7 +84,6 @@ fun @WebforjDsl AppLayout.headerSlot(block: @WebforjDsl HasComponents.() -> Unit
  *
  * @param block The initialization steps of the footer components.
  */
-@WebforjDsl
 fun @WebforjDsl AppLayout.footerSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, AppLayout::addToFooter)
 }
@@ -105,7 +102,6 @@ fun @WebforjDsl AppLayout.footerSlot(block: @WebforjDsl HasComponents.() -> Unit
  *
  * @param block The initialization steps of the drawer components.
  */
-@WebforjDsl
 fun @WebforjDsl AppLayout.drawerSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, AppLayout::addToDrawer)
 }
@@ -122,7 +118,6 @@ fun @WebforjDsl AppLayout.drawerSlot(block: @WebforjDsl HasComponents.() -> Unit
  *
  * @param block The initialization steps of the drawer title components.
  */
-@WebforjDsl
 fun @WebforjDsl AppLayout.drawerTitleSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, AppLayout::addToDrawerTitle)
 }
@@ -140,7 +135,6 @@ fun @WebforjDsl AppLayout.drawerTitleSlot(block: @WebforjDsl HasComponents.() ->
  *
  * @param block The initialization steps of the drawer header actions components.
  */
-@WebforjDsl
 fun @WebforjDsl AppLayout.drawerHeaderActionsSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, AppLayout::addToDrawerHeaderActions)
 }
@@ -158,7 +152,6 @@ fun @WebforjDsl AppLayout.drawerHeaderActionsSlot(block: @WebforjDsl HasComponen
  *
  * @param block The initialization steps of the drawer footer components.
  */
-@WebforjDsl
 fun @WebforjDsl AppLayout.drawerFooterSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, AppLayout::addToDrawerFooter)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNav.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNav.kt
@@ -30,7 +30,6 @@ import kotlin.reflect.KClass
  * @return The configured `AppNav`.
  * @see AppNav
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.appNav(block: @WebforjDsl AppNav.() -> Unit = {}): AppNav = init(AppNav(), block)
 
 /**
@@ -60,7 +59,6 @@ fun @WebforjDsl HasComponents.appNav(block: @WebforjDsl AppNav.() -> Unit = {}):
  * @return The configured `AppNavItem`.
  * @see AppNavItem
  */
-@WebforjDsl
 fun @WebforjDsl AppNav.appNavItem(
   text: String,
   path: String? = null,
@@ -98,7 +96,6 @@ fun @WebforjDsl AppNav.appNavItem(
  * @return The configured `AppNavItem`.
  * @see AppNavItem
  */
-@WebforjDsl
 fun @WebforjDsl AppNavItem.appNavItem(
   text: String,
   path: String? = null,
@@ -111,7 +108,6 @@ fun @WebforjDsl AppNavItem.appNavItem(
   return item
 }
 
-@WebforjDsl
 private fun createAppNavItem(
   text: String,
   path: String? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/columnslayout/ColumnsLayout.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/columnslayout/ColumnsLayout.kt
@@ -37,7 +37,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `ColumnsLayout` instance.
  * @see ColumnsLayout
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.columnsLayout(
   vararg breakpoints: ColumnsLayout.Breakpoint = emptyArray(),
   block: @WebforjDsl ColumnsLayout.() -> Unit = {}

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/flexlayout/FlexLayout.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/flexlayout/FlexLayout.kt
@@ -49,7 +49,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `FlexLayout` instance.
  * @see FlexLayout
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.flexLayout(
   direction: FlexDirection? = null,
   block: @WebforjDsl FlexLayout.() -> Unit = {}

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/ChoiceBox.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/ChoiceBox.kt
@@ -20,7 +20,6 @@ import com.webforj.kotlin.dsl.init
  * @see ChoiceBox
  * @see listItem
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.choiceBox(label: String? = null, block: @WebforjDsl ChoiceBox.() -> Unit = {}): ChoiceBox {
   val choiceBox = label?.let { ChoiceBox(it) } ?: ChoiceBox()
   return init(choiceBox, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/ComboBox.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/ComboBox.kt
@@ -20,7 +20,6 @@ import com.webforj.kotlin.dsl.init
  * @see ComboBox
  * @see listItem
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.comboBox(label: String? = null, block: @WebforjDsl ComboBox.() -> Unit = {}): ComboBox {
   val comboBox = label?.let { ComboBox(it) } ?: ComboBox()
   return init(comboBox, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/DwcList.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/DwcList.kt
@@ -18,7 +18,6 @@ import com.webforj.kotlin.dsl.WebforjDsl
  * @param items Variable number of pairs where the first element is the key and the second is the display text
  * @param index Optional position to insert the items. If null, items are appended to the end
  */
-@WebforjDsl
 fun @WebforjDsl DwcList<*, *>.items(vararg items: Pair<Any, String>, index: Int? = null) {
   val list = items.map { ListItem(it.first, it.second) }
   if (index != null) {
@@ -39,7 +38,6 @@ fun @WebforjDsl DwcList<*, *>.items(vararg items: Pair<Any, String>, index: Int?
  * @param items Variable number of strings to add as list items
  * @param index Optional position to insert the items. If null, items are appended to the end
  */
-@WebforjDsl
 fun @WebforjDsl DwcList<*, *>.items(vararg items: String, index: Int? = null) {
   index?.let { insert(it, *items) } ?: insert(*items)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/ListBox.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/ListBox.kt
@@ -20,7 +20,6 @@ import com.webforj.kotlin.dsl.init
  * @see ListBox
  * @see listItem
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.listBox(label: String? = null, block: @WebforjDsl ListBox.() -> Unit = {}): ListBox {
   val listBox = label?.let { ListBox(it) } ?: ListBox()
   return init(listBox, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/ListItem.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/list/ListItem.kt
@@ -22,7 +22,6 @@ import com.webforj.kotlin.dsl.WebforjDsl
  * @see comboBox
  * @see listBox
  */
-@WebforjDsl
 fun @WebforjDsl DwcList<*, *>.listItem(text: String, key: Any? = null, block: @WebforjDsl ListItem.() -> Unit = {}): ListItem {
   val listItem = key?.let { ListItem(key, text) } ?: ListItem(text)
   listItem.block()

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/loading/Loading.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/loading/Loading.kt
@@ -24,7 +24,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Loading`.
  * @see Loading
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.loading(text: String? = null, block: @WebforjDsl Loading.() -> Unit = {}): Loading {
   val loading = text?.let { Loading(it) } ?: Loading()
   return init(loading, block)
@@ -45,6 +44,5 @@ fun @WebforjDsl HasComponents.loading(text: String? = null, block: @WebforjDsl L
  * @see LoadingSpinner
  * @see DwcSpinner
  */
-@WebforjDsl
 fun @WebforjDsl Loading.spinner(block: @WebforjDsl DwcSpinner<LoadingSpinner>.() -> Unit): LoadingSpinner =
   spinner.apply(block) as LoadingSpinner

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/login/Login.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/login/Login.kt
@@ -41,7 +41,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Login`.
  * @see Login
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.login(block: @WebforjDsl Login.() -> Unit = {}): Login = init(Login(), block)
 
 /**
@@ -57,7 +56,6 @@ fun @WebforjDsl HasComponents.login(block: @WebforjDsl Login.() -> Unit = {}): L
  *
  * @param block The initialization steps of the before header components.
  */
-@WebforjDsl
 fun @WebforjDsl Login.beforeHeaderSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Login::addToBeforeHeader)
 }
@@ -75,7 +73,6 @@ fun @WebforjDsl Login.beforeHeaderSlot(block: @WebforjDsl HasComponents.() -> Un
  *
  * @param block The initialization steps of the after header components.
  */
-@WebforjDsl
 fun @WebforjDsl Login.afterHeaderSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Login::addToAfterHeader)
 }
@@ -93,7 +90,6 @@ fun @WebforjDsl Login.afterHeaderSlot(block: @WebforjDsl HasComponents.() -> Uni
  *
  * @param block The initialization steps of the before content components.
  */
-@WebforjDsl
 fun @WebforjDsl Login.beforeContentSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Login::addToBeforeContent)
 }
@@ -111,7 +107,6 @@ fun @WebforjDsl Login.beforeContentSlot(block: @WebforjDsl HasComponents.() -> U
  *
  * @param block The initialization steps of the after content components.
  */
-@WebforjDsl
 fun @WebforjDsl Login.afterContentSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Login::addToAfterContent)
 }
@@ -129,7 +124,6 @@ fun @WebforjDsl Login.afterContentSlot(block: @WebforjDsl HasComponents.() -> Un
  *
  * @param block The initialization steps of the before form components.
  */
-@WebforjDsl
 fun @WebforjDsl Login.beforeFormSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Login::addToBeforeForm)
 }
@@ -147,7 +141,6 @@ fun @WebforjDsl Login.beforeFormSlot(block: @WebforjDsl HasComponents.() -> Unit
  *
  * @param block The initialization steps of the after form components.
  */
-@WebforjDsl
 fun @WebforjDsl Login.afterFormSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Login::addToAfterForm)
 }
@@ -165,7 +158,6 @@ fun @WebforjDsl Login.afterFormSlot(block: @WebforjDsl HasComponents.() -> Unit)
  *
  * @param block The initialization steps of the before footer components.
  */
-@WebforjDsl
 fun @WebforjDsl Login.beforeFooterSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Login::addToBeforeFooter)
 }
@@ -183,7 +175,6 @@ fun @WebforjDsl Login.beforeFooterSlot(block: @WebforjDsl HasComponents.() -> Un
  *
  * @param block The initialization steps of the after footer components.
  */
-@WebforjDsl
 fun @WebforjDsl Login.afterFooterSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Login::addToAfterFooter)
 }
@@ -209,7 +200,6 @@ fun @WebforjDsl Login.afterFooterSlot(block: @WebforjDsl HasComponents.() -> Uni
  * @return The configured `LoginI18n`.
  * @see LoginI18n
  */
-@WebforjDsl
 fun @WebforjDsl Login.loginI18n(block: @WebforjDsl LoginI18n.() -> Unit): LoginI18n {
   val loginI18n = LoginI18n().apply(block)
   i18n = loginI18n
@@ -233,5 +223,4 @@ fun @WebforjDsl Login.loginI18n(block: @WebforjDsl LoginI18n.() -> Unit): LoginI
  * @return The configured `LoginErrorI18n`.
  * @see LoginErrorI18n
  */
-@WebforjDsl
 fun @WebforjDsl LoginI18n.loginErrorI18n(block: @WebforjDsl LoginErrorI18n.() -> Unit): LoginErrorI18n = error.apply(block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/markdown/MarkdownViewer.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/markdown/MarkdownViewer.kt
@@ -27,7 +27,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `MarkdownViewer`.
  * @see MarkdownViewer
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.markdownViewer(content: String? = null, block: @WebforjDsl MarkdownViewer.() -> Unit = {}): MarkdownViewer {
   val viewer = content?.let { MarkdownViewer(it) } ?: MarkdownViewer()
   return init(viewer, block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/navigator/Navigator.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/navigator/Navigator.kt
@@ -25,7 +25,6 @@ import com.webforj.kotlin.dsl.init
  * @see Navigator
  * @see [paginator]
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.navigator(
   text: String? = null,
   layout: Navigator.Layout? = null,
@@ -75,7 +74,6 @@ fun @WebforjDsl HasComponents.navigator(
  * @see Repository
  * @see [paginator]
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.navigator(
   repository: Repository<*>,
   text: String? = null,
@@ -120,7 +118,6 @@ fun @WebforjDsl HasComponents.navigator(
  * @see Repository
  * @see [navigator]
  */
-@WebforjDsl
 fun @WebforjDsl Navigator.paginator(
   pageSize: Int? = null,
   totalItems: Int? = null,
@@ -155,7 +152,6 @@ fun @WebforjDsl Navigator.paginator(
  * @see Repository
  * @see [navigator]
  */
-@WebforjDsl
 fun @WebforjDsl Navigator.paginator(
   repository: Repository<*>,
   pageSize: Int? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/optioninput/CheckBox.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/optioninput/CheckBox.kt
@@ -22,7 +22,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `CheckBox`.
  * @see CheckBox
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.checkBox(
   text: String? = null,
   checked: Boolean? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/optioninput/RadioButton.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/optioninput/RadioButton.kt
@@ -24,7 +24,6 @@ import com.webforj.kotlin.dsl.init
  * @see RadioButton
  * @see switch
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.radioButton(
   text: String? = null,
   checked: Boolean? = null,
@@ -53,7 +52,6 @@ fun @WebforjDsl HasComponents.radioButton(
  * @see RadioButton
  * @see radioButton
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.switch(
   text: String? = null,
   checked: Boolean? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/optioninput/RadioButtonGroup.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/optioninput/RadioButtonGroup.kt
@@ -21,7 +21,6 @@ import com.webforj.kotlin.dsl.init
  * @see radioButton
  * @see switch
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.radioButtonGroup(name: String? = null, block: @WebforjDsl RadioButtonGroup.() -> Unit): RadioButtonGroup {
   val group = name?.let { RadioButtonGroup(it) } ?: RadioButtonGroup()
   return init(group, block)
@@ -45,7 +44,6 @@ fun @WebforjDsl HasComponents.radioButtonGroup(name: String? = null, block: @Web
  * @see switch
  * @see radioButtonGroup
  */
-@WebforjDsl
 fun @WebforjDsl RadioButtonGroup.radioButton(
   text: String? = null,
   checked: Boolean? = null,
@@ -77,7 +75,6 @@ fun @WebforjDsl RadioButtonGroup.radioButton(
  * @see radioButton
  * @see radioButtonGroup
  */
-@WebforjDsl
 fun @WebforjDsl RadioButtonGroup.switch(
   text: String? = null,
   checked: Boolean? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/progressbar/ProgressBar.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/progressbar/ProgressBar.kt
@@ -28,7 +28,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `ProgressBar`.
  * @see ProgressBar
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.progressBar(
   value: Int? = null,
   min: Int? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/refresher/Refresher.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/refresher/Refresher.kt
@@ -25,7 +25,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Refresher`.
  * @see Refresher
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.refresher(block: @WebforjDsl Refresher.() -> Unit = {}): Refresher = init(Refresher(), block)
 
 /**
@@ -43,6 +42,5 @@ fun @WebforjDsl HasComponents.refresher(block: @WebforjDsl Refresher.() -> Unit 
  * @return The configured `RefresherI18n` instance.
  * @see RefresherI18n
  */
-@WebforjDsl
 fun @WebforjDsl Refresher.i18n(block: @WebforjDsl RefresherI18n.() -> Unit): RefresherI18n =
   i18n.apply(block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/slider/Slider.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/slider/Slider.kt
@@ -49,7 +49,6 @@ import com.webforj.kotlin.dsl.init
  * @see Slider
  * @see Slider.Orientation
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.slider(
   value: Int? = null,
   min: Int? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/spinner/Spinner.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/spinner/Spinner.kt
@@ -28,7 +28,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Spinner`.
  * @see Spinner
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.spinner(
   theme: Theme? = null,
   spinnerExpanse: SpinnerExpanse? = null,

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/splitter/Splitter.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/splitter/Splitter.kt
@@ -37,7 +37,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Splitter`.
  * @see Splitter
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.splitter(id: String? = null, block: @WebforjDsl Splitter.() -> Unit = {}): Splitter {
   val splitter = id?.let { Splitter(id) } ?: Splitter()
   return init(splitter, block)
@@ -61,7 +60,6 @@ fun @WebforjDsl HasComponents.splitter(id: String? = null, block: @WebforjDsl Sp
  *
  * @param block The initialization steps of the master component.
  */
-@WebforjDsl
 fun @WebforjDsl Splitter.masterSlot(block: @WebforjDsl HasComponents.() -> Component) {
   SingleSlotSetter(block).setSlot(this, Splitter::setMaster)
 }
@@ -83,7 +81,6 @@ fun @WebforjDsl Splitter.masterSlot(block: @WebforjDsl HasComponents.() -> Compo
  *
  * @param block The initialization steps of the detail component.
  */
-@WebforjDsl
 fun @WebforjDsl Splitter.detailSlot(block: @WebforjDsl HasComponents.() -> Component) {
   SingleSlotSetter(block).setSlot(this, Splitter::setDetail)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/tabbedpane/TabbedPane.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/tabbedpane/TabbedPane.kt
@@ -30,7 +30,6 @@ import com.webforj.kotlin.dsl.init
  * @see TabbedPane
  * @see tab
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.tabbedPane(name: String? = null, block: @WebforjDsl TabbedPane.() -> Unit = {}): TabbedPane {
   val tabbedPane = name?.let { TabbedPane(it) } ?: TabbedPane()
   return init(tabbedPane, block)
@@ -60,7 +59,6 @@ private val tabContentMap: MutableMap<Tab, Component?> = hashMapOf()
  * @see prefixSlot
  * @see suffixSlot
  */
-@WebforjDsl
 fun @WebforjDsl TabbedPane.tab(text: String, block: @WebforjDsl Tab.() -> Unit = {}): Tab {
   val tab = Tab(text)
   tab.block()
@@ -90,7 +88,6 @@ fun @WebforjDsl TabbedPane.tab(text: String, block: @WebforjDsl Tab.() -> Unit =
  * @see prefixSlot
  * @see suffixSlot
  */
-@WebforjDsl
 fun @WebforjDsl Tab.contentSlot(block: @WebforjDsl HasComponents.() -> Component) {
   tabContentMap[this] = SingleSlotSetter(block).component
 }
@@ -110,7 +107,6 @@ fun @WebforjDsl Tab.contentSlot(block: @WebforjDsl HasComponents.() -> Component
  * @see contentSlot
  * @see suffixSlot
  */
-@WebforjDsl
 fun @WebforjDsl Tab.prefixSlot(block: @WebforjDsl HasComponents.() -> Component) {
   SingleSlotSetter(block).setSlot(this, Tab::setPrefixComponent)
 }
@@ -130,7 +126,6 @@ fun @WebforjDsl Tab.prefixSlot(block: @WebforjDsl HasComponents.() -> Component)
  * @see contentSlot
  * @see prefixSlot
  */
-@WebforjDsl
 fun @WebforjDsl Tab.suffixSlot(block: @WebforjDsl HasComponents.() -> Component) {
   SingleSlotSetter(block).setSlot(this, Tab::setSuffixComponent)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/table/Table.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/table/Table.kt
@@ -60,7 +60,6 @@ import com.webforj.kotlin.dsl.init
  * @see Table
  * @see column
  */
-@WebforjDsl
 fun <T> @WebforjDsl HasComponents.table(block: @WebforjDsl Table<T>.() -> Unit = {}): Table<T> = init(Table<T>(), block)
 
 /**
@@ -80,7 +79,6 @@ fun <T> @WebforjDsl HasComponents.table(block: @WebforjDsl Table<T>.() -> Unit =
  * @see Column
  * @see Table.getColumnById
  */
-@WebforjDsl
 fun <T> @WebforjDsl Table<T>.column(id: String, block: @WebforjDsl Column<T, *>.() -> Unit = {}): Column<T, *>? {
   val column = getColumnById(id)
   column?.let(block)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/text/Label.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/text/Label.kt
@@ -19,7 +19,6 @@ import com.webforj.kotlin.dsl.init
  * @param block The initialization steps of the `Label`.
  * @return The configured `Label`.
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.label(text: String? = null, wrap: Boolean? = null, block: @WebforjDsl Label.() -> Unit = {}): Label {
   val label = when {
     wrap != null && text != null -> Label(text, wrap)

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/toast/Toast.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/toast/Toast.kt
@@ -36,7 +36,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Toast`.
  * @see Toast
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.toast(
   text: String? = null,
   duration: Int? = null,
@@ -77,7 +76,6 @@ fun @WebforjDsl HasComponents.toast(
  *
  * @param block The initialization steps of the message components.
  */
-@WebforjDsl
 fun @WebforjDsl Toast.messageSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Toast::addToMessage)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/toolbar/Toolbar.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/toolbar/Toolbar.kt
@@ -36,7 +36,6 @@ import com.webforj.kotlin.dsl.init
  * @return The configured `Toolbar`.
  * @see Toolbar
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.toolbar(block: @WebforjDsl Toolbar.() -> Unit = {}): Toolbar = init(Toolbar(), block)
 
 /**
@@ -51,7 +50,6 @@ fun @WebforjDsl HasComponents.toolbar(block: @WebforjDsl Toolbar.() -> Unit = {}
  *
  * @param block The initialization steps of the start components.
  */
-@WebforjDsl
 fun @WebforjDsl Toolbar.startSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Toolbar::addToStart)
 }
@@ -68,7 +66,6 @@ fun @WebforjDsl Toolbar.startSlot(block: @WebforjDsl HasComponents.() -> Unit) {
  *
  * @param block The initialization steps of the title components.
  */
-@WebforjDsl
 fun @WebforjDsl Toolbar.titleSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Toolbar::addToTitle)
 }
@@ -86,7 +83,6 @@ fun @WebforjDsl Toolbar.titleSlot(block: @WebforjDsl HasComponents.() -> Unit) {
  *
  * @param block The initialization steps of the end components.
  */
-@WebforjDsl
 fun @WebforjDsl Toolbar.endSlot(block: @WebforjDsl HasComponents.() -> Unit) {
   MultiSlotSetter(block).setSlot(this, Toolbar::addToEnd)
 }

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/tree/Tree.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/tree/Tree.kt
@@ -42,7 +42,6 @@ import com.webforj.kotlin.dsl.init
  * @see Tree
  * @see treeNode
  */
-@WebforjDsl
 fun @WebforjDsl HasComponents.tree(block: @WebforjDsl Tree.() -> Unit = {}): Tree {
   val tree = Tree()
   return init(tree, block)
@@ -66,7 +65,6 @@ fun @WebforjDsl HasComponents.tree(block: @WebforjDsl Tree.() -> Unit = {}): Tre
  * @see tree
  * @see treeNode
  */
-@WebforjDsl
 fun @WebforjDsl Tree.treeNode(text: String, key: Any? = null, block: @WebforjDsl TreeNode.() -> Unit = {}): TreeNode {
   val node = key?.let { TreeNode(key, text) } ?: TreeNode(text)
   node.block()
@@ -92,7 +90,6 @@ fun @WebforjDsl Tree.treeNode(text: String, key: Any? = null, block: @WebforjDsl
  * @see tree
  * @see treeNode
  */
-@WebforjDsl
 fun @WebforjDsl TreeNode.treeNode(text: String, key: Any? = null, block: @WebforjDsl TreeNode.() -> Unit = {}): TreeNode {
   val node = key?.let { TreeNode(key, text) } ?: TreeNode(text)
   node.block()

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/extension/HasPrefixExtensions.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/extension/HasPrefixExtensions.kt
@@ -17,7 +17,6 @@ val HasPrefix<*>.prefix: Component?
  *
  * @param block The initialization of the [Component].
  */
-@WebforjDsl
 fun @WebforjDsl HasPrefix<*>.prefixSlot(block: @WebforjDsl HasComponents.() -> Component) {
   SingleSlotSetter(block).setSlot(this) {
     prefixComponent = it

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/extension/HasSuffixExtensions.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/extension/HasSuffixExtensions.kt
@@ -17,7 +17,6 @@ val HasSuffix<*>.suffix: Component?
  *
  * @param block The initialization of the [Component].
  */
-@WebforjDsl
 fun @WebforjDsl HasSuffix<*>.suffixSlot(block: @WebforjDsl HasComponents.() -> Component) {
   SingleSlotSetter(block).setSlot(this) {
     suffixComponent = it


### PR DESCRIPTION
Updates the `WebforjDsl` annotation to be used in external projects, adding `build` extension function for `Component` to properly utilize the `DslMarker` utility.

Currently `apply` is used to start building UIs, allowing for illegal constructs like this.
```kotlin
Div().apply {
   button {
      button { }
    }
}
```
In this example both buttons are going to be added to the div, even though it looks like the second button is going to be added to the first.
With the `build` function this is properly caught:
```kotlin
Div().build {
  button {
    button { }
  }
}
```
Now this will cause a compile time error to be emitted, to define the second button inside the first (if need for event handling for example or another coupling), `this@div` can be used, or with a specific label:
```kotlin
Div().build container@ { 
  button {
    this@container.button { }
  }
}
```

closes #1311 
closes #1315 