### PR TITLE
feat(appnav): add item pinning and search configuration

### DIFF
--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNav.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNav.java
@@ -2,7 +2,12 @@ package com.webforj.component.layout.appnav;
 
 import com.webforj.component.element.PropertyDescriptor;
 import com.webforj.component.element.annotation.NodeName;
+import com.webforj.component.element.annotation.PropertyExclude;
+import com.webforj.component.element.annotation.PropertyMethods;
+import com.webforj.component.icons.IconDefinition;
 import com.webforj.component.layout.appnav.event.AppNavLocationChangedEvent;
+import com.webforj.component.layout.appnav.event.AppNavPinEvent;
+import com.webforj.component.layout.appnav.event.AppNavSearchEvent;
 import com.webforj.concern.HasClassName;
 import com.webforj.concern.HasStyle;
 import com.webforj.concern.HasVisibility;
@@ -10,6 +15,9 @@ import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.router.Router;
 import com.webforj.router.history.Location;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -32,6 +40,41 @@ public class AppNav extends NavigationContainer<AppNav>
   // Property descriptors
   private final PropertyDescriptor<Boolean> autoOpenProp =
       PropertyDescriptor.property("autoOpen", true);
+  @PropertyMethods(target = Search.class, setter = "setFieldVisible", getter = "isFieldVisible")
+  private final PropertyDescriptor<Boolean> searchableProp =
+      PropertyDescriptor.property("searchInput", false);
+  @PropertyMethods(target = Search.class, setter = "setTerm", getter = "getTerm")
+  private final PropertyDescriptor<String> searchTermProp =
+      PropertyDescriptor.property("searchTerm", "");
+  @PropertyMethods(target = Search.class, setter = "setPlaceholder", getter = "getPlaceholder")
+  private final PropertyDescriptor<String> searchPlaceholderProp =
+      PropertyDescriptor.property("searchPlaceholder", "Search");
+  @PropertyMethods(target = Search.class, setter = "setEmptyMessage", getter = "getEmptyMessage")
+  private final PropertyDescriptor<String> emptyMessageProp =
+      PropertyDescriptor.property("searchNodata", "No data to display");
+  @PropertyMethods(target = Pinning.class, setter = "setEnabled", getter = "isEnabled")
+  private final PropertyDescriptor<Boolean> pinnableProp =
+      PropertyDescriptor.property("pinnable", false);
+  @PropertyMethods(target = Pinning.class, setter = "setAutosave", getter = "isAutosave")
+  private final PropertyDescriptor<Boolean> pinAutosaveProp =
+      PropertyDescriptor.property("pinAutosave", false);
+  @PropertyMethods(target = Pinning.class, setter = "setTitle", getter = "getTitle")
+  private final PropertyDescriptor<String> pinnedTitleProp =
+      PropertyDescriptor.property("pinnedTitle", "Pinned");
+  @PropertyMethods(target = Pinning.class, setter = "setTouchVisible", getter = "isTouchVisible")
+  private final PropertyDescriptor<Boolean> pinTouchVisibleProp =
+      PropertyDescriptor.property("pinTouchVisible", false);
+  // Excluded from the property tester because the setters take an IconDefinition, not the raw
+  // string.
+  @PropertyExclude
+  private final PropertyDescriptor<String> pinUnpinnedIconProp =
+      PropertyDescriptor.property("iconUnpinned", "dwc:pin");
+  @PropertyExclude
+  private final PropertyDescriptor<String> pinPinnedIconProp =
+      PropertyDescriptor.property("iconPinned", "dwc:pinned-off");
+
+  private final Search search = new Search();
+  private final Pinning pinning = new Pinning();
 
   /**
    * Creates a new {@code AppNav} component.
@@ -43,6 +86,25 @@ public class AppNav extends NavigationContainer<AppNav>
       Location location = event.getLocation();
       Router.getCurrent().navigate(location);
     });
+  }
+
+  /**
+   * Creates a new {@code AppNav} component with the given id.
+   *
+   * <p>
+   * Setting an id (or name) gives pinning autosave a stable storage key, so pinned items are
+   * restored across reloads. See {@link Pinning#setAutosave(boolean)}.
+   * </p>
+   *
+   * @param id the id of the component
+   * @since 26.01
+   */
+  public AppNav(String id) {
+    this();
+
+    if (id != null) {
+      getElement().setAttribute("id", id);
+    }
   }
 
   /**
@@ -64,6 +126,24 @@ public class AppNav extends NavigationContainer<AppNav>
    */
   public boolean isAutoOpen() {
     return get(autoOpenProp);
+  }
+
+  /**
+   * Returns the configuration object for the navigation's embedded search field.
+   *
+   * @return the search configuration
+   */
+  public Search getSearch() {
+    return search;
+  }
+
+  /**
+   * Returns the configuration object for the navigation's pinning.
+   *
+   * @return the pinning configuration
+   */
+  public Pinning getPinning() {
+    return pinning;
   }
 
   /**
@@ -89,10 +169,344 @@ public class AppNav extends NavigationContainer<AppNav>
   }
 
   /**
+   * Adds a listener for the {@link AppNavSearchEvent} event.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<AppNavSearchEvent> addSearchListener(
+      EventListener<AppNavSearchEvent> listener) {
+    return addEventListener(AppNavSearchEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addSearchListener(EventListener)}.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<AppNavSearchEvent> onSearch(
+      EventListener<AppNavSearchEvent> listener) {
+    return addSearchListener(listener);
+  }
+
+  /**
+   * Adds a listener for the {@link AppNavPinEvent} event.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<AppNavPinEvent> addPinListener(
+      EventListener<AppNavPinEvent> listener) {
+    return addEventListener(AppNavPinEvent.class, listener);
+  }
+
+  /**
+   * Alias for {@link #addPinListener(EventListener)}.
+   *
+   * @param listener the listener
+   * @return A registration object for removing the event listener
+   */
+  public ListenerRegistration<AppNavPinEvent> onPin(EventListener<AppNavPinEvent> listener) {
+    return addPinListener(listener);
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
   protected final String getSlotName() {
     return "";
+  }
+
+  /**
+   * Configures the navigation's embedded search field.
+   *
+   * @author Hyyan Abo Fakher
+   * @since 26.01
+   */
+  public final class Search {
+
+    /**
+     * Sets whether the built in search field is shown.
+     *
+     * <p>
+     * Set to {@code false} to provide your own search field and drive the navigation through
+     * {@link #setTerm(String)} and the {@link AppNavSearchEvent} instead.
+     * </p>
+     *
+     * @param fieldVisible {@code true} to show the search field and enable filtering, {@code false}
+     *        to hide it
+     * @return the search configuration itself
+     */
+    public Search setFieldVisible(boolean fieldVisible) {
+      set(searchableProp, fieldVisible);
+
+      return this;
+    }
+
+    /**
+     * Checks whether the built in search field is shown.
+     *
+     * @return {@code true} if the search field is shown, {@code false} otherwise
+     */
+    public boolean isFieldVisible() {
+      return get(searchableProp);
+    }
+
+    /**
+     * Sets the current search term.
+     *
+     * @param term the search term
+     * @return the search configuration itself
+     */
+    public Search setTerm(String term) {
+      set(searchTermProp, term);
+
+      return this;
+    }
+
+    /**
+     * Gets the current search term.
+     *
+     * @return the search term
+     */
+    public String getTerm() {
+      return get(searchTermProp);
+    }
+
+    /**
+     * Sets the placeholder text of the search field.
+     *
+     * @param placeholder the placeholder text
+     * @return the search configuration itself
+     */
+    public Search setPlaceholder(String placeholder) {
+      set(searchPlaceholderProp, placeholder);
+
+      return this;
+    }
+
+    /**
+     * Gets the placeholder text of the search field.
+     *
+     * @return the placeholder text
+     */
+    public String getPlaceholder() {
+      return get(searchPlaceholderProp);
+    }
+
+    /**
+     * Sets the message shown when a search returns no results.
+     *
+     * <p>
+     * Plain text is rendered as text. To render rich content, wrap the message in
+     * {@code <html>...</html>}, for example {@code "<html><strong>Nothing found</strong></html>"}.
+     * </p>
+     *
+     * @param emptyMessage the empty message
+     * @return the search configuration itself
+     */
+    public Search setEmptyMessage(String emptyMessage) {
+      String value = emptyMessage == null ? "" : emptyMessage;
+      set(emptyMessageProp, isWrappedWithHtmlTag(value) ? value : sanitizeHtml(value));
+
+      return this;
+    }
+
+    /**
+     * Gets the message shown when a search returns no results.
+     *
+     * @return the empty message
+     */
+    public String getEmptyMessage() {
+      return get(emptyMessageProp);
+    }
+
+    private boolean isWrappedWithHtmlTag(String text) {
+      return (text == null ? "" : text).trim().startsWith("<html>");
+    }
+
+    private String sanitizeHtml(String html) {
+      return (html == null ? "" : html).replaceAll("\\<[^>]*>", "");
+    }
+  }
+
+  /**
+   * Configures the navigation's pinning.
+   *
+   * @author Hyyan Abo Fakher
+   * @since 26.01
+   */
+  public final class Pinning {
+
+    /**
+     * Sets whether pinning is enabled.
+     *
+     * <p>
+     * When enabled, a pin toggle is shown on navigable leaf items and pinned items are moved into a
+     * group at the top of the navigation.
+     * </p>
+     *
+     * @param enabled {@code true} to enable pinning, {@code false} otherwise
+     * @return the pinning configuration itself
+     */
+    public Pinning setEnabled(boolean enabled) {
+      set(pinnableProp, enabled);
+
+      return this;
+    }
+
+    /**
+     * Checks whether pinning is enabled.
+     *
+     * @return {@code true} if pinning is enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+      return get(pinnableProp);
+    }
+
+    /**
+     * Sets whether the set of pinned items is persisted to the browser's local storage and restored
+     * on reload.
+     *
+     * <p>
+     * Persistence is per browser and requires an id or name on the component. Disable it to take
+     * full control of persistence through the {@link AppNavPinEvent} and
+     * {@link AppNavItem#setPinned(boolean)} instead, for example to store pins per user.
+     * </p>
+     *
+     * @param autosave {@code true} to persist pins to local storage, {@code false} otherwise
+     * @return the pinning configuration itself
+     */
+    public Pinning setAutosave(boolean autosave) {
+      set(pinAutosaveProp, autosave);
+
+      return this;
+    }
+
+    /**
+     * Checks whether pins are persisted to local storage.
+     *
+     * @return {@code true} if pins are persisted, {@code false} otherwise
+     */
+    public boolean isAutosave() {
+      return get(pinAutosaveProp);
+    }
+
+    /**
+     * Sets the title of the pinned group.
+     *
+     * @param title the title
+     * @return the pinning configuration itself
+     */
+    public Pinning setTitle(String title) {
+      set(pinnedTitleProp, title);
+
+      return this;
+    }
+
+    /**
+     * Gets the title of the pinned group.
+     *
+     * @return the title
+     */
+    public String getTitle() {
+      return get(pinnedTitleProp);
+    }
+
+    /**
+     * Sets whether the pin toggle stays visible on touch devices.
+     *
+     * <p>
+     * Touch devices have no hover to reveal the pin, so it is hidden there by default. Enable this
+     * to keep the pin visible and tappable on touch.
+     * </p>
+     *
+     * @param touchVisible {@code true} to keep the pin visible on touch, {@code false} otherwise
+     * @return the pinning configuration itself
+     */
+    public Pinning setTouchVisible(boolean touchVisible) {
+      set(pinTouchVisibleProp, touchVisible);
+
+      return this;
+    }
+
+    /**
+     * Checks whether the pin toggle stays visible on touch devices.
+     *
+     * @return {@code true} if the pin stays visible on touch, {@code false} otherwise
+     */
+    public boolean isTouchVisible() {
+      return get(pinTouchVisibleProp);
+    }
+
+    /**
+     * Sets the icon shown on items that are not pinned.
+     *
+     * @param icon the icon
+     * @return the pinning configuration itself
+     * @throws NullPointerException if {@code icon} is null
+     */
+    public Pinning setUnpinnedIcon(IconDefinition<?> icon) {
+      Objects.requireNonNull(icon, "icon cannot be null");
+      set(pinUnpinnedIconProp, String.format("%s:%s", icon.getPool(), icon.getName()));
+
+      return this;
+    }
+
+    /**
+     * Gets the icon shown on items that are not pinned, in {@code pool:name} form.
+     *
+     * @return the unpinned icon
+     */
+    public String getUnpinnedIcon() {
+      return get(pinUnpinnedIconProp);
+    }
+
+    /**
+     * Sets the icon shown on items that are pinned.
+     *
+     * @param icon the icon
+     * @return the pinning configuration itself
+     * @throws NullPointerException if {@code icon} is null
+     */
+    public Pinning setPinnedIcon(IconDefinition<?> icon) {
+      Objects.requireNonNull(icon, "icon cannot be null");
+      set(pinPinnedIconProp, String.format("%s:%s", icon.getPool(), icon.getName()));
+
+      return this;
+    }
+
+    /**
+     * Gets the icon shown on items that are pinned, in {@code pool:name} form.
+     *
+     * @return the pinned icon
+     */
+    public String getPinnedIcon() {
+      return get(pinPinnedIconProp);
+    }
+
+    /**
+     * Returns the currently pinned items, in tree order.
+     *
+     * @return the pinned items
+     */
+    public List<AppNavItem> getItems() {
+      List<AppNavItem> result = new ArrayList<>();
+      collectPinned(AppNav.this.getItems(), result);
+
+      return result;
+    }
+
+    private void collectPinned(List<AppNavItem> items, List<AppNavItem> result) {
+      for (AppNavItem item : items) {
+        if (item.isPinned()) {
+          result.add(item);
+        }
+
+        collectPinned(item.getItems(), result);
+      }
+    }
   }
 }

--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNavItem.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNavItem.java
@@ -13,12 +13,8 @@ import com.webforj.concern.HasStyle;
 import com.webforj.concern.HasText;
 import com.webforj.concern.HasVisibility;
 import com.webforj.router.Router;
-import com.webforj.router.history.Location;
 import com.webforj.router.history.ParametersBag;
-import com.webforj.router.history.SegmentsBag;
 import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -55,6 +51,10 @@ public class AppNavItem extends NavigationContainer<AppNavItem> implements HasSt
       PropertyDescriptor.property("routerIgnore", false);
   private final PropertyDescriptor<NavigationTarget> targetProp =
       PropertyDescriptor.property("target", NavigationTarget.SELF);
+  private final PropertyDescriptor<Boolean> pinnedProp =
+      PropertyDescriptor.property("pinned", false);
+  @PropertyExclude
+  private final PropertyDescriptor<String> pinKeyProp = PropertyDescriptor.property("pinKey", "");
 
   /**
    * Describes the target of the navigation item.
@@ -305,6 +305,60 @@ public class AppNavItem extends NavigationContainer<AppNavItem> implements HasSt
    */
   public NavigationTarget getTarget() {
     return get(targetProp);
+  }
+
+  /**
+   * Sets whether the navigation item is pinned.
+   *
+   * <p>
+   * A pinned item is moved into the group at the top of the navigation. Pinning must be enabled on
+   * the {@link AppNav} through {@code getPinning().setEnabled(true)} for this to take effect.
+   * </p>
+   *
+   * @param pin {@code true} to pin the item, {@code false} otherwise
+   * @return the component itself
+   */
+  public AppNavItem setPinned(boolean pin) {
+    set(pinnedProp, pin);
+
+    return this;
+  }
+
+  /**
+   * Returns whether the navigation item is pinned.
+   *
+   * @return {@code true} if the item is pinned, {@code false} otherwise
+   */
+  public boolean isPinned() {
+    return isAttached() ? get(pinnedProp, true, Boolean.class) : get(pinnedProp);
+  }
+
+  /**
+   * Sets the stable key that identifies the item for pinning.
+   *
+   * <p>
+   * The key is used to persist pins and match them across reloads. When not set, the item's path is
+   * used. Set an explicit key when the path can change at runtime.
+   * </p>
+   *
+   * @param pinKey the pin key
+   * @return the component itself
+   */
+  public AppNavItem setPinKey(String pinKey) {
+    set(pinKeyProp, pinKey);
+
+    return this;
+  }
+
+  /**
+   * Gets the stable key that identifies the item for pinning.
+   *
+   * @return the explicit pin key, or the path when none was set
+   */
+  public String getPinKey() {
+    String pinKey = get(pinKeyProp);
+
+    return pinKey == null || pinKey.isEmpty() ? getPath() : pinKey;
   }
 
   /**

--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/NavigationContainer.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/NavigationContainer.java
@@ -3,6 +3,7 @@ package com.webforj.component.layout.appnav;
 import com.webforj.component.ComponentLifecycleObserver;
 import com.webforj.component.element.ElementCompositeContainer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -61,6 +62,15 @@ abstract class NavigationContainer<T extends ElementCompositeContainer>
     items.remove(item);
     item.destroy();
     return getSelf();
+  }
+
+  /**
+   * Returns the direct navigation items of this container.
+   *
+   * @return an unmodifiable list of the direct navigation items
+   */
+  public List<AppNavItem> getItems() {
+    return Collections.unmodifiableList(items);
   }
 
   /**

--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/event/AppNavPinEvent.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/event/AppNavPinEvent.java
@@ -1,0 +1,97 @@
+package com.webforj.component.layout.appnav.event;
+
+import com.webforj.component.element.annotation.EventName;
+import com.webforj.component.element.annotation.EventOptions;
+import com.webforj.component.element.annotation.EventOptions.EventData;
+import com.webforj.component.event.ComponentEvent;
+import com.webforj.component.layout.appnav.AppNav;
+import com.webforj.component.layout.appnav.AppNavItem;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Emitted when an item's pinned state changes.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ *
+ * @see AppNav
+ */
+@EventName(value = "dwc-pin-changed")
+@EventOptions(data = {@EventData(key = "key", exp = "event.detail.key"),
+    @EventData(key = "pinned", exp = "event.detail.pinned"),
+    @EventData(key = "keys", exp = "event.detail.keys")})
+public final class AppNavPinEvent extends ComponentEvent<AppNav> {
+
+  /**
+   * Creates a new {@code AppNavPinEvent} with the given target and detail.
+   *
+   * @param target the target of the event
+   * @param detail the detail of the event
+   */
+  public AppNavPinEvent(AppNav target, Map<String, Object> detail) {
+    super(target, detail);
+  }
+
+  /**
+   * Gets the key of the item whose pinned state changed.
+   *
+   * @return the key
+   */
+  public String getKey() {
+    return (String) getData().get("key");
+  }
+
+  /**
+   * Gets the item whose pinned state changed.
+   *
+   * <p>
+   * Resolves the item from the navigation by matching its {@link AppNavItem#getPinKey() pin key}.
+   * Returns {@code null} when the item is no longer part of the navigation.
+   * </p>
+   *
+   * @return the item whose pinned state changed, or {@code null} when it is no longer part of the
+   *         navigation
+   */
+  public AppNavItem getItem() {
+    return findByPinKey(((AppNav) getComponent()).getItems(), getKey()).orElse(null);
+  }
+
+  /**
+   * Gets whether the item is now pinned.
+   *
+   * @return {@code true} if the item is now pinned, {@code false} otherwise
+   */
+  public boolean isPinned() {
+    return Boolean.TRUE.equals(getData().get("pinned"));
+  }
+
+  /**
+   * Gets the full set of currently pinned keys, in pinned order.
+   *
+   * @return the pinned keys
+   */
+  @SuppressWarnings("unchecked")
+  public List<String> getKeys() {
+    Object keys = getData().get("keys");
+
+    return keys instanceof List ? (List<String>) keys : List.of();
+  }
+
+  private Optional<AppNavItem> findByPinKey(List<AppNavItem> items, String key) {
+    for (AppNavItem item : items) {
+      if (Objects.equals(item.getPinKey(), key)) {
+        return Optional.of(item);
+      }
+
+      Optional<AppNavItem> found = findByPinKey(item.getItems(), key);
+      if (found.isPresent()) {
+        return found;
+      }
+    }
+
+    return Optional.empty();
+  }
+}

--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/event/AppNavSearchEvent.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/event/AppNavSearchEvent.java
@@ -1,0 +1,40 @@
+package com.webforj.component.layout.appnav.event;
+
+import com.webforj.component.element.annotation.EventName;
+import com.webforj.component.element.annotation.EventOptions;
+import com.webforj.component.element.annotation.EventOptions.EventData;
+import com.webforj.component.event.ComponentEvent;
+import com.webforj.component.layout.appnav.AppNav;
+import java.util.Map;
+
+/**
+ * Emitted when a search is performed through the navigation's search field.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ *
+ * @see AppNav
+ */
+@EventName(value = "dwc-searched")
+@EventOptions(data = {@EventData(key = "term", exp = "event.detail")})
+public final class AppNavSearchEvent extends ComponentEvent<AppNav> {
+
+  /**
+   * Creates a new {@code AppNavSearchEvent} with the given target and detail.
+   *
+   * @param target the target of the event
+   * @param detail the detail of the event
+   */
+  public AppNavSearchEvent(AppNav target, Map<String, Object> detail) {
+    super(target, detail);
+  }
+
+  /**
+   * Gets the search term.
+   *
+   * @return the search term
+   */
+  public String getTerm() {
+    return String.valueOf(getData().get("term"));
+  }
+}

--- a/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavItemTest.java
+++ b/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavItemTest.java
@@ -166,6 +166,29 @@ class AppNavItemTest {
       component.setPath(View.class);
       assertEquals("/test", component.getFullPath());
     }
+
+    @Test
+    void shouldSetGetPinned() {
+      assertFalse(component.isPinned());
+
+      component.setPinned(true);
+      assertTrue(component.isPinned());
+    }
+
+    @Test
+    void shouldSetGetPinKey() {
+      component.setPinKey("dashboard");
+      assertEquals("dashboard", component.getPinKey());
+    }
+
+    @Test
+    void shouldFallBackToPathWhenNoPinKey() {
+      component.setPath("/dashboard");
+      assertEquals("/dashboard", component.getPinKey());
+
+      component.setPinKey("explicit");
+      assertEquals("explicit", component.getPinKey());
+    }
   }
 
   @Nested

--- a/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavTest.java
+++ b/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
+import com.webforj.component.icons.IconDefinition;
 import com.webforj.component.layout.appnav.event.AppNavLocationChangedEvent;
+import com.webforj.component.layout.appnav.event.AppNavPinEvent;
+import com.webforj.component.layout.appnav.event.AppNavSearchEvent;
 import com.webforj.dispatcher.EventListener;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +53,119 @@ class AppNavTest {
 
       assertEquals(2, listeners.size());
       assertTrue(listeners.get(1) instanceof EventListener<AppNavLocationChangedEvent>);
+    }
+
+    @Test
+    void shouldAddSearchListener() {
+      component.onSearch(event -> {
+      });
+
+      List<EventListener<AppNavSearchEvent>> listeners =
+          component.getEventListeners(AppNavSearchEvent.class);
+
+      assertEquals(1, listeners.size());
+      assertTrue(listeners.get(0) instanceof EventListener<AppNavSearchEvent>);
+    }
+
+    @Test
+    void shouldAddPinListener() {
+      component.onPin(event -> {
+      });
+
+      List<EventListener<AppNavPinEvent>> listeners =
+          component.getEventListeners(AppNavPinEvent.class);
+
+      assertEquals(1, listeners.size());
+      assertTrue(listeners.get(0) instanceof EventListener<AppNavPinEvent>);
+    }
+  }
+
+  @Nested
+  @DisplayName("Pinning API")
+  class PinningApi {
+
+    @Test
+    void shouldConfigurePinning() {
+      component.getPinning().setEnabled(true).setAutosave(false).setTitle("Pinned");
+
+      assertTrue(component.getPinning().isEnabled());
+      assertEquals(false, component.getPinning().isAutosave());
+      assertEquals("Pinned", component.getPinning().getTitle());
+    }
+
+    @Test
+    void shouldReturnPinnedItemsAcrossTheTree() {
+      AppNavItem home = new AppNavItem("Home", "/home");
+      AppNavItem group = new AppNavItem("Docs");
+      AppNavItem reports = new AppNavItem("Reports", "/docs/reports").setPinned(true);
+      group.addItem(reports);
+      component.addItem(home);
+      component.addItem(group);
+
+      assertEquals(List.of(reports), component.getPinning().getItems());
+
+      home.setPinned(true);
+      assertEquals(List.of(home, reports), component.getPinning().getItems());
+    }
+
+    @Test
+    void shouldConfigurePinIcons() {
+      component.getPinning().setUnpinnedIcon(icon("tabler", "bookmark"))
+          .setPinnedIcon(icon("tabler", "bookmark-filled"));
+
+      assertEquals("tabler:bookmark", component.getPinning().getUnpinnedIcon());
+      assertEquals("tabler:bookmark-filled", component.getPinning().getPinnedIcon());
+    }
+
+    private IconDefinition<Object> icon(String pool, String name) {
+      return new IconDefinition<>() {
+        @Override
+        public Object setName(String value) {
+          return this;
+        }
+
+        @Override
+        public String getName() {
+          return name;
+        }
+
+        @Override
+        public Object setPool(String value) {
+          return this;
+        }
+
+        @Override
+        public String getPool() {
+          return pool;
+        }
+      };
+    }
+  }
+
+  @Nested
+  @DisplayName("Search API")
+  class SearchApi {
+
+    @Test
+    void shouldKeepPlainTextEmptyMessage() {
+      component.getSearch().setEmptyMessage("Nothing found");
+
+      assertEquals("Nothing found", component.getSearch().getEmptyMessage());
+    }
+
+    @Test
+    void shouldSanitizeTagsFromPlainTextEmptyMessage() {
+      component.getSearch().setEmptyMessage("Nothing <b>found</b>");
+
+      assertEquals("Nothing found", component.getSearch().getEmptyMessage());
+    }
+
+    @Test
+    void shouldKeepHtmlWrappedEmptyMessage() {
+      component.getSearch().setEmptyMessage("<html><strong>Nothing</strong></html>");
+
+      assertEquals("<html><strong>Nothing</strong></html>",
+          component.getSearch().getEmptyMessage());
     }
   }
 }

--- a/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/event/AppNavPinEventTest.java
+++ b/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/event/AppNavPinEventTest.java
@@ -1,0 +1,65 @@
+package com.webforj.component.layout.appnav.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.webforj.component.layout.appnav.AppNav;
+import com.webforj.component.layout.appnav.AppNavItem;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AppNavPinEventTest {
+
+  @Test
+  void shouldReturnKeyAndState() {
+    AppNavPinEvent event = new AppNavPinEvent(new AppNav(),
+        Map.of("key", "/orders", "pinned", true, "keys", List.of("/orders")));
+
+    assertEquals("/orders", event.getKey());
+    assertTrue(event.isPinned());
+  }
+
+  @Test
+  void shouldReturnKeys() {
+    AppNavPinEvent event = new AppNavPinEvent(new AppNav(),
+        Map.of("key", "/orders", "pinned", true, "keys", List.of("/orders", "/users")));
+
+    assertEquals(List.of("/orders", "/users"), event.getKeys());
+  }
+
+  @Test
+  void shouldResolveItemFromKeyIncludingNested() {
+    AppNav nav = new AppNav();
+    AppNavItem orders = new AppNavItem("Orders", "/orders");
+    AppNavItem group = new AppNavItem("Group");
+    AppNavItem nested = new AppNavItem("Nested", "/group/nested");
+    group.addItem(nested);
+    nav.addItem(orders);
+    nav.addItem(group);
+
+    AppNavPinEvent event = new AppNavPinEvent(nav,
+        Map.of("key", "/group/nested", "pinned", true, "keys", List.of("/group/nested")));
+
+    assertSame(nested, event.getItem());
+  }
+
+  @Test
+  void shouldReturnNullWhenItemNotFound() {
+    AppNavPinEvent event = new AppNavPinEvent(new AppNav(),
+        Map.of("key", "/missing", "pinned", false, "keys", List.of()));
+
+    assertNull(event.getItem());
+  }
+
+  @Test
+  void shouldReturnNullWhenKeyMissing() {
+    AppNav nav = new AppNav();
+    nav.addItem(new AppNavItem("Orders", "/orders"));
+    AppNavPinEvent event = new AppNavPinEvent(nav, Map.of("pinned", false, "keys", List.of()));
+
+    assertNull(event.getItem());
+  }
+}

--- a/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/event/AppNavSearchEventTest.java
+++ b/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/event/AppNavSearchEventTest.java
@@ -1,0 +1,17 @@
+package com.webforj.component.layout.appnav.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.webforj.component.layout.appnav.AppNav;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AppNavSearchEventTest {
+
+  @Test
+  void shouldReturnTerm() {
+    AppNavSearchEvent event = new AppNavSearchEvent(new AppNav(), Map.of("term", "orders"));
+
+    assertEquals("orders", event.getTerm());
+  }
+}

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNav.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNav.kt
@@ -108,6 +108,44 @@ fun @WebforjDsl AppNavItem.appNavItem(
   return item
 }
 
+/**
+ * Configures the `AppNav`'s embedded search field.
+ * ```
+ * appNav {
+ *   search {
+ *     setFieldVisible(true)
+ *     setPlaceholder("Search")
+ *   }
+ *   appNavItem("Home", "/home")
+ * }
+ * ```
+ *
+ * @param block The configuration steps for the search field.
+ * @return The configured `AppNav.Search`.
+ * @see AppNav.Search
+ */
+fun @WebforjDsl AppNav.search(block: @WebforjDsl AppNav.Search.() -> Unit): AppNav.Search =
+  search.apply(block)
+
+/**
+ * Configures the `AppNav`'s pinning.
+ * ```
+ * appNav {
+ *   pinning {
+ *     setEnabled(true)
+ *     setAutosave(true)
+ *   }
+ *   appNavItem("Home", "/home")
+ * }
+ * ```
+ *
+ * @param block The configuration steps for pinning.
+ * @return The configured `AppNav.Pinning`.
+ * @see AppNav.Pinning
+ */
+fun @WebforjDsl AppNav.pinning(block: @WebforjDsl AppNav.Pinning.() -> Unit): AppNav.Pinning =
+  pinning.apply(block)
+
 private fun createAppNavItem(
   text: String,
   path: String? = null,

--- a/webforj-kotlin/src/test/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNavTest.kt
+++ b/webforj-kotlin/src/test/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNavTest.kt
@@ -139,6 +139,32 @@ class AppNavTest {
   }
 
   @Test
+  fun shouldConfigureSearch() {
+    val appNav = root.appNav {
+      search {
+        isFieldVisible = true
+        placeholder = "Find"
+      }
+    }
+
+    assertTrue(appNav.search.isFieldVisible)
+    assertEquals("Find", appNav.search.placeholder)
+  }
+
+  @Test
+  fun shouldConfigurePinning() {
+    val appNav = root.appNav {
+      pinning {
+        isEnabled = true
+        title = "Pinned Custom Title"
+      }
+    }
+
+    assertTrue(appNav.pinning.isEnabled)
+    assertEquals("Pinned Custom Title", appNav.pinning.title)
+  }
+
+  @Test
   fun shouldCreateAppNavItemWithInitializationBlock() {
     val appNav = root.appNav {
       val item = appNavItem("Custom Item") {


### PR DESCRIPTION
AppNav can now pin frequently used items into a group at the top of the navigation and filter its items through a built in search field. Both are off by default. Pinning moves the real item, so its listeners and slotted content are preserved, and restores it to its exact original position when unpinned, even for items nested in groups. Pins can persist across reloads. The pin event resolves to the item that changed.

## Java

```java
AppNav nav = new AppNav("main-nav");

nav.getSearch()
    .setFieldVisible(true)
    .setPlaceholder("Search");

nav.getPinning()
    .setEnabled(true)
    .setAutosave(true)
    .setUnpinnedIcon(TablerIcon.create("pin"))
    .setPinnedIcon(TablerIcon.create("pinned-off"));

nav.addItem(new AppNavItem("Dashboard", "/dashboard"));
nav.addItem(new AppNavItem("Reports", "/reports").setPinned(true));

nav.onPin(event -> {
  AppNavItem item = event.getItem();
  // react to the pin/unpin, or persist event.getKeys() yourself
});
```

## Kotlin

```kotlin
appNav {
  search {
    isFieldVisible = true
    placeholder = "Search"
  }

  pinning {
    isEnabled = true
    isAutosave = true
    setUnpinnedIcon(TablerIcon.create("pin"))
    setPinnedIcon(TablerIcon.create("pinned-off"))
  }

  appNavItem("Dashboard", "/dashboard")
  appNavItem("Reports", "/reports") { isPinned = true }

  onPin { event -> update(event.item) }
}
```

closes #1290