### PR TITLE
feat: add Page Visibility API

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/Page.java
+++ b/webforj-foundation/src/main/java/com/webforj/Page.java
@@ -18,6 +18,7 @@ import com.webforj.event.page.PageEvent;
 import com.webforj.event.page.PageEventOptions;
 import com.webforj.event.page.PageUnloadEvent;
 import com.webforj.event.page.PageUnloadEventHandler;
+import com.webforj.event.page.PageVisibilityChangeEvent;
 import com.webforj.exceptions.WebforjWebManagerException;
 import com.webforj.sink.page.PageEventSink;
 import com.webforj.sink.page.PageEventSinkRegistry;
@@ -56,6 +57,7 @@ public final class Page implements HasJsExecution {
   private PageExecuteJsAsyncHandler executeJsAsyncHandler = null;
   private Environment environment = Environment.getCurrent();
   private boolean isBrowserCloseEventRegistered = false;
+  private boolean isVisibilityChangeEventRegistered = false;
   private ViewTransitionManager viewTransitionManager;
   private final Map<String, PageEventSinkRegistry> registries = new HashMap<>();
   private final EventDispatcher eventDispatcher = new EventDispatcher();
@@ -1107,6 +1109,22 @@ public final class Page implements HasJsExecution {
   }
 
   /**
+   * Returns the current visibility state of the page reported by the browser.
+   *
+   * <p>
+   * The value is read asynchronously from the browser and delivered through the returned
+   * {@link PendingResult}.
+   * </p>
+   *
+   * @return a pending result that resolves with the current {@link PageVisibilityState}
+   * @since 26.01
+   */
+  public PendingResult<PageVisibilityState> getVisibilityState() {
+    return executeJsAsync("document.visibilityState")
+        .thenApply(value -> PageVisibilityState.fromValue(String.valueOf(value)));
+  }
+
+  /**
    * Adds a {@link PageEvent} listener for the page.
    *
    * @param type the type/name of the event. (e.g. "click").
@@ -1147,7 +1165,6 @@ public final class Page implements HasJsExecution {
       }
     }, finalEventOptions);
   }
-
 
   /**
    * Adds a {@link PageEvent} listener for the page.
@@ -1211,6 +1228,50 @@ public final class Page implements HasJsExecution {
    */
   public ListenerRegistration<PageUnloadEvent> onUnload(EventListener<PageUnloadEvent> listener) {
     return addUnloadListener(listener);
+  }
+
+  /**
+   * Adds a listener that is notified each time the browser reports a change in the page's
+   * visibility state.
+   *
+   * <p>
+   * The browser fires the underlying event whenever the document moves between the foreground and a
+   * hidden state, for example when the user switches tabs or minimizes the window. The event is
+   * registered with the browser the first time a listener is added.
+   * </p>
+   *
+   * @param listener the listener to add
+   * @return the registration object that can be used to remove the listener
+   * @since 26.01
+   */
+  public ListenerRegistration<PageVisibilityChangeEvent> addVisibilityChangeListener(
+      EventListener<PageVisibilityChangeEvent> listener) {
+    if (!isVisibilityChangeEventRegistered) {
+      isVisibilityChangeEventRegistered = true;
+
+      PageEventOptions options = new PageEventOptions();
+      options.addData("state", "document.visibilityState");
+
+      addEventListener("visibilitychange", ev -> {
+        String value = String.valueOf(ev.getData().get("state"));
+        getEventDispatcher().dispatchEvent(
+            new PageVisibilityChangeEvent(this, PageVisibilityState.fromValue(value)));
+      }, options);
+    }
+
+    return getEventDispatcher().addListener(PageVisibilityChangeEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addVisibilityChangeListener(EventListener)}.
+   *
+   * @param listener the listener to add
+   * @return the registration object that can be used to remove the listener
+   * @since 26.01
+   */
+  public ListenerRegistration<PageVisibilityChangeEvent> onVisibilityChange(
+      EventListener<PageVisibilityChangeEvent> listener) {
+    return addVisibilityChangeListener(listener);
   }
 
   private void performDownload(String sourceFilePath, String fileName) throws BBjException {

--- a/webforj-foundation/src/main/java/com/webforj/PageVisibilityState.java
+++ b/webforj-foundation/src/main/java/com/webforj/PageVisibilityState.java
@@ -1,0 +1,54 @@
+package com.webforj;
+
+/**
+ * The visibility state of the {@link Page} reported by the browser.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public enum PageVisibilityState {
+
+  /**
+   * The page content is at least partially visible. In practice, this means the page is the
+   * foreground tab of a non minimized window.
+   */
+  VISIBLE("visible"),
+
+  /**
+   * The page content is not visible to the user. In practice, the document is either a background
+   * tab, in a minimized window, the screen is locked, or the operating system is showing a
+   * screensaver.
+   */
+  HIDDEN("hidden");
+
+  private final String value;
+
+  PageVisibilityState(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Returns the string value reported by the browser for this state.
+   *
+   * @return the state value
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Resolves a state from the string value reported by the browser. Any value that is not
+   * {@code "visible"} maps to {@link #HIDDEN}, which matches the conservative reading of the
+   * specification for legacy values such as {@code "prerender"} or {@code "unloaded"}.
+   *
+   * @param value the value reported by the browser
+   * @return the resolved state
+   */
+  public static PageVisibilityState fromValue(String value) {
+    if (VISIBLE.value.equalsIgnoreCase(value)) {
+      return VISIBLE;
+    }
+
+    return HIDDEN;
+  }
+}

--- a/webforj-foundation/src/main/java/com/webforj/event/page/PageVisibilityChangeEvent.java
+++ b/webforj-foundation/src/main/java/com/webforj/event/page/PageVisibilityChangeEvent.java
@@ -1,0 +1,70 @@
+package com.webforj.event.page;
+
+import com.webforj.Page;
+import com.webforj.PageVisibilityState;
+import java.util.EventObject;
+
+/**
+ * An event that indicates the browser tab hosting the page has changed visibility state.
+ *
+ * <p>
+ * The event is fired by the browser whenever the user switches tabs, minimizes the window, opens
+ * the operating system task switcher, or otherwise causes the document to enter or leave the
+ * background.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public class PageVisibilityChangeEvent extends EventObject {
+  private final transient Page page;
+  private final PageVisibilityState state;
+
+  /**
+   * Construct a new PageVisibilityChangeEvent.
+   *
+   * @param source the page that produced the event
+   * @param state the visibility state reported by the browser
+   */
+  public PageVisibilityChangeEvent(Page source, PageVisibilityState state) {
+    super(source);
+    this.page = source;
+    this.state = state;
+  }
+
+  /**
+   * Returns the page that produced the event.
+   *
+   * @return the page
+   */
+  public Page getPage() {
+    return page;
+  }
+
+  /**
+   * Returns the visibility state reported by the browser.
+   *
+   * @return the visibility state
+   */
+  public PageVisibilityState getState() {
+    return state;
+  }
+
+  /**
+   * Returns {@code true} when the reported state is {@link PageVisibilityState#HIDDEN}.
+   *
+   * @return whether the page is hidden
+   */
+  public boolean isHidden() {
+    return state == PageVisibilityState.HIDDEN;
+  }
+
+  /**
+   * Returns {@code true} when the reported state is {@link PageVisibilityState#VISIBLE}.
+   *
+   * @return whether the page is visible
+   */
+  public boolean isVisible() {
+    return state == PageVisibilityState.VISIBLE;
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/PageTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/PageTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -33,6 +34,7 @@ import com.webforj.environment.ObjectTable;
 import com.webforj.event.page.PageEvent;
 import com.webforj.event.page.PageEventOptions;
 import com.webforj.event.page.PageUnloadEvent;
+import com.webforj.event.page.PageVisibilityChangeEvent;
 import com.webforj.exceptions.WebforjWebManagerException;
 import com.webforj.utilities.Assets;
 import java.awt.Color;
@@ -44,6 +46,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 class PageTest {
@@ -336,6 +341,73 @@ class PageTest {
       EventListener<PageUnloadEvent> listener = mock(EventListener.class);
 
       assertThrows(WebforjWebManagerException.class, () -> page.onUnload(listener));
+    }
+  }
+
+  @Nested
+  class VisibilityChange {
+
+    MockedStatic<Environment> mockedEnvironment;
+
+    @BeforeEach
+    void setUpVisibility() throws BBjException {
+      when(webManager.newEventOptions()).thenReturn(mock(BBjWebEventOptions.class));
+      mockedEnvironment = mockStatic(Environment.class);
+      mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
+    }
+
+    @AfterEach
+    void tearDownVisibility() {
+      mockedEnvironment.close();
+    }
+
+    @Test
+    void shouldRegisterBrowserCallbackOnceAcrossListeners() throws BBjException {
+      page.onVisibilityChange(event -> {
+      });
+      page.onVisibilityChange(event -> {
+      });
+
+      verify(webManager, times(1)).setCallback(eq("visibilitychange"), any(), eq("handleEvent"),
+          any());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"visible, VISIBLE", "hidden, HIDDEN"})
+    void shouldDispatchEventForBrowserState(String value, PageVisibilityState expected) {
+      AtomicReference<PageVisibilityChangeEvent> captured = new AtomicReference<>();
+      page.onVisibilityChange(captured::set);
+
+      fireVisibilityChangeWithState(value);
+
+      assertEquals(expected, captured.get().getState());
+      assertEquals(page, captured.get().getPage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"visible, VISIBLE", "hidden, HIDDEN"})
+    void getVisibilityStateShouldMapBrowserValue(String value, PageVisibilityState expected) {
+      PendingResult<Object> raw = new PendingResult<>();
+      doReturn(raw).when(page).executeJsAsync("document.visibilityState");
+
+      AtomicReference<PageVisibilityState> captured = new AtomicReference<>();
+      page.getVisibilityState().thenAccept(captured::set);
+
+      raw.complete(value);
+
+      assertEquals(expected, captured.get());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void fireVisibilityChangeWithState(String state) {
+      ArgumentCaptor<EventListener<PageEvent>> listenerCaptor =
+          ArgumentCaptor.forClass(EventListener.class);
+      verify(page).addEventListener(eq("visibilitychange"), listenerCaptor.capture(),
+          any(PageEventOptions.class));
+
+      PageEvent pageEvent = new PageEvent(page, Map.of("state", state), "visibilitychange", 1,
+          new PageEventOptions());
+      listenerCaptor.getValue().onEvent(pageEvent);
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/PageVisibilityStateTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/PageVisibilityStateTest.java
@@ -1,0 +1,36 @@
+package com.webforj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PageVisibilityStateTest {
+
+  @Test
+  void shouldReturnReportedValue() {
+    assertEquals("visible", PageVisibilityState.VISIBLE.getValue());
+    assertEquals("hidden", PageVisibilityState.HIDDEN.getValue());
+  }
+
+  @Test
+  void shouldResolveVisibleFromValueIgnoringCase() {
+    assertEquals(PageVisibilityState.VISIBLE, PageVisibilityState.fromValue("VISIBLE"));
+    assertEquals(PageVisibilityState.VISIBLE, PageVisibilityState.fromValue("Visible"));
+  }
+
+  @Test
+  void shouldFallBackToHiddenForLegacyValues() {
+    assertEquals(PageVisibilityState.HIDDEN, PageVisibilityState.fromValue("prerender"));
+    assertEquals(PageVisibilityState.HIDDEN, PageVisibilityState.fromValue("unloaded"));
+  }
+
+  @Test
+  void shouldFallBackToHiddenForNullValue() {
+    assertEquals(PageVisibilityState.HIDDEN, PageVisibilityState.fromValue(null));
+  }
+
+  @Test
+  void shouldFallBackToHiddenForEmptyValue() {
+    assertEquals(PageVisibilityState.HIDDEN, PageVisibilityState.fromValue(""));
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/event/page/PageVisibilityChangeEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/event/page/PageVisibilityChangeEventTest.java
@@ -1,0 +1,44 @@
+package com.webforj.event.page;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.webforj.Page;
+import com.webforj.PageVisibilityState;
+import org.junit.jupiter.api.Test;
+
+class PageVisibilityChangeEventTest {
+
+  @Test
+  void shouldExposeStateAndPage() {
+    Page page = mock(Page.class);
+
+    PageVisibilityChangeEvent event =
+        new PageVisibilityChangeEvent(page, PageVisibilityState.VISIBLE);
+
+    assertSame(page, event.getPage());
+    assertSame(page, event.getSource());
+    assertEquals(PageVisibilityState.VISIBLE, event.getState());
+  }
+
+  @Test
+  void shouldReportVisibleWhenStateIsVisible() {
+    PageVisibilityChangeEvent event =
+        new PageVisibilityChangeEvent(mock(Page.class), PageVisibilityState.VISIBLE);
+
+    assertTrue(event.isVisible());
+    assertFalse(event.isHidden());
+  }
+
+  @Test
+  void shouldReportHiddenWhenStateIsHidden() {
+    PageVisibilityChangeEvent event =
+        new PageVisibilityChangeEvent(mock(Page.class), PageVisibilityState.HIDDEN);
+
+    assertTrue(event.isHidden());
+    assertFalse(event.isVisible());
+  }
+}


### PR DESCRIPTION

Adds a Page Visibility API to `Page` so apps can detect when the browser tab moves between the foreground and a hidden state and react. 

On `Page`:

- `getVisibilityState()` returns a `PendingResult<PageVisibilityState>` with the current visibility state.
- `addVisibilityChangeListener(EventListener<PageVisibilityChangeEvent>)` fires every time the browser reports a visibility change. The matching alias is `onVisibilityChange(...)`.
