### PR TITLE
fix: read webforj.security config from Spring application.properties

### DIFF
--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringAutoConfiguration.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringAutoConfiguration.java
@@ -10,6 +10,7 @@ import com.webforj.spring.scope.SpringScopeCleanup;
 import com.webforj.spring.scope.processor.EnvironmentScopeProcessor;
 import com.webforj.spring.scope.processor.RouteScopeProcessor;
 import com.webforj.spring.scope.processor.SessionScopeProcessor;
+import com.webforj.spring.security.SpringSecurityConfigurationProperties;
 import java.lang.System.Logger;
 import java.util.List;
 import java.util.Locale;
@@ -35,7 +36,8 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnClass(ServletContextInitializer.class)
 @AutoConfigureBefore(WebMvcAutoConfiguration.class)
-@EnableConfigurationProperties(SpringConfigurationProperties.class)
+@EnableConfigurationProperties({SpringConfigurationProperties.class,
+    SpringSecurityConfigurationProperties.class})
 @Import(WebforjServletConfiguration.class)
 public class SpringAutoConfiguration {
   private static Logger logger = System.getLogger(SpringAutoConfiguration.class.getName());
@@ -44,11 +46,13 @@ public class SpringAutoConfiguration {
    * Creates the webforJ configuration from Spring properties.
    *
    * @param properties the Spring configuration properties
+   * @param securityProperties the Spring security configuration properties
    * @return the webforJ configuration
    */
   @Bean(name = "webforjConfig")
-  Config webforjConfig(SpringConfigurationProperties properties) {
-    Config config = WebforjConfigBuilder.buildConfig(properties);
+  Config webforjConfig(SpringConfigurationProperties properties,
+      SpringSecurityConfigurationProperties securityProperties) {
+    Config config = WebforjConfigBuilder.buildConfig(properties, securityProperties);
     logger.log(Logger.Level.DEBUG, "Built webforJ configuration from Spring properties");
     return config;
   }

--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/WebforjConfigBuilder.java
@@ -2,6 +2,7 @@ package com.webforj.spring;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.webforj.spring.security.SpringSecurityConfigurationProperties;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +29,19 @@ class WebforjConfigBuilder {
    * @return a Config object with all configured values
    */
   public static Config buildConfig(SpringConfigurationProperties properties) {
+    return buildConfig(properties, new SpringSecurityConfigurationProperties());
+  }
+
+  /**
+   * Builds a Typesafe Config object from Spring configuration properties.
+   *
+   * @param properties the Spring configuration properties
+   * @param security the Spring security configuration properties
+   *
+   * @return a Config object with all configured values
+   */
+  public static Config buildConfig(SpringConfigurationProperties properties,
+      SpringSecurityConfigurationProperties security) {
     ConfigMapBuilder builder = new ConfigMapBuilder();
 
     // Basic configurations
@@ -42,6 +56,10 @@ class WebforjConfigBuilder {
     // Client configuration
     builder.add("webforj.clientHeartbeatRate", properties::getClientHeartbeatRate)
         .add("webforj.sessionTimeout", properties::getSessionTimeout, 60);
+
+    // Security configuration
+    builder.add("webforj.security.maxContentLength", security::getMaxContentLength, 0)
+        .add("webforj.security.maxInitPerMinute", security::getMaxInitPerMinute, 0);
 
     // Assets configurations
     builder.add("webforj.assetsDir", properties::getAssetsDir)

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringAutoConfigurationTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/SpringAutoConfigurationTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
 import com.webforj.servlet.WebforjServlet;
+import com.webforj.spring.security.SpringSecurityConfigurationProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -109,7 +110,8 @@ class SpringAutoConfigurationTest {
 
     @Test
     void shouldCreateWebforjConfigFromProperties() {
-      Config configResult = autoConfiguration.webforjConfig(properties);
+      Config configResult =
+          autoConfiguration.webforjConfig(properties, new SpringSecurityConfigurationProperties());
 
       assertNotNull(configResult);
     }

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/WebforjConfigBuilderTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.typesafe.config.Config;
+import com.webforj.spring.security.SpringSecurityConfigurationProperties;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -550,6 +551,30 @@ class WebforjConfigBuilderTest {
       assertFalse(config.hasPath("webforj.components"));
       assertFalse(config.hasPath("webforj.locale"));
       assertFalse(config.hasPath("webforj.servlets"));
+    }
+  }
+
+  @Nested
+  class SecurityConfiguration {
+
+    @Test
+    void shouldDefaultLimitsToZero() {
+      Config config = WebforjConfigBuilder.buildConfig(properties);
+
+      assertEquals(0, config.getInt("webforj.security.maxContentLength"));
+      assertEquals(0, config.getInt("webforj.security.maxInitPerMinute"));
+    }
+
+    @Test
+    void shouldMergeSecurityLimits() {
+      SpringSecurityConfigurationProperties security = new SpringSecurityConfigurationProperties();
+      security.setMaxContentLength(1048576);
+      security.setMaxInitPerMinute(100);
+
+      Config config = WebforjConfigBuilder.buildConfig(properties, security);
+
+      assertEquals(1048576, config.getInt("webforj.security.maxContentLength"));
+      assertEquals(100, config.getInt("webforj.security.maxInitPerMinute"));
     }
   }
 }


### PR DESCRIPTION
`webforj.security.maxContentLength` and `webforj.security.maxInitPerMinute` can be set in a Spring Boot `application.properties` file, with or without Spring Security on the classpath. 

```properties
webforj.security.maxContentLength=1000000
webforj.security.maxInitPerMinute=100
```

Both default to `0`, which leaves the limit off.
