### PR TITLE
fix: load webforJ dependent packages under Spring DevTools

### DIFF
--- a/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/RestartBannerSuppressor.java
+++ b/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/RestartBannerSuppressor.java
@@ -1,0 +1,64 @@
+package com.webforj.spring.devtools;
+
+import org.springframework.boot.Banner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.SpringApplicationRunListener;
+import org.springframework.boot.bootstrap.ConfigurableBootstrapContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.Ordered;
+
+/**
+ * Prints the application banner once and suppresses it on every Spring DevTools restart.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public final class RestartBannerSuppressor implements SpringApplicationRunListener, Ordered {
+
+  /**
+   * JVM wide marker that the banner has been printed. It is a system property because it must
+   * survive a restart, where a static field would not since it lives on the restart classloader
+   * that DevTools discards.
+   */
+  private static final String SHOWN_PROPERTY = "webforj.devtools.banner-shown";
+
+  private final SpringApplication application;
+
+  /**
+   * Creates the run listener. This constructor is used by Spring Boot.
+   *
+   * @param application the application being started
+   * @param args the application arguments
+   */
+  public RestartBannerSuppressor(SpringApplication application, String[] args) {
+    this.application = application;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int getOrder() {
+    return Ordered.HIGHEST_PRECEDENCE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void starting(ConfigurableBootstrapContext bootstrapContext) {
+    if (System.getProperty(SHOWN_PROPERTY) != null) {
+      application.setBannerMode(Banner.Mode.OFF);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void contextPrepared(ConfigurableApplicationContext context) {
+    // Runs after the banner is printed and only on the restarted run, so the pre relaunch pass on
+    // the base classloader never marks the banner as shown.
+    System.setProperty(SHOWN_PROPERTY, "true");
+  }
+}

--- a/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/RestartClasspathAugmenter.java
+++ b/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/RestartClasspathAugmenter.java
@@ -1,0 +1,255 @@
+package com.webforj.spring.devtools;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.SpringApplicationRunListener;
+import org.springframework.boot.bootstrap.ConfigurableBootstrapContext;
+import org.springframework.boot.devtools.restart.AgentReloader;
+import org.springframework.boot.devtools.restart.DefaultRestartInitializer;
+import org.springframework.boot.devtools.restart.Restarter;
+import org.springframework.core.Ordered;
+
+/**
+ * Seeds dependency JARs that depend on webforJ onto the Spring DevTools restart classloader, so a
+ * dependency that ships webforJ UI is loaded alongside the framework and the application instead of
+ * on the base classloader.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public final class RestartClasspathAugmenter implements SpringApplicationRunListener, Ordered {
+  private static final System.Logger logger =
+      System.getLogger(RestartClasspathAugmenter.class.getName());
+
+  /**
+   * JVM wide marker so the detection runs once, even though the listener is created on every
+   * restart.
+   */
+  private static final String APPLIED_PROPERTY = "webforj.devtools.restart.classpath-augmented";
+  private static final String RESTART_ENABLED_PROPERTY = "spring.devtools.restart.enabled";
+  private static final Pattern WEBFORJ_JAR = Pattern.compile("webforj-[\\w\\d-.]+\\.jar");
+
+  /**
+   * Matches a {@code com.webforj} groupId, the webforJ group or one of its subgroups, inside a
+   * Maven descriptor, without matching an unrelated group such as {@code com.webforjx}.
+   */
+  private static final Pattern WEBFORJ_GROUP_ID =
+      Pattern.compile("<groupId>\\s*com\\.webforj(\\.[\\w.-]+)?\\s*</groupId>");
+
+  private final String[] args;
+
+  /**
+   * Creates the run listener. This constructor is used by Spring Boot.
+   *
+   * @param application the application being started
+   * @param args the application arguments
+   */
+  public RestartClasspathAugmenter(SpringApplication application, String[] args) {
+    this.args = args.clone();
+  }
+
+  RestartClasspathAugmenter() {
+    this.args = new String[0];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int getOrder() {
+    // Run before the event publishing run listener (order 0) that fires the starting event, so this
+    // initializes the Restarter before RestartApplicationListener does.
+    return Ordered.HIGHEST_PRECEDENCE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void starting(ConfigurableBootstrapContext bootstrapContext) {
+    if (isApplied()) {
+      return;
+    }
+
+    markAsApplied();
+
+    // When restart is disabled there is no classloader split, so a webforJ dependency is already on
+    // the same classloader as webforJ and needs nothing.
+    if (!isRestartEnabled()) {
+      return;
+    }
+
+    long startNanos = System.nanoTime();
+    List<URL> additions = findWebforjDependentJars(resolveClasspathEntries());
+    long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
+
+    logger.log(System.Logger.Level.INFO,
+        "Classpath detection found {0} webforJ dependent JAR(s) in {1} ms", additions.size(),
+        elapsedMillis);
+
+    if (additions.isEmpty()) {
+      return;
+    }
+
+    logger.log(System.Logger.Level.INFO,
+        "Seeding {0} webforJ dependent JAR(s) into the restart classloader", additions.size());
+    Restarter.initialize(args, false, new AdditionalUrlsRestartInitializer(additions), true);
+  }
+
+  private boolean isApplied() {
+    return System.getProperty(APPLIED_PROPERTY) != null;
+  }
+
+  private void markAsApplied() {
+    System.setProperty(APPLIED_PROPERTY, "true");
+  }
+
+  private boolean isRestartEnabled() {
+    String property = System.getProperty(RESTART_ENABLED_PROPERTY);
+    if (property != null) {
+      return Boolean.parseBoolean(property);
+    }
+
+    return !AgentReloader.isActive();
+  }
+
+  private Set<File> resolveClasspathEntries() {
+    // URLs are taken from the classloader hierarchy, which covers launchers whose dependencies are
+    // not on {@code java.class.path} such as the Spring Boot JAR launcher, and merged with
+    // {@code java.class.path}, which covers the standard application classloader that does not
+    // expose its URLs.
+
+    Set<File> files = new LinkedHashSet<>();
+
+    ClassLoader loader = Thread.currentThread().getContextClassLoader();
+    if (loader == null) {
+      loader = getClass().getClassLoader();
+    }
+
+    while (loader != null) {
+      if (loader instanceof URLClassLoader urlLoader) {
+        for (URL url : urlLoader.getURLs()) {
+          if ("file".equals(url.getProtocol())) {
+            try {
+              files.add(new File(url.toURI()).getAbsoluteFile());
+            } catch (Exception e) {
+              logger.log(System.Logger.Level.DEBUG, "Could not resolve classpath URL " + url, e);
+            }
+          }
+        }
+      }
+
+      loader = loader.getParent();
+    }
+
+    for (String entry : System.getProperty("java.class.path", "").split(File.pathSeparator)) {
+      if (!entry.isEmpty()) {
+        files.add(new File(entry).getAbsoluteFile());
+      }
+    }
+
+    return files;
+  }
+
+  List<URL> findWebforjDependentJars(Collection<File> entries) {
+    List<URL> result = new ArrayList<>();
+
+    for (File entry : entries) {
+      URL url = resolveWebforjDependentJarUrl(entry);
+      if (url != null) {
+        result.add(url);
+      }
+    }
+
+    return result;
+  }
+
+  private URL resolveWebforjDependentJarUrl(File jar) {
+    String name = jar.getName();
+    if (!name.endsWith(".jar") || WEBFORJ_JAR.matcher(name).matches()) {
+      return null;
+    }
+
+    if (!jar.isFile() || !isWebforjDependent(jar)) {
+      return null;
+    }
+
+    try {
+      return jar.toURI().toURL();
+    } catch (Exception e) {
+      logger.log(System.Logger.Level.DEBUG, "Could not resolve URL for " + jar, e);
+
+      return null;
+    }
+  }
+
+  private boolean isWebforjDependent(File jar) {
+    try (ZipFile zip = new ZipFile(jar)) {
+      Enumeration<? extends ZipEntry> entries = zip.entries();
+
+      while (entries.hasMoreElements()) {
+        ZipEntry zipEntry = entries.nextElement();
+        String name = zipEntry.getName();
+
+        if (name.startsWith("META-INF/maven/") && name.endsWith("/pom.xml")) {
+          try (InputStream in = zip.getInputStream(zipEntry)) {
+            String pom = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+
+            if (WEBFORJ_GROUP_ID.matcher(pom).find()) {
+              return true;
+            }
+          }
+        }
+      }
+    } catch (Exception e) {
+      logger.log(System.Logger.Level.DEBUG, "Could not read descriptor of " + jar, e);
+    }
+
+    return false;
+  }
+
+  /**
+   * A restart initializer that appends additional JAR URLs to the initial restart classloader.
+   *
+   * <p>
+   * It delegates the development context decision to {@link DefaultRestartInitializer}. When the
+   * delegate returns no URLs the application is not in a development context, so no URLs are added
+   * and restart stays disabled.
+   * </p>
+   */
+  private static final class AdditionalUrlsRestartInitializer extends DefaultRestartInitializer {
+
+    private final List<URL> additional;
+
+    AdditionalUrlsRestartInitializer(List<URL> additional) {
+      this.additional = additional;
+    }
+
+    @Override
+    public URL[] getInitialUrls(Thread thread) {
+      URL[] base = super.getInitialUrls(thread);
+      if (base == null) {
+        return null;
+      }
+
+      List<URL> merged = new ArrayList<>(Arrays.asList(base));
+      merged.addAll(additional);
+
+      return merged.toArray(URL[]::new);
+    }
+  }
+}

--- a/webforj-spring/webforj-spring-devtools/src/main/resources/META-INF/spring.factories
+++ b/webforj-spring/webforj-spring-devtools/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,8 @@
 # Environment Post Processors
 org.springframework.boot.EnvironmentPostProcessor=\
 com.webforj.spring.devtools.browser.HeadlessModeConfigurer
+
+# Application Run Listeners
+org.springframework.boot.SpringApplicationRunListener=\
+com.webforj.spring.devtools.RestartClasspathAugmenter,\
+com.webforj.spring.devtools.RestartBannerSuppressor

--- a/webforj-spring/webforj-spring-devtools/src/test/java/com/webforj/spring/devtools/RestartBannerSuppressorTest.java
+++ b/webforj-spring/webforj-spring-devtools/src/test/java/com/webforj/spring/devtools/RestartBannerSuppressorTest.java
@@ -1,0 +1,63 @@
+package com.webforj.spring.devtools;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.Banner;
+import org.springframework.boot.SpringApplication;
+
+class RestartBannerSuppressorTest {
+
+  private static final String SHOWN_PROPERTY = "webforj.devtools.banner-shown";
+
+  @Mock
+  private SpringApplication application;
+
+  private AutoCloseable mocks;
+  private RestartBannerSuppressor suppressor;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    System.clearProperty(SHOWN_PROPERTY);
+    suppressor = new RestartBannerSuppressor(application, new String[0]);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    System.clearProperty(SHOWN_PROPERTY);
+    mocks.close();
+  }
+
+  @Test
+  void shouldPrintBannerOnFirstStart() {
+    suppressor.starting(null);
+
+    verify(application, never()).setBannerMode(Banner.Mode.OFF);
+  }
+
+  @Test
+  void shouldSuppressBannerWhenAlreadyShown() {
+    System.setProperty(SHOWN_PROPERTY, "true");
+
+    suppressor.starting(null);
+
+    verify(application).setBannerMode(Banner.Mode.OFF);
+  }
+
+  @Test
+  void shouldMarkBannerShownOnContextPrepared() {
+    assertNull(System.getProperty(SHOWN_PROPERTY));
+
+    suppressor.contextPrepared(null);
+
+    assertNotNull(System.getProperty(SHOWN_PROPERTY));
+  }
+}

--- a/webforj-spring/webforj-spring-devtools/src/test/java/com/webforj/spring/devtools/RestartClasspathAugmenterTest.java
+++ b/webforj-spring/webforj-spring-devtools/src/test/java/com/webforj/spring/devtools/RestartClasspathAugmenterTest.java
@@ -1,0 +1,103 @@
+package com.webforj.spring.devtools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RestartClasspathAugmenterTest {
+
+  private final RestartClasspathAugmenter augmenter = new RestartClasspathAugmenter();
+
+  @Test
+  void shouldDetectJarThatDeclaresWebforjDependency(@TempDir Path dir) throws Exception {
+    File jar = jarWithPom(dir, "acme-addon-1.0.jar", "com.acme", "acme-addon",
+        "<dependency><groupId>com.webforj</groupId></dependency>");
+
+    List<URL> result = augmenter.findWebforjDependentJars(List.of(jar));
+
+    assertEquals(List.of(jar.toURI().toURL()), result);
+  }
+
+  @Test
+  void shouldIgnoreJarWithoutWebforjDependency(@TempDir Path dir) throws Exception {
+    File jar = jarWithPom(dir, "other-1.0.jar", "com.other", "other",
+        "<dependency><groupId>org.apache.commons</groupId></dependency>");
+
+    assertTrue(augmenter.findWebforjDependentJars(List.of(jar)).isEmpty());
+  }
+
+  @Test
+  void shouldIgnoreJarWithoutMavenDescriptor(@TempDir Path dir) throws Exception {
+    File jar = jarWithEntry(dir, "nodescriptor-1.0.jar", "com/acme/Foo.class", "data");
+
+    assertTrue(augmenter.findWebforjDependentJars(List.of(jar)).isEmpty());
+  }
+
+  @Test
+  void shouldIgnoreWebforjOwnJarsMatchedByName(@TempDir Path dir) throws Exception {
+    File jar = jarWithPom(dir, "webforj-foundation-26.01.jar", "com.webforj", "webforj-foundation",
+        "<dependency><groupId>com.webforj</groupId></dependency>");
+
+    assertTrue(augmenter.findWebforjDependentJars(List.of(jar)).isEmpty());
+  }
+
+  @Test
+  void shouldReturnOnlyDependentJarsFromMixedClasspath(@TempDir Path dir) throws Exception {
+    File dependent = jarWithPom(dir, "addon-1.0.jar", "com.acme", "addon",
+        "<dependency><groupId>com.webforj</groupId></dependency>");
+    File unrelated = jarWithPom(dir, "lib-1.0.jar", "com.lib", "lib",
+        "<dependency><groupId>org.slf4j</groupId></dependency>");
+
+    assertEquals(List.of(dependent.toURI().toURL()),
+        augmenter.findWebforjDependentJars(List.of(dependent, unrelated)));
+  }
+
+  @Test
+  void shouldNotMatchWebforjMentionedOnlyInText(@TempDir Path dir) throws Exception {
+    File jar = jarWithPom(dir, "other-1.0.jar", "com.other", "other",
+        "<!-- com.webforj --><dependency><groupId>org.other</groupId></dependency>");
+
+    assertTrue(augmenter.findWebforjDependentJars(List.of(jar)).isEmpty());
+  }
+
+  @Test
+  void shouldNotMatchSimilarGroupId(@TempDir Path dir) throws Exception {
+    File jar = jarWithPom(dir, "other-1.0.jar", "com.other", "other",
+        "<dependency><groupId>com.webforjx</groupId></dependency>");
+
+    assertTrue(augmenter.findWebforjDependentJars(List.of(jar)).isEmpty());
+  }
+
+  private static File jarWithPom(Path dir, String jarName, String groupId, String artifactId,
+      String dependenciesXml) throws Exception {
+    String pom = "<project><modelVersion>4.0.0</modelVersion><groupId>" + groupId
+        + "</groupId><artifactId>" + artifactId + "</artifactId><dependencies>" + dependenciesXml
+        + "</dependencies></project>";
+    String entry = "META-INF/maven/" + groupId + "/" + artifactId + "/pom.xml";
+
+    return jarWithEntry(dir, jarName, entry, pom);
+  }
+
+  private static File jarWithEntry(Path dir, String jarName, String entryName, String content)
+      throws Exception {
+    File jar = dir.resolve(jarName).toFile();
+
+    try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(jar))) {
+      zip.putNextEntry(new ZipEntry(entryName));
+      zip.write(content.getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+    }
+
+    return jar;
+  }
+}


### PR DESCRIPTION
Under Spring DevTools the project output and the dependency jars are loaded on two different classloaders. webforJ is loaded on the restart classloader, so a third party package that ships webforJ UI components has to load there too, otherwise its components cannot resolve webforJ classes and fail to render under the development server.

In development a package on the classpath that declares a dependency on webforJ is detected and loaded on the restart classloader alongside the framework and the application. This requires no configuration and no change to the package. Adding the package as a dependency is enough for its components, routes, and services to work under the development server.
