### PR TITLE
refactor: show setText content literally and add legacyHtmlInText flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
         <version>3.20.0</version>
       </dependency>
       <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.22.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.10.3</version>

--- a/webforj-components/webforj-alert/src/main/java/com/webforj/component/alert/Alert.java
+++ b/webforj-components/webforj-alert/src/main/java/com/webforj/component/alert/Alert.java
@@ -19,6 +19,7 @@ import com.webforj.concern.HasText;
 import com.webforj.concern.HasVisibility;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
+import com.webforj.utilities.HtmlText;
 
 /**
  * The alert component provides contextual feedback messages for the user.
@@ -199,23 +200,6 @@ public class Alert extends ElementCompositeContainer
    * {@inheritDoc}
    */
   @Override
-  public Alert setText(String text) {
-    setHtml(sanitizeHtml(text));
-    return this;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public String getText() {
-    return sanitizeHtml(getHtml());
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public Alert setVisible(boolean visible) {
     return visible ? open() : close();
   }
@@ -226,6 +210,24 @@ public class Alert extends ElementCompositeContainer
   @Override
   public boolean isVisible() {
     return isOpened();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Alert setText(String text) {
+    setHtml(HtmlText.forHtmlSink(text));
+
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getText() {
+    return HtmlText.toText(getHtml());
   }
 
   /**
@@ -265,10 +267,6 @@ public class Alert extends ElementCompositeContainer
    */
   public ListenerRegistration<AlertCloseEvent> onClose(EventListener<AlertCloseEvent> listener) {
     return addCloseListener(listener);
-  }
-
-  private String sanitizeHtml(String html) {
-    return html.replaceAll("\\<[^>]*>", "");
   }
 
   Element getOriginalElement() {

--- a/webforj-components/webforj-alert/src/test/java/com/webforj/component/alert/AlertTest.java
+++ b/webforj-components/webforj-alert/src/test/java/com/webforj/component/alert/AlertTest.java
@@ -91,6 +91,34 @@ class AlertTest {
   }
 
   @Nested
+  class TextApi {
+
+    @Test
+    void shouldShowTextLiterally() {
+      component.setText("<b>hi</b> world");
+
+      assertEquals("<b>hi</b> world", component.getText());
+      assertEquals("&lt;b&gt;hi&lt;/b&gt; world", component.getHtml());
+    }
+
+    @Test
+    void shouldExtractTextFromHtml() {
+      component.setHtml("<b>hello</b>");
+
+      assertEquals("<b>hello</b>", component.getHtml());
+      assertEquals("hello", component.getText());
+    }
+
+    @Test
+    void shouldRenderHtmlWhenTextIsWrappedWithHtmlTag() {
+      component.setText("<html><b>hi</b></html>");
+
+      assertEquals("<html><b>hi</b></html>", component.getHtml());
+      assertEquals("hi", component.getText());
+    }
+  }
+
+  @Nested
   @DisplayName("Slots API")
   class SlotsApi {
 

--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNav.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNav.java
@@ -15,6 +15,7 @@ import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.router.Router;
 import com.webforj.router.history.Location;
+import com.webforj.utilities.HtmlText;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -308,8 +309,7 @@ public class AppNav extends NavigationContainer<AppNav>
      * @return the search configuration itself
      */
     public Search setEmptyMessage(String emptyMessage) {
-      String value = emptyMessage == null ? "" : emptyMessage;
-      set(emptyMessageProp, isWrappedWithHtmlTag(value) ? value : sanitizeHtml(value));
+      set(emptyMessageProp, HtmlText.forHtmlSink(emptyMessage));
 
       return this;
     }
@@ -321,14 +321,6 @@ public class AppNav extends NavigationContainer<AppNav>
      */
     public String getEmptyMessage() {
       return get(emptyMessageProp);
-    }
-
-    private boolean isWrappedWithHtmlTag(String text) {
-      return (text == null ? "" : text).trim().startsWith("<html>");
-    }
-
-    private String sanitizeHtml(String html) {
-      return (html == null ? "" : html).replaceAll("\\<[^>]*>", "");
     }
   }
 

--- a/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavTest.java
+++ b/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavTest.java
@@ -154,10 +154,10 @@ class AppNavTest {
     }
 
     @Test
-    void shouldSanitizeTagsFromPlainTextEmptyMessage() {
+    void shouldEscapeTagsInPlainTextEmptyMessage() {
       component.getSearch().setEmptyMessage("Nothing <b>found</b>");
 
-      assertEquals("Nothing found", component.getSearch().getEmptyMessage());
+      assertEquals("Nothing &lt;b&gt;found&lt;/b&gt;", component.getSearch().getEmptyMessage());
     }
 
     @Test

--- a/webforj-components/webforj-infinite-scroll/src/main/java/com/webforj/component/infinitescroll/InfiniteScroll.java
+++ b/webforj-components/webforj-infinite-scroll/src/main/java/com/webforj/component/infinitescroll/InfiniteScroll.java
@@ -17,6 +17,7 @@ import com.webforj.concern.HasText;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.utilities.Assets;
+import com.webforj.utilities.HtmlText;
 
 /**
  * A component to load content continuously as the user scrolls down, eliminating the need for
@@ -170,7 +171,8 @@ public class InfiniteScroll extends ElementCompositeContainer
    */
   @Override
   public InfiniteScroll setText(String text) {
-    setHtml(sanitizeHtml(text));
+    setHtml(HtmlText.forHtmlSink(text));
+
     return this;
   }
 
@@ -179,7 +181,7 @@ public class InfiniteScroll extends ElementCompositeContainer
    */
   @Override
   public String getText() {
-    return sanitizeHtml(getHtml());
+    return HtmlText.toText(getHtml());
   }
 
   /**
@@ -219,10 +221,6 @@ public class InfiniteScroll extends ElementCompositeContainer
   public ListenerRegistration<InfiniteScrollEvent> onScroll(
       EventListener<InfiniteScrollEvent> listener) {
     return addScrollListener(listener);
-  }
-
-  private String sanitizeHtml(String html) {
-    return html.replaceAll("\\<[^>]*>", "");
   }
 
   Element getOriginalElement() {

--- a/webforj-components/webforj-loading/src/main/java/com/webforj/component/loading/Loading.java
+++ b/webforj-components/webforj-loading/src/main/java/com/webforj/component/loading/Loading.java
@@ -13,6 +13,7 @@ import com.webforj.concern.HasClassName;
 import com.webforj.concern.HasHtml;
 import com.webforj.concern.HasStyle;
 import com.webforj.concern.HasText;
+import com.webforj.utilities.HtmlText;
 
 /**
  * An overlay that can be used to indicate activity while blocking user interaction. The loading
@@ -98,7 +99,8 @@ public class Loading extends ElementCompositeContainer
    */
   @Override
   public Loading setText(String text) {
-    setHtml(sanitizeHtml(text));
+    setHtml(HtmlText.forHtmlSink(text));
+
     return this;
   }
 
@@ -107,7 +109,7 @@ public class Loading extends ElementCompositeContainer
    */
   @Override
   public String getText() {
-    return sanitizeHtml(getHtml());
+    return HtmlText.toText(getHtml());
   }
 
   /**
@@ -167,10 +169,6 @@ public class Loading extends ElementCompositeContainer
   @Override
   public DwcSpinner<LoadingSpinner> getSpinner() {
     return new LoadingSpinner();
-  }
-
-  private String sanitizeHtml(String html) {
-    return html.replaceAll("\\<[^>]*>", "");
   }
 
   /**

--- a/webforj-components/webforj-loading/src/test/java/com/webforj/component/loading/LoadingTest.java
+++ b/webforj-components/webforj-loading/src/test/java/com/webforj/component/loading/LoadingTest.java
@@ -52,9 +52,9 @@ class LoadingTest {
     }
 
     @Test
-    void shouldRemoveHtmlWhenSetGetTextUsed() {
+    void shouldShowTextLiterallyAndExtractTextFromHtml() {
       component.setText("<div>Hello, World!</div>");
-      assertEquals("Hello, World!", component.getText());
+      assertEquals("<div>Hello, World!</div>", component.getText());
 
       component.setHtml("<div>Hello, World!</div>");
       assertEquals("<div>Hello, World!</div>", component.getHtml());

--- a/webforj-components/webforj-toast/src/main/java/com/webforj/component/toast/Toast.java
+++ b/webforj-components/webforj-toast/src/main/java/com/webforj/component/toast/Toast.java
@@ -16,6 +16,7 @@ import com.webforj.concern.HasHtml;
 import com.webforj.concern.HasStyle;
 import com.webforj.concern.HasText;
 import com.webforj.exceptions.WebforjAppInitializeException;
+import com.webforj.utilities.HtmlText;
 import java.util.List;
 
 /**
@@ -218,7 +219,8 @@ public class Toast extends ElementCompositeContainer
    */
   @Override
   public Toast setText(String text) {
-    setHtml(sanitizeHtml(text));
+    setHtml(HtmlText.forHtmlSink(text));
+
     return this;
   }
 
@@ -227,7 +229,7 @@ public class Toast extends ElementCompositeContainer
    */
   @Override
   public String getText() {
-    return sanitizeHtml(getHtml());
+    return HtmlText.toText(getHtml());
   }
 
   /**
@@ -459,9 +461,5 @@ public class Toast extends ElementCompositeContainer
       });
     }
     return frame;
-  }
-
-  private String sanitizeHtml(String html) {
-    return html.replaceAll("\\<[^>]*>", "");
   }
 }

--- a/webforj-components/webforj-toast/src/test/java/com/webforj/component/toast/ToastTest.java
+++ b/webforj-components/webforj-toast/src/test/java/com/webforj/component/toast/ToastTest.java
@@ -157,9 +157,9 @@ class ToastTest {
     }
 
     @Test
-    void shouldRemoveHtmlWhenSetGetTextUsed() {
+    void shouldShowTextLiterallyAndExtractTextFromHtml() {
       component.setText("<div>Hello, World!</div>");
-      assertEquals("Hello, World!", component.getText());
+      assertEquals("<div>Hello, World!</div>", component.getText());
 
       component.setHtml("<div>Hello, World!</div>");
       assertEquals("<div>Hello, World!</div>", component.getHtml());

--- a/webforj-foundation/pom.xml
+++ b/webforj-foundation/pom.xml
@@ -71,6 +71,10 @@
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/webforj-foundation/src/main/java/com/webforj/component/DwcComponent.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/DwcComponent.java
@@ -31,6 +31,7 @@ import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.exceptions.WebforjRestrictedAccessException;
 import com.webforj.exceptions.WebforjRuntimeException;
+import com.webforj.utilities.HtmlText;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.lang.reflect.Type;
@@ -415,11 +416,15 @@ public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
   @Override
   public T setText(String text) {
     String value = text == null ? "" : text;
-    if (!isWrappedWithHtmlTag(value)) {
-      value = sanitizeHtml(value);
-      doSetText(value);
+
+    if (HtmlText.isWrappedWithHtmlTag(value)) {
+      if (HtmlText.isLegacyHtmlInTextEnabled()) {
+        setHtml(HtmlText.forHtmlSink(value));
+      } else {
+        doSetText(removeHtmlTag(value));
+      }
     } else {
-      setHtml(value);
+      doSetText(value);
     }
 
     return getSelf();
@@ -430,7 +435,9 @@ public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
    */
   @Override
   public String getText() {
-    return sanitizeHtml(doGetText());
+    String value = doGetText();
+
+    return HtmlText.isWrappedWithHtmlTag(value) ? HtmlText.toText(value) : value;
   }
 
   /**
@@ -1360,17 +1367,9 @@ public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
     return self;
   }
 
-  private String sanitizeHtml(String html) {
-    return (html == null ? "" : html).replaceAll("\\<[^>]*>", "");
-  }
-
-  private boolean isWrappedWithHtmlTag(String text) {
-    return (text == null ? "" : text).trim().startsWith("<html>");
-  }
-
   private String addHtmlTag(String text) {
     String value = text == null ? "" : text;
-    if (!isWrappedWithHtmlTag(value)) {
+    if (!HtmlText.isWrappedWithHtmlTag(value)) {
       value = "<html>" + value + "</html>";
     }
 

--- a/webforj-foundation/src/main/java/com/webforj/utilities/HtmlText.java
+++ b/webforj-foundation/src/main/java/com/webforj/utilities/HtmlText.java
@@ -1,0 +1,172 @@
+package com.webforj.utilities;
+
+import com.typesafe.config.Config;
+import com.webforj.Environment;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.TextNode;
+
+/**
+ * Converts between a component's plain text and the HTML content that backs it.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public final class HtmlText {
+  static final String LEGACY_HTML_IN_TEXT = "webforj.legacyHtmlInText";
+  private static final String HTML_MARKER = "<html>";
+  private static final Logger logger = System.getLogger(HtmlText.class.getName());
+  private static final Set<String> warnedCallers = ConcurrentHashMap.newKeySet();
+
+  private HtmlText() {}
+
+  /**
+   * Checks whether the given value opts in to HTML rendering by being wrapped in an {@code <html>}
+   * tag.
+   *
+   * @param text the value to check
+   * @return {@code true} when the trimmed value starts with {@code <html>}
+   */
+  public static boolean isWrappedWithHtmlTag(String text) {
+    return (text == null ? "" : text).trim().startsWith(HTML_MARKER);
+  }
+
+  /**
+   * Converts plain text into the value to store on a sink that renders through {@code innerHTML},
+   * so the text is shown literally.
+   *
+   * <p>
+   * The reserved HTML characters are encoded, so a value such as {@code "<b>hi</b>"} becomes
+   * {@code "&lt;b&gt;hi&lt;/b&gt;"} and is shown as those characters rather than run as markup. A
+   * value wrapped in {@code <html>} is the deprecated opt-in described on
+   * {@link #LEGACY_HTML_IN_TEXT}. A {@code null} value is treated as an empty string.
+   * </p>
+   *
+   * @param text the plain text to convert
+   * @return the backing content, never {@code null}
+   */
+  public static String forHtmlSink(String text) {
+    if (text == null || text.isEmpty()) {
+      return "";
+    }
+
+    if (!isWrappedWithHtmlTag(text)) {
+      return escape(text);
+    }
+
+    if (isLegacyHtmlInTextEnabled()) {
+      warnLegacyHtmlInText(text);
+
+      return text;
+    }
+
+    return escape(stripMarker(text));
+  }
+
+  /**
+   * Removes the {@code <html>} opt-in marker, returning the content it wrapped.
+   *
+   * @param text the value wrapped in {@code <html>}
+   * @return the content inside the marker
+   */
+  public static String stripMarker(String text) {
+    String value = (text == null ? "" : text).trim();
+
+    if (value.startsWith(HTML_MARKER)) {
+      value = value.substring(HTML_MARKER.length());
+    }
+
+    if (value.endsWith("</html>")) {
+      value = value.substring(0, value.length() - "</html>".length());
+    }
+
+    return value;
+  }
+
+  /**
+   * Returns the visible text of the given backing content with tags removed and entities decoded.
+   *
+   * <p>
+   * A value produced by {@link #forHtmlSink(String)} is decoded back to its original text. Real
+   * markup yields its text content. A {@code null} value is treated as an empty string.
+   * </p>
+   *
+   * @param html the backing content to read
+   * @return the visible text, never {@code null}
+   */
+  public static String toText(String html) {
+    if (html == null || html.isEmpty()) {
+      return "";
+    }
+
+    return Jsoup.parse(html).text();
+  }
+
+  private static String escape(String text) {
+    return new TextNode(text).outerHtml();
+  }
+
+  /**
+   * Indicates whether the deprecated {@code <html>} opt-in described on
+   * {@link #LEGACY_HTML_IN_TEXT} is enabled.
+   *
+   * @return {@code true} when {@code <html>}-wrapped text is rendered as markup
+   */
+  public static boolean isLegacyHtmlInTextEnabled() {
+    Environment environment = Environment.getCurrent();
+    if (environment == null) {
+      return true;
+    }
+
+    Config config = environment.getConfig();
+    if (config != null && config.hasPath(LEGACY_HTML_IN_TEXT)
+        && !config.getIsNull(LEGACY_HTML_IN_TEXT)) {
+      return config.getBoolean(LEGACY_HTML_IN_TEXT);
+    }
+
+    return true;
+  }
+
+  private static void warnLegacyHtmlInText(String text) {
+    String origin = findOrigin();
+    if (!warnedCallers.add(origin)) {
+      return;
+    }
+
+    logger.log(Level.WARNING,
+        "Passing <html>-wrapped content to setText is deprecated and will be removed in webforJ 27."
+            + " Use setHtml for intentional HTML, or set webforj.legacyHtmlInText=false to treat it"
+            + " as plain text. Triggered by " + origin + " with value: \"" + snippet(text) + "\".");
+  }
+
+  private static String findOrigin() {
+    StackTraceElement component = null;
+    for (StackTraceElement frame : Thread.currentThread().getStackTrace()) {
+      String className = frame.getClassName();
+      if (className.equals(HtmlText.class.getName()) || className.startsWith("java.")
+          || className.startsWith("jdk.")) {
+        continue;
+      }
+
+      if (className.startsWith("com.webforj.")) {
+        component = frame;
+        continue;
+      }
+
+      String origin = component == null ? "" : component.getClassName() + " at ";
+
+      return origin + frame;
+    }
+
+    return "an unknown location";
+  }
+
+  private static String snippet(String text) {
+    String value = text.strip();
+
+    return value.length() <= 60 ? value : value.substring(0, 57) + "...";
+  }
+}

--- a/webforj-foundation/src/main/resources/webforj-default.conf
+++ b/webforj-foundation/src/main/resources/webforj-default.conf
@@ -15,6 +15,13 @@ webforj.entry = null
 # is disabled by default.
 webforj.debug = null
 
+# Controls whether a value wrapped in <html> passed to a text setter such as
+# setText is rendered as HTML. While enabled the wrapped content is sanitized to
+# remove scripts, event handlers and unsafe URLs before rendering, and the usage
+# is reported as deprecated. Set to false to treat such values as plain text. This
+# legacy behavior defaults to true and will be removed in webforJ 27.
+webforj.legacyHtmlInText = true
+
 # When specified, the base path determines where DWC components are loaded from.
 # By default, components are loaded from the server hosting the application.
 # However, setting a custom base path allows components to be loaded from an

--- a/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
@@ -383,6 +383,31 @@ class DwcComponentTest {
     }
 
     @Test
+    void shouldPassMarkupRawSoControlRendersItLiterally() throws BBjException {
+      String markup = "<b>hi</b> world";
+      doReturn(markup).when(control).getText();
+
+      component.setText(markup);
+      assertEquals(markup, component.getText());
+
+      verify(control, times(1)).setText(markup);
+    }
+
+    @Test
+    void shouldRouteHtmlWrappedTextToHtmlSink() throws BBjException {
+      component.setText("<html><b>hi</b></html>");
+
+      verify(control, times(1)).setText("<html><b>hi</b></html>");
+    }
+
+    @Test
+    void shouldPassHtmlWrappedTextThroughRawToHtmlSink() throws BBjException {
+      component.setText("<html><b>hi</b><script>alert(1)</script></html>");
+
+      verify(control, times(1)).setText("<html><b>hi</b><script>alert(1)</script></html>");
+    }
+
+    @Test
     @DisplayName("When value is null then empty string is returned")
     void whenValueIsNullThenEmptyStringIsReturned() throws IllegalAccessException {
       ReflectionUtils.nullifyControl(component);

--- a/webforj-foundation/src/test/java/com/webforj/utilities/HtmlTextTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/utilities/HtmlTextTest.java
@@ -1,0 +1,115 @@
+package com.webforj.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.typesafe.config.Config;
+import com.webforj.Environment;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+class HtmlTextTest {
+
+  @Nested
+  class IsWrappedWithHtmlTag {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"<html>hi</html>", "  <html>hi</html>", "<html><b>hi</b></html>"})
+    void shouldBeTrueWhenWrapped(String input) {
+      assertEquals(true, HtmlText.isWrappedWithHtmlTag(input));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"hi", "<b>hi</b>", "text <html>"})
+    void shouldBeFalseWhenNotWrapped(String input) {
+      assertEquals(false, HtmlText.isWrappedWithHtmlTag(input));
+    }
+  }
+
+  @Nested
+  class ForHtmlSink {
+
+    @Test
+    void shouldEncodeReservedCharacters() {
+      assertEquals("&lt;b&gt;hi&lt;/b&gt; world", HtmlText.forHtmlSink("<b>hi</b> world"));
+      assertEquals("Tom &amp; Jerry", HtmlText.forHtmlSink("Tom & Jerry"));
+      assertEquals("5 &lt; 3 and 9 &gt; 2", HtmlText.forHtmlSink("5 < 3 and 9 > 2"));
+    }
+
+    @Test
+    void shouldNeutralizeScriptPayloadInPlainText() {
+      assertEquals("&lt;script&gt;alert(1)&lt;/script&gt;",
+          HtmlText.forHtmlSink("<script>alert(1)</script>"));
+    }
+
+    @Test
+    void shouldPassHtmlWrappedThroughRaw() {
+      assertEquals("<html><b>hi</b></html>", HtmlText.forHtmlSink("<html><b>hi</b></html>"));
+      assertEquals("<html><b>hi</b><script>alert(1)</script></html>",
+          HtmlText.forHtmlSink("<html><b>hi</b><script>alert(1)</script></html>"));
+      assertEquals("<html><img src=\"x\" onerror=\"alert(1)\"></html>",
+          HtmlText.forHtmlSink("<html><img src=\"x\" onerror=\"alert(1)\"></html>"));
+    }
+
+    @Test
+    void shouldStripMarkerAndEscapeInsideWhenLegacyDisabled() {
+      withLegacyHtmlInText(false, () -> assertEquals("&lt;b&gt;hi&lt;/b&gt;",
+          HtmlText.forHtmlSink("<html><b>hi</b></html>")));
+    }
+
+    @Test
+    void shouldLeavePlainTextUntouched() {
+      assertEquals("Click Me", HtmlText.forHtmlSink("Click Me"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldReturnEmptyForNullOrEmpty(String input) {
+      assertEquals("", HtmlText.forHtmlSink(input));
+    }
+  }
+
+  @Nested
+  class ToText {
+
+    @Test
+    void shouldReturnVisibleTextOfMarkup() {
+      assertEquals("hello", HtmlText.toText("<b>hello</b>"));
+      assertEquals("Nothing", HtmlText.toText("<html><strong>Nothing</strong></html>"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldReturnEmptyForNullOrEmpty(String input) {
+      assertEquals("", HtmlText.toText(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Click Me", "Tom & Jerry", "5 < 3", "<b>hi</b> world",
+        "<script>alert(1)</script>"})
+    void shouldRoundTripThroughForHtmlSink(String value) {
+      assertEquals(value, HtmlText.toText(HtmlText.forHtmlSink(value)));
+    }
+  }
+
+  private static void withLegacyHtmlInText(boolean enabled, Runnable assertion) {
+    try (MockedStatic<Environment> mocked = mockStatic(Environment.class)) {
+      Environment environment = mock(Environment.class);
+      Config config = mock(Config.class);
+      mocked.when(Environment::getCurrent).thenReturn(environment);
+      when(environment.getConfig()).thenReturn(config);
+      when(config.hasPath(HtmlText.LEGACY_HTML_IN_TEXT)).thenReturn(true);
+      when(config.getIsNull(HtmlText.LEGACY_HTML_IN_TEXT)).thenReturn(false);
+      when(config.getBoolean(HtmlText.LEGACY_HTML_IN_TEXT)).thenReturn(enabled);
+
+      assertion.run();
+    }
+  }
+}

--- a/webforj-rewrite/src/main/java/com/webforj/rewrite/v26/MigrateHtmlInSetText.java
+++ b/webforj-rewrite/src/main/java/com/webforj/rewrite/v26/MigrateHtmlInSetText.java
@@ -1,0 +1,90 @@
+package com.webforj.rewrite.v26;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.ChangeMethodName;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * Migrates {@code setText} calls whose argument is a string literal wrapped in {@code <html>} to
+ * {@code setHtml}.
+ *
+ * <p>
+ * Passing {@code <html>} content to a text setter is a deprecated opt-in to HTML rendering that
+ * will be removed in webforJ 27. A string literal is hardcoded, trusted content, so such a call is
+ * rewritten to {@code setHtml} when the receiver supports it. When the receiver has no
+ * {@code setHtml}, or when the argument is not a literal, the call is flagged for manual handling
+ * instead.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public class MigrateHtmlInSetText extends Recipe {
+
+  private static final String SET_TEXT_PATTERN = "com.webforj..* setText(java.lang.String)";
+  private static final MethodMatcher SET_TEXT = new MethodMatcher(SET_TEXT_PATTERN, true);
+  private static final String HAS_HTML = "com.webforj.concern.HasHtml";
+
+  @Override
+  public String getDisplayName() {
+    return "Migrate <html> content from setText to setHtml";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Rewrites setText calls whose argument is a string literal starting with <html> to "
+        + "setHtml when the receiver supports it, since the legacy HTML in setText behavior is "
+        + "deprecated and will be removed in webforJ 27. Calls that cannot be rewritten safely are "
+        + "flagged for manual handling.";
+  }
+
+  @Override
+  public TreeVisitor<?, ExecutionContext> getVisitor() {
+    return new JavaIsoVisitor<ExecutionContext>() {
+
+      @Override
+      public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+          ExecutionContext ctx) {
+        J.MethodInvocation invocation = super.visitMethodInvocation(method, ctx);
+        if (!SET_TEXT.matches(invocation) || invocation.getArguments().size() != 1) {
+          return invocation;
+        }
+
+        Expression argument = invocation.getArguments().get(0);
+        if (!(argument instanceof J.Literal literal) || !(literal.getValue() instanceof String text)
+            || !text.trim().startsWith("<html>")) {
+          return invocation;
+        }
+
+        if (!receiverHasSetHtml(invocation)) {
+          return SearchResult.found(invocation,
+              "webforJ 26: setText with <html> is deprecated and this type has no setHtml, handle "
+                  + "manually. Removed in webforJ 27.");
+        }
+
+        return (J.MethodInvocation) new ChangeMethodName(SET_TEXT_PATTERN, "setHtml", true, null)
+            .getVisitor().visitNonNull(invocation, ctx, getCursor().getParentOrThrow());
+      }
+
+      private boolean receiverHasSetHtml(J.MethodInvocation invocation) {
+        Expression select = invocation.getSelect();
+        JavaType type = null;
+        if (select != null) {
+          type = select.getType();
+        } else if (invocation.getMethodType() != null) {
+          type = invocation.getMethodType().getDeclaringType();
+        }
+
+        return TypeUtils.isAssignableTo(HAS_HTML, type);
+      }
+    };
+  }
+}

--- a/webforj-rewrite/src/main/resources/META-INF/rewrite/webforj-26.yml
+++ b/webforj-rewrite/src/main/resources/META-INF/rewrite/webforj-26.yml
@@ -224,3 +224,26 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: com.webforj
       artifactId: webforj
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.webforj.rewrite.v26.UpgradeWebforj_26_01
+displayName: Upgrade to webforJ 26.01
+description: Upgrades webforJ projects to version 26.01.
+tags:
+  - webforj
+recipeList:
+  - com.webforj.rewrite.v26.UpgradeWebforj
+  - com.webforj.rewrite.v26.MigrateHtmlInSetText
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.webforj.rewrite.v26.UpgradeWebforjSpring_26_01
+displayName: Upgrade to webforJ Spring 26.01
+description: Upgrades webforJ Spring Boot projects to version 26.01.
+tags:
+  - webforj
+  - spring
+recipeList:
+  - com.webforj.rewrite.v26.UpgradeWebforjSpring
+  - com.webforj.rewrite.v26.MigrateHtmlInSetText

--- a/webforj-rewrite/src/test/java/com/webforj/rewrite/v26/MigrateHtmlInSetTextTest.java
+++ b/webforj-rewrite/src/test/java/com/webforj/rewrite/v26/MigrateHtmlInSetTextTest.java
@@ -1,0 +1,88 @@
+package com.webforj.rewrite.v26;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+@SuppressWarnings("java:S2699")
+class MigrateHtmlInSetTextTest implements RewriteTest {
+
+  @Override
+  public void defaults(RecipeSpec spec) {
+    spec.recipe(new MigrateHtmlInSetText());
+  }
+
+  @Test
+  void shouldMigrateHtmlWrappedSetTextToSetHtml() {
+    rewriteRun(java("""
+        import com.webforj.component.button.Button;
+
+        class MyView {
+          void render() {
+            Button button = new Button();
+            button.setText("<html><b>hi</b></html>");
+          }
+        }
+        """, """
+        import com.webforj.component.button.Button;
+
+        class MyView {
+          void render() {
+            Button button = new Button();
+            button.setHtml("<html><b>hi</b></html>");
+          }
+        }
+        """));
+  }
+
+  @Test
+  void shouldFlagHtmlWrappedSetTextWhenReceiverHasNoSetHtml() {
+    rewriteRun(java("""
+        import com.webforj.BusyIndicator;
+
+        class MyView {
+          void render(BusyIndicator indicator) {
+            indicator.setText("<html><b>hi</b></html>");
+          }
+        }
+        """,
+        """
+            import com.webforj.BusyIndicator;
+
+            class MyView {
+              void render(BusyIndicator indicator) {
+                /*~~(webforJ 26: setText with <html> is deprecated and this type has no setHtml, handle manually. Removed in webforJ 27.)~~>*/indicator.setText("<html><b>hi</b></html>");
+              }
+            }
+            """));
+  }
+
+  @Test
+  void shouldIgnorePlainTextSetText() {
+    rewriteRun(java("""
+        import com.webforj.component.button.Button;
+
+        class MyView {
+          void render() {
+            Button button = new Button();
+            button.setText("Click Me");
+          }
+        }
+        """));
+  }
+
+  @Test
+  void shouldIgnoreNonLiteralSetText() {
+    rewriteRun(java("""
+        import com.webforj.component.button.Button;
+
+        class MyView {
+          void render(Button button, String message) {
+            button.setText(message);
+          }
+        }
+        """));
+  }
+}

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringConfigurationProperties.java
@@ -49,6 +49,18 @@ public class SpringConfigurationProperties {
   private Boolean debug;
 
   /**
+   * Legacy HTML in text setters configuration.
+   *
+   * <p>
+   * Controls whether a value wrapped in {@code <html>} passed to a text setter such as setText is
+   * rendered as HTML. While enabled the wrapped content is sanitized before rendering and the usage
+   * is reported as deprecated. Set to false to treat such values as plain text. Defaults to true
+   * and will be removed in webforJ 27.
+   * </p>
+   */
+  private Boolean legacyHtmlInText;
+
+  /**
    * Base path for loading DWC components.
    *
    * <p>
@@ -289,6 +301,26 @@ public class SpringConfigurationProperties {
    */
   public void setDebug(Boolean debug) {
     this.debug = debug;
+  }
+
+  /**
+   * Gets whether legacy HTML in text setters is enabled.
+   *
+   * @return true if a value wrapped in {@code <html>} passed to a text setter is rendered as HTML,
+   *         false if treated as plain text, null if not set
+   */
+  public Boolean getLegacyHtmlInText() {
+    return legacyHtmlInText;
+  }
+
+  /**
+   * Sets whether legacy HTML in text setters is enabled.
+   *
+   * @param legacyHtmlInText true to render a value wrapped in {@code <html>} passed to a text
+   *        setter as HTML, false to treat it as plain text
+   */
+  public void setLegacyHtmlInText(Boolean legacyHtmlInText) {
+    this.legacyHtmlInText = legacyHtmlInText;
   }
 
   /**

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
@@ -36,7 +36,8 @@ class WebforjConfigBuilder {
         .add("webforj.components", properties::getComponents)
         .add("webforj.locale", properties::getLocale)
         .add("webforj.quiet", properties::getQuiet, false)
-        .add("webforj.reloadOnServerError", properties::getReloadOnServerError, false);
+        .add("webforj.reloadOnServerError", properties::getReloadOnServerError, false)
+        .add("webforj.legacyHtmlInText", properties::getLegacyHtmlInText, true);
 
     // Client configuration
     builder.add("webforj.clientHeartbeatRate", properties::getClientHeartbeatRate)


### PR DESCRIPTION
setText shows its value as literal characters, so markup written as text appears as those characters rather than running. Intentional HTML goes through setHtml.

```java
component.setText("<b>hi</b>"); // shows the characters <b>hi</b>
component.setHtml("<b>hi</b>"); // renders bold
```

> [!WARNING]
> Passing `<html>` wrapped content to setText is deprecated and will be removed in webforJ 27. The `webforj.legacyHtmlInText` setting controls it (default `true`). While the setting is `true`, an `<html>` wrapped value renders its content as HTML, while it is `false`, the same value is shown literally.
>
> A deprecation warning is logged the first time an `<html>` wrapped value reaches setText, naming the component and the call site so the call can be moved to setHtml. Setting `webforj.legacyHtmlInText` to `false` adopts the webforJ 27 default ahead of time. Spring applications set the same value through `webforj.legacy-html-in-text`.

An OpenRewrite recipe automates the literal cases. `com.webforj.rewrite.v26.UpgradeWebforj_26_01` (or `UpgradeWebforjSpring_26_01` for Spring applications) rewrites a `setText` call whose argument is an `<html>` wrapped string literal to `setHtml` when the receiver supports `setHtml`, and adds a comment to an `<html>` literal call on a type that has no `setHtml`. A `setText` call whose argument is a variable, or a value passed through a component constructor or built at runtime, is left unchanged; the logged warning covers those cases.


