### PR TITLE
feat: introduce HasI18n and HasSelectionMode concern interfaces

### DIFF
--- a/webforj-components/webforj-login/src/main/java/com/webforj/component/login/Login.java
+++ b/webforj-components/webforj-login/src/main/java/com/webforj/component/login/Login.java
@@ -10,6 +10,7 @@ import com.webforj.component.login.event.LoginCancelEvent;
 import com.webforj.component.login.event.LoginSubmitEvent;
 import com.webforj.concern.HasClassName;
 import com.webforj.concern.HasEnablement;
+import com.webforj.concern.HasI18n;
 import com.webforj.concern.HasStyle;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
@@ -22,8 +23,8 @@ import com.webforj.dispatcher.ListenerRegistration;
  * @since 24.01
  */
 @NodeName("dwc-login")
-public class Login extends ElementCompositeContainer
-    implements HasClassName<Login>, HasStyle<Login>, HasEnablement<Login> {
+public class Login extends ElementCompositeContainer implements HasClassName<Login>,
+    HasStyle<Login>, HasEnablement<Login>, HasI18n<Login, LoginI18n> {
 
   /**
    * An enum for indicating whether the user will be required to login for every visit to a client
@@ -313,21 +314,18 @@ public class Login extends ElementCompositeContainer
   }
 
   /**
-   * Sets the i18n object.
-   *
-   * @param i18n the i18n object
-   * @return the component itself
+   * {@inheritDoc}
    */
+  @Override
   public Login setI18n(LoginI18n i18n) {
     set(this.i18n, i18n);
     return this;
   }
 
   /**
-   * Gets the used i18n object.
-   *
-   * @return the i18n object
+   * {@inheritDoc}
    */
+  @Override
   public LoginI18n getI18n() {
     return get(i18n);
   }

--- a/webforj-components/webforj-refresher/src/main/java/com/webforj/component/refresher/Refresher.java
+++ b/webforj-components/webforj-refresher/src/main/java/com/webforj/component/refresher/Refresher.java
@@ -12,6 +12,7 @@ import com.webforj.component.refresher.event.RefresherRefreshEvent;
 import com.webforj.concern.HasAttribute;
 import com.webforj.concern.HasClassName;
 import com.webforj.concern.HasEnablement;
+import com.webforj.concern.HasI18n;
 import com.webforj.concern.HasStyle;
 import com.webforj.concern.HasTheme;
 import com.webforj.dispatcher.EventListener;
@@ -28,7 +29,7 @@ import com.webforj.utilities.Assets;
 @NodeName("dwc-refresher")
 public class Refresher extends ElementCompositeContainer
     implements HasClassName<Refresher>, HasStyle<Refresher>, HasAttribute<Refresher>,
-    HasEnablement<Refresher>, HasTheme<Refresher, Theme> {
+    HasEnablement<Refresher>, HasTheme<Refresher, Theme>, HasI18n<Refresher, RefresherI18n> {
 
   private RefresherI18n i18n = new RefresherI18n();
 
@@ -146,22 +147,22 @@ public class Refresher extends ElementCompositeContainer
   }
 
   /**
-   * Sets the refresher i18n object.
-   *
-   * @param i18n the refresher i18n object
+   * {@inheritDoc}
    */
-  public void setI18n(RefresherI18n i18n) {
+  @Override
+  public Refresher setI18n(RefresherI18n i18n) {
     this.i18n = i18n;
     set(textPullProp, i18n.getPull());
     set(textReleaseProp, i18n.getRelease());
     set(textRefreshProp, i18n.getRefresh());
+
+    return this;
   }
 
   /**
-   * Gets the refresher i18n object.
-   *
-   * @return the refresher i18n object
+   * {@inheritDoc}
    */
+  @Override
   public RefresherI18n getI18n() {
     return i18n;
   }

--- a/webforj-data/src/main/java/com/webforj/data/concern/HasSelectionMode.java
+++ b/webforj-data/src/main/java/com/webforj/data/concern/HasSelectionMode.java
@@ -1,0 +1,33 @@
+package com.webforj.data.concern;
+
+/**
+ * An interface for components that pick a selection mode such as files, directories, or both.
+ *
+ * <p>
+ * The mode type {@code M} is component specific. Each component picks its own enum so call sites
+ * read naturally with the component name in the import path.
+ * </p>
+ *
+ * @param <T> the type of the component that implements this interface
+ * @param <M> the type of the selection mode value
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public interface HasSelectionMode<T, M> {
+
+  /**
+   * Sets the selection mode.
+   *
+   * @param selectionMode the selection mode
+   * @return the component itself
+   */
+  T setSelectionMode(M selectionMode);
+
+  /**
+   * Gets the selection mode.
+   *
+   * @return the selection mode
+   */
+  M getSelectionMode();
+}

--- a/webforj-foundation/src/main/java/com/webforj/component/list/MultipleSelectableList.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/MultipleSelectableList.java
@@ -1,6 +1,7 @@
 package com.webforj.component.list;
 
 import com.webforj.component.Component;
+import com.webforj.data.concern.HasSelectionMode;
 import com.webforj.data.selection.MultipleSelectable;
 
 /**
@@ -19,7 +20,8 @@ import com.webforj.data.selection.MultipleSelectable;
  * @since 23.05
  */
 public interface MultipleSelectableList<T extends Component>
-    extends MultipleSelectable<T, ListItem>, SelectableList<T> {
+    extends MultipleSelectable<T, ListItem>, SelectableList<T>,
+    HasSelectionMode<T, MultipleSelectableList.SelectionMode> {
 
   /**
    * The selection mode of the list box.
@@ -36,18 +38,15 @@ public interface MultipleSelectableList<T extends Component>
   }
 
   /**
-   * Sets the selection mode of the list box.
-   *
-   * @param mode the selection mode
-   * @return the component itself
+   * {@inheritDoc}
    */
+  @Override
   public T setSelectionMode(SelectionMode mode);
 
   /**
-   * Returns the selection mode of the list box.
-   *
-   * @return the selection mode
+   * {@inheritDoc}
    */
+  @Override
   public SelectionMode getSelectionMode();
 }
 

--- a/webforj-foundation/src/main/java/com/webforj/component/tree/Tree.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tree/Tree.java
@@ -26,6 +26,7 @@ import com.webforj.component.tree.sink.TreeDoubleClickEventSink;
 import com.webforj.component.tree.sink.TreeExpandEventSink;
 import com.webforj.component.tree.sink.TreeSelectEventSink;
 import com.webforj.component.window.Window;
+import com.webforj.data.concern.HasSelectionMode;
 import com.webforj.data.selection.ItemMultiSelectable;
 import com.webforj.data.selection.ItemSingleSelectable;
 import com.webforj.data.selection.KeyMultiSelectable;
@@ -61,7 +62,8 @@ import java.util.UUID;
  */
 public final class Tree extends DwcFocusableComponent<Tree>
     implements TreeNodeDelegate, ItemSingleSelectable<Tree, TreeNode>, KeySingleSelectable<Tree>,
-    ItemMultiSelectable<Tree, TreeNode>, KeyMultiSelectable<Tree> {
+    ItemMultiSelectable<Tree, TreeNode>, KeyMultiSelectable<Tree>,
+    HasSelectionMode<Tree, Tree.SelectionMode> {
   static final String PROP_CONNECT = "connect";
   private static final String NULL_KEY_MESSAGE = "Key cannot be null";
   private static final String NULL_TEXT_MESSAGE = "Text cannot be null";
@@ -299,6 +301,7 @@ public final class Tree extends DwcFocusableComponent<Tree>
    * @return the component itself
    * @throws NullPointerException if {@code mode} is null
    */
+  @Override
   public Tree setSelectionMode(SelectionMode mode) {
     Objects.requireNonNull(mode, NULL_MODE_MESSAGE);
 
@@ -322,6 +325,7 @@ public final class Tree extends DwcFocusableComponent<Tree>
    *
    * @return the current selection mode
    */
+  @Override
   public SelectionMode getSelectionMode() {
     return selectionMode;
   }

--- a/webforj-foundation/src/main/java/com/webforj/concern/HasI18n.java
+++ b/webforj-foundation/src/main/java/com/webforj/concern/HasI18n.java
@@ -1,0 +1,33 @@
+package com.webforj.concern;
+
+/**
+ * An interface for components that expose a localization bundle.
+ *
+ * <p>
+ * The bundle type {@code I} is component specific. Each component picks the bundle that carries its
+ * user visible strings.
+ * </p>
+ *
+ * @param <T> the type of the component that implements this interface
+ * @param <I> the type of the i18n bundle
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public interface HasI18n<T, I> {
+
+  /**
+   * Sets the i18n bundle.
+   *
+   * @param i18n the i18n bundle
+   * @return the component itself
+   */
+  T setI18n(I i18n);
+
+  /**
+   * Gets the i18n bundle.
+   *
+   * @return the i18n bundle
+   */
+  I getI18n();
+}


### PR DESCRIPTION
Introduce `HasI18n` and `HasSelectionMode` concern interfaces

Two new concern interfaces.

- **`HasI18n<T, I>`**: for components with a localizable bundle of type `I`. Generic so each component keeps its bundle type in the import path.
- **`HasSelectionMode<T, M>`**: for components with a selection mode of type `M`. Generic so each component keeps its own enum.

`Refresher.setI18n` now returns `Refresher` instead of `void`. Existing call sites compile unchanged.
