### PR TITLE
feat: add autoWidth property to Dialog and option dialogs

### DIFF
--- a/webforj-components/webforj-dialog/src/main/java/com/webforj/component/dialog/Dialog.java
+++ b/webforj-components/webforj-dialog/src/main/java/com/webforj/component/dialog/Dialog.java
@@ -51,6 +51,8 @@ public class Dialog extends ElementCompositeContainer
   // Properties
   private final PropertyDescriptor<Alignment> alignmentProp =
       PropertyDescriptor.property("alignment", Alignment.CENTER);
+  private final PropertyDescriptor<Boolean> autoWidthProp =
+      PropertyDescriptor.property("autoWidth", false);
   @PropertyMethods(setter = "setAutoFocus", getter = "isAutoFocus")
   private final PropertyDescriptor<Boolean> autoFocusProp =
       PropertyDescriptor.property("autofocus", false);
@@ -162,6 +164,33 @@ public class Dialog extends ElementCompositeContainer
    */
   public Alignment getAlignment() {
     return get(alignmentProp);
+  }
+
+  /**
+   * Sets whether the dialog width should fit its content instead of filling the available space.
+   *
+   * <p>
+   * When true, the dialog will size itself based on its content width rather than stretching to
+   * fill the available space.
+   * </p>
+   *
+   * @param autoWidth whether the dialog should auto-size its width
+   * @return the component itself
+   * @since 26.00
+   */
+  public Dialog setAutoWidth(boolean autoWidth) {
+    set(autoWidthProp, autoWidth);
+    return this;
+  }
+
+  /**
+   * Gets whether the dialog width fits its content.
+   *
+   * @return {@code true} if auto width is enabled, {@code false} otherwise
+   * @since 26.00
+   */
+  public boolean isAutoWidth() {
+    return get(autoWidthProp);
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/optiondialog/DwcOptionDialog.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/optiondialog/DwcOptionDialog.java
@@ -29,6 +29,7 @@ public class DwcOptionDialog<T> {
   }
 
   private Alignment alignment = Alignment.CENTER;
+  private boolean autoWidth = false;
   private boolean blurred = false;
   private String breakpoint = "";
   private boolean fullscreen = false;
@@ -57,6 +58,34 @@ public class DwcOptionDialog<T> {
    */
   public Alignment getAlignment() {
     return alignment;
+  }
+
+  /**
+   * Sets whether the dialog width should fit its content instead of filling the available space.
+   *
+   * <p>
+   * When true, the dialog will size itself based on its content width rather than stretching to
+   * fill the available space.
+   * </p>
+   *
+   * @param autoWidth whether the dialog should auto-size its width
+   * @return the dialog
+   * @since 26.00
+   */
+  public T setAutoWidth(boolean autoWidth) {
+    this.autoWidth = autoWidth;
+    toggleAttribute("auto-width", "", autoWidth);
+    return getSelf();
+  }
+
+  /**
+   * Gets whether the dialog width fits its content.
+   *
+   * @return {@code true} if auto width is enabled, {@code false} otherwise
+   * @since 26.00
+   */
+  public boolean isAutoWidth() {
+    return autoWidth;
   }
 
   /**

--- a/webforj-foundation/src/test/java/com/webforj/component/optiondialog/DialogTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/optiondialog/DialogTest.java
@@ -24,6 +24,18 @@ class DialogTest {
   }
 
   @Test
+  void shouldToggleAutoWidthState() {
+    assertFalse(component.isAutoWidth());
+    component.setAutoWidth(true);
+    assertTrue(component.isAutoWidth());
+    assertTrue(component.getAttributes().containsKey("auto-width"));
+
+    component.setAutoWidth(false);
+    assertFalse(component.isAutoWidth());
+    assertFalse(component.getAttributes().containsKey("auto-width"));
+  }
+
+  @Test
   void shouldToggleBlurredState() {
     component.setBlurred(true);
     assertTrue(component.isBlurred());


### PR DESCRIPTION
Support the new dwc-dialog `autoWidth` attribute that makes the dialog width fit its content instead of filling available space.