### PR TITLE
feat: add Geolocation API

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/App.java
+++ b/webforj-foundation/src/main/java/com/webforj/App.java
@@ -607,6 +607,12 @@ public abstract class App {
       page.destroy();
     }
 
+    // dispose the geolocation subsystem
+    Geolocation geolocation = Geolocation.getCurrent();
+    if (geolocation != null) {
+      geolocation.destroy();
+    }
+
     // dispose the router
     Router router = Router.getCurrent();
     if (router != null) {

--- a/webforj-foundation/src/main/java/com/webforj/Geolocation.java
+++ b/webforj-foundation/src/main/java/com/webforj/Geolocation.java
@@ -1,0 +1,272 @@
+package com.webforj;
+
+import com.basis.bbj.proxies.sysgui.BBjGeolocation;
+import com.basis.bbj.proxyif.SysGuiEventConstants;
+import com.basis.startup.type.BBjException;
+import com.basis.util.common.BasisNumber;
+import com.webforj.dispatcher.EventDispatcher;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+import com.webforj.environment.ObjectTable;
+import com.webforj.event.geolocation.GeolocationEventHandler;
+import com.webforj.event.geolocation.GeolocationPosition;
+import com.webforj.event.geolocation.GeolocationStatus;
+import com.webforj.event.geolocation.GeolocationWatchEvent;
+import com.webforj.exceptions.WebforjGeolocationException;
+import com.webforj.exceptions.WebforjRuntimeException;
+import com.webforj.sink.geolocation.GeolocationWatchEventSink;
+import com.webforj.sink.geolocation.GeolocationWatchEventSinkRegistry;
+import java.util.function.Consumer;
+
+/**
+ * Provides an interface to the browser's geolocation subsystem.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public final class Geolocation {
+
+  private final EventDispatcher eventDispatcher = new EventDispatcher();
+  private final GeolocationEventHandler eventHandler = new GeolocationEventHandler();
+  private final GeolocationWatchEventSink watchSink =
+      new GeolocationWatchEventSink(this, eventDispatcher);
+  private final GeolocationWatchEventSinkRegistry watchRegistry =
+      new GeolocationWatchEventSinkRegistry(watchSink);
+  private boolean positionCallbackRegistered = false;
+
+  private Geolocation() {}
+
+  /**
+   * Returns the geolocation instance for the current environment.
+   *
+   * @return the geolocation instance
+   */
+  public static Geolocation getCurrent() {
+    String key = Geolocation.class.getName();
+    if (ObjectTable.contains(key)) {
+      return (Geolocation) ObjectTable.get(key);
+    }
+
+    Geolocation instance = new Geolocation();
+    ObjectTable.put(key, instance);
+
+    return instance;
+  }
+
+  /**
+   * Returns whether a geolocation instance is available for the current environment.
+   *
+   * @return {@code true} when a geolocation instance is available
+   */
+  public static boolean isPresent() {
+    return getCurrent() != null;
+  }
+
+  /**
+   * Executes the given consumer with the geolocation instance when one is available.
+   *
+   * @param consumer the consumer to execute
+   */
+  public static void ifPresent(Consumer<Geolocation> consumer) {
+    if (Geolocation.isPresent()) {
+      consumer.accept(Geolocation.getCurrent());
+    }
+  }
+
+  /**
+   * Sets the high accuracy option for use in subsequent requests for geolocation information.
+   *
+   * <p>
+   * The high accuracy attribute provides a hint that the application would like to receive the best
+   * possible results. This may result in slower response times or increased power consumption. The
+   * user might also deny this capability, or the device might not be able to provide more accurate
+   * results than if the flag wasn't specified. The intended purpose of this attribute is to allow
+   * applications to inform the browser that they do not require high accuracy geolocation fixes
+   * and, therefore, the browser can avoid using geolocation providers that consume a significant
+   * amount of power (e.g. GPS). This is especially useful for applications running on battery
+   * powered devices, such as mobile phones.
+   * </p>
+   *
+   * @param highAccuracy indicates whether the application would like to receive the most accurate
+   *        results available
+   * @return this geolocation instance
+   */
+  public Geolocation useHighAccuracy(boolean highAccuracy) {
+    getBbjGeolocation().setHighAccuracy(highAccuracy);
+
+    return this;
+  }
+
+  /**
+   * Returns the high accuracy option that will be used in subsequent requests for geolocation
+   * information.
+   *
+   * @return whether subsequent requests for geolocation information will request the most accurate
+   *         results available
+   * @see #useHighAccuracy(boolean)
+   */
+  public boolean isHighAccuracy() {
+    return getBbjGeolocation().isHighAccuracy();
+  }
+
+  /**
+   * Sets the timeout option for use in subsequent requests for geolocation information.
+   *
+   * <p>
+   * The timeout attribute denotes the maximum length of time (expressed in seconds) that is allowed
+   * to pass from the call to {@link #getCurrentPosition()} or a watch listener until the browser
+   * returns a position. If the browser is unable to successfully acquire a new position before the
+   * given timeout elapses, and no other errors have occurred in this interval, the request is
+   * reported with the {@link GeolocationStatus#TIMEOUT} status. Note that the time that is spent
+   * obtaining the user permission is not included in the period covered by the timeout attribute.
+   * The timeout attribute only applies to the location acquisition operation.
+   * </p>
+   *
+   * @param seconds the timeout value in seconds
+   * @return this geolocation instance
+   */
+  public Geolocation useTimeout(double seconds) {
+    getBbjGeolocation().setTimeout(BasisNumber.valueOf(seconds));
+
+    return this;
+  }
+
+  /**
+   * Returns the timeout value in seconds that will be used in subsequent requests for geolocation
+   * information.
+   *
+   * @return the timeout value in seconds
+   * @see #useTimeout(double)
+   */
+  public double getTimeout() {
+    return getBbjGeolocation().getTimeout().doubleValue();
+  }
+
+  /**
+   * Sets the maximum age option for use in subsequent requests for geolocation information.
+   *
+   * <p>
+   * The maximum age attribute indicates that the application is willing to accept a cached position
+   * whose age is no greater than the specified time in seconds. If maximum age is set to {@code 0},
+   * the browser must immediately attempt to acquire a new position object. If the browser does not
+   * have a cached position available whose age is no greater than the specified maximum age, then
+   * it must acquire a new position object. In case of a watch, the maximum age refers to the first
+   * position object returned by the browser.
+   * </p>
+   *
+   * @param seconds the maximum age in seconds of any cached position ({@code 0} to acquire a
+   *        current position)
+   * @return this geolocation instance
+   */
+  public Geolocation useMaximumAge(double seconds) {
+    getBbjGeolocation().setMaximumAge(BasisNumber.valueOf(seconds));
+
+    return this;
+  }
+
+  /**
+   * Returns the maximum age in seconds of any cached position that will be used in subsequent
+   * requests for geolocation information.
+   *
+   * @return the maximum age in seconds of any cached position ({@code 0} to acquire a current
+   *         position)
+   * @see #useMaximumAge(double)
+   */
+  public double getMaximumAge() {
+    return getBbjGeolocation().getMaximumAge().doubleValue();
+  }
+
+  /**
+   * Requests that the browser pass back geolocation information in a subsequent watch event or
+   * pending result.
+   *
+   * <p>
+   * This method does not directly return geolocation information. It requests that the information
+   * be returned through the returned {@link PendingResult}, which completes with the reported
+   * {@link GeolocationPosition} or exceptionally with a {@link WebforjGeolocationException}
+   * carrying the matching {@link GeolocationStatus} when the browser is unable to obtain a
+   * position.
+   * </p>
+   *
+   * @return a pending result that resolves with the device's position
+   */
+  public PendingResult<GeolocationPosition> getCurrentPosition() {
+    PendingResult<GeolocationPosition> pending = new PendingResult<>();
+
+    try {
+      ensurePositionCallbackRegistered();
+      eventHandler.enqueuePositionRequest(pending);
+      getBbjGeolocation().getCurrentPosition();
+    } catch (BBjException e) {
+      throw new WebforjRuntimeException("Failed to request current geolocation position.", e);
+    }
+
+    return pending;
+  }
+
+  /**
+   * Adds a listener that is notified each time the browser reports a position update.
+   *
+   * <p>
+   * The browser begins watching the position when the first listener is added and stops watching
+   * once the last listener is removed.
+   * </p>
+   *
+   * @param listener the listener to add
+   * @return a registration that can be used to remove the listener
+   */
+  public ListenerRegistration<GeolocationWatchEvent> addWatchListener(
+      EventListener<GeolocationWatchEvent> listener) {
+    return watchRegistry.addEventListener(listener);
+  }
+
+  /**
+   * Alias for {@link #addWatchListener(EventListener)}.
+   *
+   * @param listener the listener to add
+   * @return a registration that can be used to remove the listener
+   */
+  public ListenerRegistration<GeolocationWatchEvent> onWatch(
+      EventListener<GeolocationWatchEvent> listener) {
+    return addWatchListener(listener);
+  }
+
+  private void ensurePositionCallbackRegistered() throws BBjException {
+    if (positionCallbackRegistered) {
+      return;
+    }
+
+    getBbjGeolocation().setCallback(SysGuiEventConstants.ON_GEOLOCATION_POSITION, eventHandler,
+        "handlePositionEvent");
+    positionCallbackRegistered = true;
+  }
+
+  GeolocationEventHandler getEventHandler() {
+    return eventHandler;
+  }
+
+  GeolocationWatchEventSinkRegistry getWatchRegistry() {
+    return watchRegistry;
+  }
+
+  GeolocationWatchEventSink getWatchSink() {
+    return watchSink;
+  }
+
+  BBjGeolocation getBbjGeolocation() {
+    try {
+      return getEnvironment().getSysGui().getGeolocation();
+    } catch (BBjException e) {
+      throw new WebforjRuntimeException("Failed to access geolocation subsystem.", e);
+    }
+  }
+
+  Environment getEnvironment() {
+    return Environment.getCurrent();
+  }
+
+  void destroy() {
+    eventDispatcher.removeAllListeners();
+    ObjectTable.put(Geolocation.class.getName(), null);
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/event/geolocation/GeolocationEventHandler.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/geolocation/GeolocationEventHandler.java
@@ -1,0 +1,68 @@
+package com.webforj.event.geolocation;
+
+import com.basis.bbj.proxies.event.BBjEvent;
+import com.basis.bbj.proxies.event.BBjGeolocationEvent;
+import com.webforj.PendingResult;
+import com.webforj.exceptions.WebforjGeolocationException;
+import java.lang.System.Logger;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Handler for the {@code ON_GEOLOCATION_POSITION} BBj callback. Correlates incoming callbacks FIFO
+ * with pending one shot requests registered.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public final class GeolocationEventHandler {
+
+  private static final Logger logger = System.getLogger(GeolocationEventHandler.class.getName());
+  private final Deque<PendingResult<GeolocationPosition>> pendingPositions = new ArrayDeque<>();
+
+  /**
+   * Constructs a new handler.
+   */
+  public GeolocationEventHandler() {
+    // no-op
+  }
+
+  /**
+   * Registers a pending one shot position request that will be completed on the next
+   * {@code ON_GEOLOCATION_POSITION} callback.
+   *
+   * @param pending the pending result to complete
+   */
+  public void enqueuePositionRequest(PendingResult<GeolocationPosition> pending) {
+    pendingPositions.add(pending);
+  }
+
+  /**
+   * Handles a {@code ON_GEOLOCATION_POSITION} callback and completes the next pending request.
+   *
+   * @param event the BBj event
+   */
+  public void handlePositionEvent(BBjEvent event) {
+    BBjGeolocationEvent geoEvent = (BBjGeolocationEvent) event;
+    PendingResult<GeolocationPosition> pending = pendingPositions.poll();
+    if (pending == null) {
+      logger.log(Logger.Level.WARNING,
+          "Received geolocation position event with no pending request to complete.");
+
+      return;
+    }
+
+    GeolocationStatus status = GeolocationStatus.fromCode(geoEvent.getStatus());
+    if (status == GeolocationStatus.SUCCESS) {
+      pending.complete(toPosition(geoEvent));
+    } else {
+      pending.completeExceptionally(new WebforjGeolocationException(status, geoEvent.getMessage()));
+    }
+  }
+
+  private static GeolocationPosition toPosition(BBjGeolocationEvent event) {
+    return new GeolocationPosition(event.getLatitude(), event.getLongitude(), event.getAccuracy(),
+        event.getTimestamp(), event.getAltitude(), event.getAltitudeAccuracy(), event.getHeading(),
+        event.getSpeed());
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/event/geolocation/GeolocationPosition.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/geolocation/GeolocationPosition.java
@@ -1,0 +1,220 @@
+package com.webforj.event.geolocation;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The device's geographic position at a point in time.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public final class GeolocationPosition {
+
+  private final double latitude;
+  private final double longitude;
+  private final double accuracy;
+  private final long timestamp;
+  private final Double altitude;
+  private final Double altitudeAccuracy;
+  private final Double heading;
+  private final Double speed;
+
+  /**
+   * Creates a new position.
+   *
+   * @param latitude the latitude in decimal degrees
+   * @param longitude the longitude in decimal degrees
+   * @param accuracy the accuracy of the latitude and longitude coordinates, in meters
+   * @param timestamp the time when this position information was acquired, in milliseconds since
+   *        January 1st, 1970 UTC
+   * @param altitude the height of the position above the WGS84 ellipsoid, in meters, or
+   *        {@code null} when the device cannot provide altitude information
+   * @param altitudeAccuracy the accuracy of the altitude, in meters, or {@code null} when the
+   *        device cannot provide altitude information
+   * @param heading the direction of travel of the device, in degrees, or {@code null} when the
+   *        device cannot provide heading information
+   * @param speed the current ground speed of the device, in meters per second, or {@code null} when
+   *        the device cannot provide speed information
+   */
+  @SuppressWarnings("java:S107")
+  public GeolocationPosition(double latitude, double longitude, double accuracy, long timestamp,
+      Double altitude, Double altitudeAccuracy, Double heading, Double speed) {
+    this.latitude = latitude;
+    this.longitude = longitude;
+    this.accuracy = accuracy;
+    this.timestamp = timestamp;
+    this.altitude = altitude;
+    this.altitudeAccuracy = altitudeAccuracy;
+    this.heading = heading;
+    this.speed = speed;
+  }
+
+  /**
+   * Returns the latitude in decimal degrees.
+   *
+   * <p>
+   * The latitude attribute is a geographic coordinate specified in decimal degrees. This value is
+   * only meaningful when the request was successful.
+   * </p>
+   *
+   * @return the latitude in decimal degrees
+   */
+  public double getLatitude() {
+    return latitude;
+  }
+
+  /**
+   * Returns the longitude in decimal degrees.
+   *
+   * <p>
+   * The longitude attribute is a geographic coordinate specified in decimal degrees. This value is
+   * only meaningful when the request was successful.
+   * </p>
+   *
+   * @return the longitude in decimal degrees
+   */
+  public double getLongitude() {
+    return longitude;
+  }
+
+  /**
+   * Returns the accuracy of the latitude and longitude coordinates.
+   *
+   * <p>
+   * The accuracy attribute denotes the accuracy level of the latitude and longitude coordinates. It
+   * is specified in meters and must be supported by all browsers. The value of the accuracy
+   * attribute must be a non negative real number. This value is only meaningful when the request
+   * was successful.
+   * </p>
+   *
+   * @return the accuracy in meters
+   */
+  public double getAccuracy() {
+    return accuracy;
+  }
+
+  /**
+   * Returns the time when this position information was acquired.
+   *
+   * <p>
+   * The timestamp is the number of milliseconds since January 1st, 1970 UTC. To convert to a
+   * {@link java.util.Date} value, use {@code new java.util.Date(position.getTimestamp())}.
+   * </p>
+   *
+   * @return the timestamp in milliseconds
+   */
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Returns the altitude in meters. If the altitude is unavailable, the value is empty.
+   *
+   * <p>
+   * The altitude attribute denotes the height of the position, specified in meters above the WGS84
+   * ellipsoid. If the browser cannot provide altitude information, the value is empty. Multiply by
+   * approximately {@code 3.28} to convert from meters to feet.
+   * </p>
+   *
+   * @return the altitude in meters, or an empty {@link Optional} when the browser cannot provide
+   *         altitude information
+   */
+  public Optional<Double> getAltitude() {
+    return Optional.ofNullable(altitude);
+  }
+
+  /**
+   * Returns the accuracy level of the altitude value, specified in meters.
+   *
+   * <p>
+   * The altitudeAccuracy attribute is specified in meters. If the browser cannot provide altitude
+   * information, the value is empty. Otherwise, the value of the altitudeAccuracy attribute must be
+   * a non negative real number.
+   * </p>
+   *
+   * @return the altitude accuracy in meters, or an empty {@link Optional} when the browser cannot
+   *         provide altitude information
+   */
+  public Optional<Double> getAltitudeAccuracy() {
+    return Optional.ofNullable(altitudeAccuracy);
+  }
+
+  /**
+   * Returns the current heading in degrees.
+   *
+   * <p>
+   * The heading attribute denotes the direction of travel of the hosting device and is specified in
+   * degrees, where {@code 0 <= heading < 360}, counting clockwise relative to the true north. If
+   * the browser cannot provide heading information, the value is empty. If the hosting device is
+   * stationary (i.e. the value of the speed attribute is {@code 0}), then the value of the heading
+   * attribute is {@link Double#NaN}.
+   * </p>
+   *
+   * @return the heading in degrees, or an empty {@link Optional} when heading information is
+   *         unavailable
+   */
+  public Optional<Double> getHeading() {
+    return Optional.ofNullable(heading);
+  }
+
+  /**
+   * Returns the speed in meters per second.
+   *
+   * <p>
+   * The speed attribute denotes the current ground speed of the hosting device and is specified in
+   * meters per second. If the browser cannot provide speed information, the value is empty.
+   * Otherwise, the value of the speed attribute must be a non negative real number. Multiply by
+   * {@code 3.6} to convert to km/h. Multiply by approximately {@code 2.237} to convert to mph. For
+   * example, a reported speed value of 25 m/s corresponds to 90 km/h, or about 56 mph.
+   * </p>
+   *
+   * @return the speed in meters per second, or an empty {@link Optional} when the browser cannot
+   *         provide speed information
+   */
+  public Optional<Double> getSpeed() {
+    return Optional.ofNullable(speed);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof GeolocationPosition)) {
+      return false;
+    }
+
+    GeolocationPosition other = (GeolocationPosition) obj;
+
+    return Double.compare(latitude, other.latitude) == 0
+        && Double.compare(longitude, other.longitude) == 0
+        && Double.compare(accuracy, other.accuracy) == 0 && timestamp == other.timestamp
+        && Objects.equals(altitude, other.altitude)
+        && Objects.equals(altitudeAccuracy, other.altitudeAccuracy)
+        && Objects.equals(heading, other.heading) && Objects.equals(speed, other.speed);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(latitude, longitude, accuracy, timestamp, altitude, altitudeAccuracy,
+        heading, speed);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String toString() {
+    return "GeolocationPosition[latitude=" + latitude + ", longitude=" + longitude + ", accuracy="
+        + accuracy + ", timestamp=" + timestamp + ", altitude=" + altitude + ", altitudeAccuracy="
+        + altitudeAccuracy + ", heading=" + heading + ", speed=" + speed + "]";
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/event/geolocation/GeolocationStatus.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/geolocation/GeolocationStatus.java
@@ -1,0 +1,73 @@
+package com.webforj.event.geolocation;
+
+import com.webforj.Geolocation;
+
+/**
+ * The status reported by the browser for a {@link Geolocation} request.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public enum GeolocationStatus {
+
+  /**
+   * Success.
+   */
+  SUCCESS(0),
+
+  /**
+   * The location acquisition process failed because the application origin does not have permission
+   * to use the Geolocation API. This is the value returned if the user refuses to share their
+   * location.
+   */
+  PERMISSION_DENIED(1),
+
+  /**
+   * The position of the device could not be determined. For instance, one or more of the location
+   * providers used in the location acquisition process reported an internal error that caused the
+   * process to fail entirely.
+   */
+  POSITION_UNAVAILABLE(2),
+
+  /**
+   * The length of time specified by the timeout property has elapsed before the browser could
+   * successfully acquire a new position.
+   */
+  TIMEOUT(3),
+
+  /**
+   * The status code reported by the browser is not recognized.
+   */
+  UNKNOWN(-1);
+
+  private final int code;
+
+  GeolocationStatus(int code) {
+    this.code = code;
+  }
+
+  /**
+   * Returns the numeric status code reported by the browser.
+   *
+   * @return the numeric status code
+   */
+  public int getCode() {
+    return code;
+  }
+
+  /**
+   * Resolves a status from its numeric code, returning {@link #UNKNOWN} when no status matches.
+   *
+   * @param code the numeric status code
+   * @return the matching status, or {@link #UNKNOWN} when none matches
+   */
+  public static GeolocationStatus fromCode(int code) {
+    for (GeolocationStatus status : values()) {
+      if (status.code == code) {
+        return status;
+      }
+    }
+
+    return UNKNOWN;
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/event/geolocation/GeolocationWatchEvent.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/geolocation/GeolocationWatchEvent.java
@@ -1,0 +1,88 @@
+package com.webforj.event.geolocation;
+
+import com.webforj.Geolocation;
+import java.util.EventObject;
+import java.util.Optional;
+
+/**
+ * An event fired whenever the browser reports a watched position update for a {@link Geolocation}.
+ *
+ * <p>
+ * On a successful update the event carries a {@link GeolocationPosition}. On a failed update the
+ * event carries the reported {@link GeolocationStatus} and an optional message that contains
+ * additional information about the failure.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public final class GeolocationWatchEvent extends EventObject {
+
+  private final GeolocationStatus status;
+  private final transient GeolocationPosition position;
+  private final String message;
+
+  /**
+   * Constructs a new watch event.
+   *
+   * @param source the geolocation that produced the event
+   * @param status the status reported by the browser
+   * @param position the reported position, or {@code null} when the status is not
+   *        {@link GeolocationStatus#SUCCESS}
+   * @param message additional information about the failure, or {@code null} on success
+   */
+  public GeolocationWatchEvent(Geolocation source, GeolocationStatus status,
+      GeolocationPosition position, String message) {
+    super(source);
+    this.status = status;
+    this.position = position;
+    this.message = message;
+  }
+
+  /**
+   * Returns the geolocation that produced the event.
+   *
+   * @return the geolocation instance
+   */
+  public Geolocation getGeolocation() {
+    return (Geolocation) getSource();
+  }
+
+  /**
+   * Returns the status reported by the browser.
+   *
+   * @return the status
+   */
+  public GeolocationStatus getStatus() {
+    return status;
+  }
+
+  /**
+   * Returns whether the event represents a successful position update.
+   *
+   * @return {@code true} when the status is {@link GeolocationStatus#SUCCESS}
+   */
+  public boolean isSuccess() {
+    return status == GeolocationStatus.SUCCESS;
+  }
+
+  /**
+   * Returns the position carried by the event when the update was successful.
+   *
+   * @return the position, or an empty {@link Optional} when the update failed
+   */
+  public Optional<GeolocationPosition> getPosition() {
+    return Optional.ofNullable(position);
+  }
+
+  /**
+   * May return additional information when the status indicates an error result.
+   *
+   * @return an optional error message only meaningful when the status is not
+   *         {@link GeolocationStatus#SUCCESS}, or an empty {@link Optional} when the update
+   *         succeeded or the browser did not provide a message
+   */
+  public Optional<String> getMessage() {
+    return Optional.ofNullable(message);
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/exceptions/WebforjGeolocationException.java
+++ b/webforj-foundation/src/main/java/com/webforj/exceptions/WebforjGeolocationException.java
@@ -1,0 +1,51 @@
+package com.webforj.exceptions;
+
+import com.webforj.event.geolocation.GeolocationStatus;
+
+/**
+ * Reports a failure returned by the browser when requesting the device's geographic position.
+ *
+ * <p>
+ * The exception carries the {@link GeolocationStatus} reported by the browser together with the
+ * additional information the browser provided about the failure, when any was provided.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public class WebforjGeolocationException extends WebforjRuntimeException {
+
+  private final transient GeolocationStatus status;
+
+  /**
+   * Constructs a new exception with the given status and detail message.
+   *
+   * @param status the status reported by the browser
+   * @param message additional information about the failure
+   */
+  public WebforjGeolocationException(GeolocationStatus status, String message) {
+    super(message);
+    this.status = status;
+  }
+
+  /**
+   * Constructs a new exception with the given status, detail message, and cause.
+   *
+   * @param status the status reported by the browser
+   * @param message additional information about the failure
+   * @param cause the underlying cause
+   */
+  public WebforjGeolocationException(GeolocationStatus status, String message, Throwable cause) {
+    super(message, cause);
+    this.status = status;
+  }
+
+  /**
+   * Returns the status reported by the browser.
+   *
+   * @return the status
+   */
+  public GeolocationStatus getStatus() {
+    return status;
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/sink/geolocation/GeolocationWatchEventSink.java
+++ b/webforj-foundation/src/main/java/com/webforj/sink/geolocation/GeolocationWatchEventSink.java
@@ -1,0 +1,143 @@
+package com.webforj.sink.geolocation;
+
+import com.basis.bbj.proxies.event.BBjEvent;
+import com.basis.bbj.proxies.event.BBjGeolocationEvent;
+import com.basis.bbj.proxies.sysgui.BBjGeolocation;
+import com.basis.bbj.proxyif.SysGuiEventConstants;
+import com.basis.startup.type.BBjException;
+import com.webforj.Environment;
+import com.webforj.Geolocation;
+import com.webforj.component.event.sink.DwcEventSink;
+import com.webforj.dispatcher.EventDispatcher;
+import com.webforj.event.geolocation.GeolocationPosition;
+import com.webforj.event.geolocation.GeolocationStatus;
+import com.webforj.event.geolocation.GeolocationWatchEvent;
+import com.webforj.exceptions.WebforjRuntimeException;
+
+/**
+ * The {@code GeolocationWatchEventSink} implements the required logic for setting and removing the
+ * callback on the underlying BBj geolocation for the watch event. It delegates the BBj event to the
+ * corresponding event listener on the {@link Geolocation}.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public class GeolocationWatchEventSink implements DwcEventSink<Geolocation> {
+
+  private final Geolocation geolocation;
+  private final EventDispatcher dispatcher;
+
+  /**
+   * Constructs a new instance of {@link GeolocationWatchEventSink}.
+   *
+   * @param geolocation the associated geolocation
+   * @param dispatcher the event dispatcher
+   */
+  public GeolocationWatchEventSink(Geolocation geolocation, EventDispatcher dispatcher) {
+    this.geolocation = geolocation;
+    this.dispatcher = dispatcher;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String setCallback(Object options) {
+    if (isConnected()) {
+      try {
+        getBbjGeolocation().setCallback(SysGuiEventConstants.ON_GEOLOCATION_WATCH, this,
+            "handleEvent");
+
+        return String.valueOf(SysGuiEventConstants.ON_GEOLOCATION_WATCH);
+      } catch (BBjException e) {
+        throw new WebforjRuntimeException("Failed to set geolocation watch callback.", e);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void removeCallback(String id) {
+    if (isConnected()) {
+      try {
+        getBbjGeolocation().clearCallback(SysGuiEventConstants.ON_GEOLOCATION_WATCH);
+      } catch (BBjException e) {
+        throw new WebforjRuntimeException("Failed to clear geolocation watch callback.", e);
+      }
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public final EventDispatcher getEventDispatcher() {
+    return this.dispatcher;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public final boolean isConnected() {
+    return this.geolocation != null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isMultipleCallbacks() {
+    return false;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Geolocation getComponent() {
+    return this.geolocation;
+  }
+
+  /**
+   * Handles the BBj event and dispatches a new {@link GeolocationWatchEvent}.
+   *
+   * @param bbjEvent the BBj event to handle
+   */
+  public void handleEvent(BBjEvent bbjEvent) {
+    BBjGeolocationEvent geoEvent = (BBjGeolocationEvent) bbjEvent;
+    GeolocationStatus status = GeolocationStatus.fromCode(geoEvent.getStatus());
+    GeolocationPosition position =
+        status == GeolocationStatus.SUCCESS ? toPosition(geoEvent) : null;
+
+    dispatcher.dispatchEvent(
+        new GeolocationWatchEvent(geolocation, status, position, geoEvent.getMessage()));
+  }
+
+  /**
+   * Gets the BBj geolocation instance.
+   *
+   * @return the BBj geolocation instance
+   */
+  protected BBjGeolocation getBbjGeolocation() {
+    try {
+      return getEnvironment().getSysGui().getGeolocation();
+    } catch (BBjException e) {
+      throw new WebforjRuntimeException("Failed to access geolocation subsystem.", e);
+    }
+  }
+
+  Environment getEnvironment() {
+    return Environment.getCurrent();
+  }
+
+  private static GeolocationPosition toPosition(BBjGeolocationEvent event) {
+    return new GeolocationPosition(event.getLatitude(), event.getLongitude(), event.getAccuracy(),
+        event.getTimestamp(), event.getAltitude(), event.getAltitudeAccuracy(), event.getHeading(),
+        event.getSpeed());
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/sink/geolocation/GeolocationWatchEventSinkRegistry.java
+++ b/webforj-foundation/src/main/java/com/webforj/sink/geolocation/GeolocationWatchEventSinkRegistry.java
@@ -1,0 +1,25 @@
+package com.webforj.sink.geolocation;
+
+import com.webforj.Geolocation;
+import com.webforj.component.event.EventSinkListenerRegistry;
+import com.webforj.event.geolocation.GeolocationWatchEvent;
+
+/**
+ * {@code GeolocationWatchEventSinkRegistry} manages the event listeners for a geolocation watch
+ * sink and the corresponding {@link GeolocationWatchEvent}.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public class GeolocationWatchEventSinkRegistry
+    extends EventSinkListenerRegistry<GeolocationWatchEvent, Geolocation> {
+
+  /**
+   * Creates a new GeolocationWatchEventSinkRegistry.
+   *
+   * @param sink the corresponding sink to the event
+   */
+  public GeolocationWatchEventSinkRegistry(GeolocationWatchEventSink sink) {
+    super(sink, GeolocationWatchEvent.class);
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/GeolocationTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/GeolocationTest.java
@@ -1,0 +1,368 @@
+package com.webforj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.basis.bbj.proxies.BBjAPI;
+import com.basis.bbj.proxies.BBjSysGui;
+import com.basis.bbj.proxies.event.BBjGeolocationEvent;
+import com.basis.bbj.proxies.sysgui.BBjGeolocation;
+import com.basis.bbj.proxyif.SysGuiEventConstants;
+import com.basis.startup.type.BBjException;
+import com.basis.startup.type.BBjNumber;
+import com.webforj.dispatcher.EventListener;
+import com.webforj.dispatcher.ListenerRegistration;
+import com.webforj.environment.ObjectTable;
+import com.webforj.event.geolocation.GeolocationPosition;
+import com.webforj.event.geolocation.GeolocationStatus;
+import com.webforj.event.geolocation.GeolocationWatchEvent;
+import com.webforj.exceptions.WebforjGeolocationException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class GeolocationTest {
+
+  Geolocation geolocation;
+  Environment environment;
+  BBjAPI api;
+  BBjSysGui sysGui;
+  BBjGeolocation bbjGeolocation;
+  MockedStatic<Environment> mockedEnvironment;
+
+  @BeforeEach
+  void setUp() throws BBjException {
+    environment = mock(Environment.class);
+    api = mock(BBjAPI.class);
+    sysGui = mock(BBjSysGui.class);
+    bbjGeolocation = mock(BBjGeolocation.class);
+
+    when(environment.getBBjAPI()).thenReturn(api);
+    when(environment.getSysGui()).thenReturn(sysGui);
+    when(sysGui.getGeolocation()).thenReturn(bbjGeolocation);
+
+    mockedEnvironment = mockStatic(Environment.class);
+    mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
+
+    geolocation = spy(Geolocation.class);
+    when(geolocation.getEnvironment()).thenReturn(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    mockedEnvironment.close();
+  }
+
+  @Nested
+  class StaticAccess {
+
+    @Test
+    void shouldReturnSingletonFromObjectTable() {
+      try (MockedStatic<ObjectTable> mockedObjectTable = mockStatic(ObjectTable.class)) {
+        Geolocation existing = mock(Geolocation.class);
+        mockedObjectTable.when(() -> ObjectTable.contains(Geolocation.class.getName()))
+            .thenReturn(true);
+        mockedObjectTable.when(() -> ObjectTable.get(Geolocation.class.getName()))
+            .thenReturn(existing);
+
+        assertSame(existing, Geolocation.getCurrent());
+      }
+    }
+
+    @Test
+    void shouldCreateInstanceWhenNotInObjectTable() {
+      try (MockedStatic<ObjectTable> mockedObjectTable = mockStatic(ObjectTable.class)) {
+        mockedObjectTable.when(() -> ObjectTable.contains(Geolocation.class.getName()))
+            .thenReturn(false);
+
+        Geolocation instance = Geolocation.getCurrent();
+
+        assertNotNull(instance);
+        mockedObjectTable
+            .verify(() -> ObjectTable.put(eq(Geolocation.class.getName()), any(Geolocation.class)));
+      }
+    }
+
+    @Test
+    void ifPresentShouldInvokeConsumer() {
+      try (MockedStatic<ObjectTable> mockedObjectTable = mockStatic(ObjectTable.class)) {
+        mockedObjectTable.when(() -> ObjectTable.contains(Geolocation.class.getName()))
+            .thenReturn(false);
+
+        AtomicReference<Geolocation> captured = new AtomicReference<>();
+        Geolocation.ifPresent(captured::set);
+
+        assertNotNull(captured.get());
+      }
+    }
+  }
+
+  @Nested
+  class Configuration {
+
+    @Test
+    void shouldSetHighAccuracy() {
+      geolocation.useHighAccuracy(true);
+      verify(bbjGeolocation).setHighAccuracy(true);
+    }
+
+    @Test
+    void shouldGetHighAccuracy() {
+      when(bbjGeolocation.isHighAccuracy()).thenReturn(true);
+      assertTrue(geolocation.isHighAccuracy());
+    }
+
+    @Test
+    void shouldSetTimeout() {
+      geolocation.useTimeout(15);
+      verify(bbjGeolocation).setTimeout(any(BBjNumber.class));
+    }
+
+    @Test
+    void shouldGetTimeout() {
+      BBjNumber number = mock(BBjNumber.class);
+      when(number.doubleValue()).thenReturn(12.5);
+      when(bbjGeolocation.getTimeout()).thenReturn(number);
+
+      assertEquals(12.5, geolocation.getTimeout());
+    }
+
+    @Test
+    void shouldSetMaximumAge() {
+      geolocation.useMaximumAge(60);
+      verify(bbjGeolocation).setMaximumAge(any(BBjNumber.class));
+    }
+
+    @Test
+    void shouldGetMaximumAge() {
+      BBjNumber number = mock(BBjNumber.class);
+      when(number.doubleValue()).thenReturn(90.0);
+      when(bbjGeolocation.getMaximumAge()).thenReturn(number);
+
+      assertEquals(90.0, geolocation.getMaximumAge());
+    }
+  }
+
+  @Nested
+  class GetCurrentPosition {
+
+    @Test
+    void shouldRegisterCallbackAndRequestPosition() throws BBjException {
+      PendingResult<GeolocationPosition> result = geolocation.getCurrentPosition();
+
+      assertNotNull(result);
+      assertFalse(result.isDone());
+      verify(bbjGeolocation, times(1)).setCallback(eq(SysGuiEventConstants.ON_GEOLOCATION_POSITION),
+          any(), eq("handlePositionEvent"));
+      verify(bbjGeolocation, times(1)).getCurrentPosition();
+    }
+
+    @Test
+    void shouldRegisterCallbackOnlyOnceAcrossMultipleRequests() throws BBjException {
+      geolocation.getCurrentPosition();
+      geolocation.getCurrentPosition();
+      geolocation.getCurrentPosition();
+
+      verify(bbjGeolocation, times(1)).setCallback(eq(SysGuiEventConstants.ON_GEOLOCATION_POSITION),
+          any(), eq("handlePositionEvent"));
+      verify(bbjGeolocation, times(3)).getCurrentPosition();
+    }
+  }
+
+  @Nested
+  class WatchListener {
+
+    @Test
+    void shouldRegisterWatchCallbackWhenFirstListenerAdded() throws BBjException {
+      ListenerRegistration<GeolocationWatchEvent> registration = geolocation.onWatch(event -> {
+      });
+
+      assertNotNull(registration);
+      verify(bbjGeolocation, times(1)).setCallback(eq(SysGuiEventConstants.ON_GEOLOCATION_WATCH),
+          any(), eq("handleEvent"));
+    }
+
+    @Test
+    void shouldRegisterWatchCallbackOnlyOnceForMultipleListeners() throws BBjException {
+      geolocation.onWatch(event -> {
+      });
+      geolocation.onWatch(event -> {
+      });
+
+      verify(bbjGeolocation, times(1)).setCallback(eq(SysGuiEventConstants.ON_GEOLOCATION_WATCH),
+          any(), eq("handleEvent"));
+    }
+
+    @Test
+    void shouldClearWatchCallbackWhenLastListenerRemoved() throws BBjException {
+      ListenerRegistration<GeolocationWatchEvent> reg1 = geolocation.onWatch(event -> {
+      });
+      ListenerRegistration<GeolocationWatchEvent> reg2 = geolocation.onWatch(event -> {
+      });
+
+      reg1.remove();
+      verify(bbjGeolocation, never()).clearCallback(anyInt());
+
+      reg2.remove();
+      verify(bbjGeolocation, times(1)).clearCallback(SysGuiEventConstants.ON_GEOLOCATION_WATCH);
+
+      // registering after all removed should set callback again
+      geolocation.onWatch(event -> {
+      });
+      verify(bbjGeolocation, times(2)).setCallback(eq(SysGuiEventConstants.ON_GEOLOCATION_WATCH),
+          any(), eq("handleEvent"));
+    }
+  }
+
+  @Nested
+  class HandleEvent {
+
+    @Test
+    void shouldCompletePendingResultOnSuccess() {
+      double latitude = 35.150036;
+      double longitude = -106.593957;
+      double accuracy = 10.0;
+      long timestamp = 1700000000000L;
+      double altitude = 1500.5;
+      double altitudeAccuracy = 5.0;
+      double heading = 90.0;
+      double speed = 2.5;
+
+      BBjGeolocationEvent bbjEvent = mock(BBjGeolocationEvent.class);
+      when(bbjEvent.getStatus()).thenReturn(0);
+      when(bbjEvent.getLatitude()).thenReturn(latitude);
+      when(bbjEvent.getLongitude()).thenReturn(longitude);
+      when(bbjEvent.getAccuracy()).thenReturn(accuracy);
+      when(bbjEvent.getTimestamp()).thenReturn(timestamp);
+      when(bbjEvent.getAltitude()).thenReturn(altitude);
+      when(bbjEvent.getAltitudeAccuracy()).thenReturn(altitudeAccuracy);
+      when(bbjEvent.getHeading()).thenReturn(heading);
+      when(bbjEvent.getSpeed()).thenReturn(speed);
+
+      PendingResult<GeolocationPosition> result = geolocation.getCurrentPosition();
+      geolocation.getEventHandler().handlePositionEvent(bbjEvent);
+
+      assertTrue(result.isDone());
+      AtomicReference<GeolocationPosition> captured = new AtomicReference<>();
+      result.thenAccept(captured::set);
+
+      GeolocationPosition position = captured.get();
+      assertEquals(latitude, position.getLatitude());
+      assertEquals(longitude, position.getLongitude());
+      assertEquals(accuracy, position.getAccuracy());
+      assertEquals(timestamp, position.getTimestamp());
+      assertEquals(altitude, position.getAltitude().orElseThrow());
+      assertEquals(altitudeAccuracy, position.getAltitudeAccuracy().orElseThrow());
+      assertEquals(heading, position.getHeading().orElseThrow());
+      assertEquals(speed, position.getSpeed().orElseThrow());
+    }
+
+    @Test
+    void shouldCompleteExceptionallyOnError() {
+      String message = "User denied geolocation prompt";
+
+      BBjGeolocationEvent bbjEvent = mock(BBjGeolocationEvent.class);
+      when(bbjEvent.getStatus()).thenReturn(GeolocationStatus.PERMISSION_DENIED.getCode());
+      when(bbjEvent.getMessage()).thenReturn(message);
+
+      PendingResult<GeolocationPosition> result = geolocation.getCurrentPosition();
+      geolocation.getEventHandler().handlePositionEvent(bbjEvent);
+
+      assertTrue(result.isCompletedExceptionally());
+      AtomicReference<Throwable> captured = new AtomicReference<>();
+      result.exceptionally(throwable -> {
+        captured.set(throwable);
+
+        return null;
+      });
+
+      WebforjGeolocationException error = (WebforjGeolocationException) captured.get();
+      assertEquals(GeolocationStatus.PERMISSION_DENIED, error.getStatus());
+      assertEquals(message, error.getMessage());
+    }
+
+    @Test
+    void shouldDispatchWatchEventOnSuccess() {
+      double latitude = 10.0;
+
+      AtomicReference<GeolocationWatchEvent> captured = new AtomicReference<>();
+      EventListener<GeolocationWatchEvent> listener = captured::set;
+      geolocation.onWatch(listener);
+
+      BBjGeolocationEvent bbjEvent = mock(BBjGeolocationEvent.class);
+      when(bbjEvent.getStatus()).thenReturn(GeolocationStatus.SUCCESS.getCode());
+      when(bbjEvent.getLatitude()).thenReturn(latitude);
+      when(bbjEvent.getLongitude()).thenReturn(20.0);
+      when(bbjEvent.getAccuracy()).thenReturn(1.0);
+      when(bbjEvent.getTimestamp()).thenReturn(42L);
+
+      geolocation.getWatchSink().handleEvent(bbjEvent);
+
+      assertNotNull(captured.get());
+      assertTrue(captured.get().isSuccess());
+      assertEquals(GeolocationStatus.SUCCESS, captured.get().getStatus());
+      assertEquals(latitude, captured.get().getPosition().orElseThrow().getLatitude());
+    }
+
+    @Test
+    void shouldDispatchWatchEventOnError() {
+      String message = "Timed out";
+
+      AtomicReference<GeolocationWatchEvent> captured = new AtomicReference<>();
+      geolocation.onWatch(captured::set);
+
+      BBjGeolocationEvent bbjEvent = mock(BBjGeolocationEvent.class);
+      when(bbjEvent.getStatus()).thenReturn(GeolocationStatus.TIMEOUT.getCode());
+      when(bbjEvent.getMessage()).thenReturn(message);
+
+      geolocation.getWatchSink().handleEvent(bbjEvent);
+
+      assertEquals(GeolocationStatus.TIMEOUT, captured.get().getStatus());
+      assertFalse(captured.get().isSuccess());
+      assertEquals(message, captured.get().getMessage().orElseThrow());
+      assertTrue(captured.get().getPosition().isEmpty());
+    }
+  }
+
+  @Nested
+  class Destroy {
+
+    @Test
+    void shouldRemoveAllListeners() throws BBjException {
+      geolocation.onWatch(event -> {
+      });
+
+      geolocation.destroy();
+
+      verify(bbjGeolocation, never()).clearCallback(anyInt());
+    }
+
+    @Test
+    void shouldBeIdempotent() throws BBjException {
+      geolocation.onWatch(event -> {
+      });
+      geolocation.getCurrentPosition();
+
+      geolocation.destroy();
+      geolocation.destroy();
+
+      verify(bbjGeolocation, never()).clearCallback(anyInt());
+    }
+  }
+}


### PR DESCRIPTION
Introduces `com.webforj.Geolocation`, a singleton that exposes the browser's geolocation subsystem.

```java
PendingResult<GeolocationPosition> request = Geolocation.getCurrent().getCurrentPosition();
request.thenAccept(position -> {
  double lat = position.getLatitude();
  double lng = position.getLongitude();
  double accuracy = position.getAccuracy();
});
request.exceptionally(throwable -> {
  WebforjGeolocationException error = (WebforjGeolocationException) throwable;
  GeolocationStatus status = error.getStatus();
  String message = error.getMessage();

  return null;
});
```