### PR TITLE
fix: wait for the app to be ready before reloading after a change

### DIFF
--- a/webforj-devtools/src/main/resources/META-INF/resources/webforj/devtools-reload-client.js
+++ b/webforj-devtools/src/main/resources/META-INF/resources/webforj/devtools-reload-client.js
@@ -4,7 +4,7 @@
  * @author Hyyan Abo Fakher
  * @since 25.02
  */
-(function() {
+(function () {
   'use strict';
 
   if (!window.webforjDevToolsConfig || !window.webforjDevToolsConfig.enabled) {
@@ -14,14 +14,21 @@
   const config = window.webforjDevToolsConfig;
   const wsUrl = config.websocketUrl;
   const heartbeatInterval = config.heartbeatInterval || 30000;
-  const reconnectDelay = config.reconnectDelay || 1000;
-  const maxReconnectAttempts = config.maxReconnectAttempts || 10;
+  // A dev redeploy is back in a few seconds on localhost, so poll tight at a fixed interval
+  // instead of backing off, and give up by elapsed time.
+  const reconnectInterval = config.reconnectInterval || 400;
+  const reconnectMaxWaitMs = config.reconnectMaxWaitMs || 120000;
+  const probeInterval = config.probeInterval || 400;
+  const probeMaxWaitMs = config.probeMaxWaitMs || 120000;
 
   let ws;
   let heartbeatTimer;
   let reconnectTimer;
   let reconnectAttempts = 0;
   let hasDisconnected = false;
+  let pendingReload = false;
+  let disconnectedAt = 0;
+  let probeStartedAt = 0;
 
   function log(message) {
     console.log(
@@ -36,31 +43,34 @@
       return;
     }
 
-    log('🚀 Initiating DevTools connection to: ' + wsUrl);
+    if (!hasDisconnected) {
+      log('🚀 Initiating DevTools connection to: ' + wsUrl);
+    }
 
     try {
       ws = new WebSocket(wsUrl);
 
-      ws.onopen = function() {
+      ws.onopen = function () {
         log('✅ DevTools connection established! Ready to rock 🎸');
 
-        // If we're reconnecting after a disconnection, reload the page
+        // The reload socket coming back does not mean the application can serve yet. The socket
+        // binds early in a redeploy, before the app is initialized and the bundle is in place, so
+        // wait until the page actually answers with its bootstrap before reloading.
         if (hasDisconnected && reconnectAttempts > 0) {
-          log('🔄 Server is back online! Refreshing your experience...');
+          log('🔌 Server socket is back. Waiting until the app can serve before reloading...');
           showProgressBar();
-          setTimeout(function() {
-            window.location.reload();
-          }, 100);
+          reloadWhenReady();
           return;
         }
 
         reconnectAttempts = 0;
+        disconnectedAt = 0;
         startHeartbeat();
         // Send initial ping to confirm connection
         ws.send('ping');
       };
 
-      ws.onmessage = function(event) {
+      ws.onmessage = function (event) {
         try {
           const message = JSON.parse(event.data);
 
@@ -100,14 +110,18 @@
         }
       };
 
-      ws.onclose = function(event) {
-        log('📡 Connection closed (code: ' + event.code + ') - standing by...');
+      ws.onclose = function (event) {
+        if (!hasDisconnected) {
+          log('📡 Connection closed (code: ' + event.code
+            + ') - standing by until the app is back...');
+          showProgressBar();
+        }
         hasDisconnected = true;
         stopHeartbeat();
         scheduleReconnect();
       };
 
-      ws.onerror = function(error) {
+      ws.onerror = function () {
         log('⚠️ WebSocket hiccup detected: ' + error);
         console.error('[webforJ DevTools] WebSocket error details:', error);
         stopHeartbeat();
@@ -120,8 +134,13 @@
   }
 
   function scheduleReconnect() {
-    if (reconnectAttempts >= maxReconnectAttempts) {
-      log('😔 Max reconnection attempts reached - taking a break');
+    if (disconnectedAt === 0) {
+      disconnectedAt = Date.now();
+    }
+
+    if (Date.now() - disconnectedAt >= reconnectMaxWaitMs) {
+      log('😔 The app has not come back in ' + Math.round(reconnectMaxWaitMs / 1000)
+        + 's, giving up. Reload the page to reconnect.');
       return;
     }
 
@@ -129,20 +148,61 @@
       clearTimeout(reconnectTimer);
     }
 
+    // Fixed tight interval so a quick redeploy is caught within a fraction of a second instead of
+    // an exponential backoff that overshoots the few seconds a redeploy actually takes.
     reconnectAttempts++;
-    const delay = Math.min(reconnectDelay * Math.pow(2, reconnectAttempts - 1), 30000);
-
-    log('🕓 Reconnection attempt #' + reconnectAttempts + ' scheduled in ' + delay + 'ms');
-
-    reconnectTimer = setTimeout(function() {
+    reconnectTimer = setTimeout(function () {
       connect();
-    }, delay);
+    }, reconnectInterval);
+  }
+
+  // Reloads only once the application can actually serve.
+  // A 200 alone can be a holding or error page during a redeploy, so the page
+  // body must carry the client bootstrap reference before the reload is allowed through.
+  function reloadWhenReady() {
+    if (pendingReload) {
+      return;
+    }
+
+    pendingReload = true;
+    probeStartedAt = Date.now();
+    probeApp();
+  }
+
+  function probeApp() {
+    fetch(window.location.href, { method: 'GET', cache: 'no-store' })
+      .then(function (response) {
+        return response.ok ? response.text() : Promise.reject(new Error('not ready'));
+      })
+      .then(function (body) {
+        if (body.indexOf('webapp/webapp.min.js') !== -1
+          || body.indexOf('webapp/webapp.js') !== -1) {
+          log('✅ App is ready, reloading.');
+          window.location.reload();
+        } else {
+          scheduleProbe();
+        }
+      })
+      .catch(function () {
+        scheduleProbe();
+      });
+  }
+
+  function scheduleProbe() {
+    if (Date.now() - probeStartedAt >= probeMaxWaitMs) {
+      log('⏳ App did not become ready in time, reloading anyway.');
+      window.location.reload();
+      return;
+    }
+
+    // Fixed tight interval, matched to the reconnect cadence.
+    setTimeout(probeApp, probeInterval);
   }
 
   function startHeartbeat() {
     stopHeartbeat();
 
-    heartbeatTimer = setInterval(function() {
+    heartbeatTimer = setInterval(function () {
       if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send('ping');
       }
@@ -234,7 +294,7 @@
     // The path comes from the server as the resource path (e.g., "css/style.css")
     const resourcePath = normalizePath(message.path);
 
-    switch(message.resourceType) {
+    switch (message.resourceType) {
       case 'css':
         updateStylesheets(resourcePath, message.timestamp);
         break;
@@ -263,7 +323,7 @@
     const links = document.querySelectorAll('link[rel="stylesheet"]');
     let updatedCount = 0;
 
-    links.forEach(function(link) {
+    links.forEach(function (link) {
       // Check if href contains the resource path
       const href = normalizePath(link.href);
       const originalHref = normalizePath(link.getAttribute('href'));
@@ -290,7 +350,7 @@
     const images = document.querySelectorAll('img');
     let updatedCount = 0;
 
-    images.forEach(function(img) {
+    images.forEach(function (img) {
       const src = normalizePath(img.src);
       const originalSrc = normalizePath(img.getAttribute('src'));
 
@@ -312,7 +372,7 @@
   connect();
 
   // Clean up on page unload
-  window.addEventListener('beforeunload', function() {
+  window.addEventListener('beforeunload', function () {
     stopHeartbeat();
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);

--- a/webforj-devtools/src/main/resources/META-INF/resources/webforj/devtools-reload-client.js
+++ b/webforj-devtools/src/main/resources/META-INF/resources/webforj/devtools-reload-client.js
@@ -20,6 +20,7 @@
   const reconnectMaxWaitMs = config.reconnectMaxWaitMs || 120000;
   const probeInterval = config.probeInterval || 400;
   const probeMaxWaitMs = config.probeMaxWaitMs || 120000;
+  const serverProgressbarId = 'dwc-page-progressbar';
 
   let ws;
   let heartbeatTimer;
@@ -29,6 +30,7 @@
   let pendingReload = false;
   let disconnectedAt = 0;
   let probeStartedAt = 0;
+  let progressbarObserver;
 
   function log(message) {
     console.log(
@@ -285,6 +287,30 @@
     document.getElementById('webforj-devtools-veil')?.remove();
   }
 
+  // The dwc client raises its own page progress bar the moment it loses the server, ahead of
+  // the reload socket noticing. Treat that as another disconnect signal: take the bar down and
+  // bring up the reload pill so a redeploy always shows the same single indicator.
+  function takeOverServerProgressbar() {
+    const bar = document.getElementById(serverProgressbarId);
+    if (!bar) {
+      return;
+    }
+
+    bar.remove();
+    showStatus('Server restarting…');
+  }
+
+  function watchForServerProgressbar() {
+    if (progressbarObserver || typeof MutationObserver === 'undefined' || !document.body) {
+      return;
+    }
+
+    progressbarObserver = new MutationObserver(takeOverServerProgressbar);
+    progressbarObserver.observe(document.body, { childList: true });
+    // It may already be on the page if it appeared before this started watching.
+    takeOverServerProgressbar();
+  }
+
   function handleResourceUpdate(message) {
     // The path comes from the server as the resource path (e.g., "css/style.css")
     const resourcePath = normalizePath(message.path);
@@ -365,12 +391,17 @@
 
   // Start connection
   connect();
+  watchForServerProgressbar();
 
   // Clean up on page unload
   window.addEventListener('beforeunload', function () {
     stopHeartbeat();
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
+    }
+
+    if (progressbarObserver) {
+      progressbarObserver.disconnect();
     }
 
     if (ws) {

--- a/webforj-devtools/src/main/resources/META-INF/resources/webforj/devtools-reload-client.js
+++ b/webforj-devtools/src/main/resources/META-INF/resources/webforj/devtools-reload-client.js
@@ -58,7 +58,7 @@
         // wait until the page actually answers with its bootstrap before reloading.
         if (hasDisconnected && reconnectAttempts > 0) {
           log('🔌 Server socket is back. Waiting until the app can serve before reloading...');
-          showProgressBar();
+          showStatus('Waiting for the app…');
           reloadWhenReady();
           return;
         }
@@ -77,7 +77,7 @@
           switch (message.type) {
             case 'reload':
               log('🎯 Hot reload triggered! Refreshing in 3... 2... 1...');
-              showProgressBar();
+              showStatus('Reloading…');
               window.location.reload();
               break;
 
@@ -114,7 +114,7 @@
         if (!hasDisconnected) {
           log('📡 Connection closed (code: ' + event.code
             + ') - standing by until the app is back...');
-          showProgressBar();
+          showStatus('Server restarting…');
         }
         hasDisconnected = true;
         stopHeartbeat();
@@ -122,8 +122,6 @@
       };
 
       ws.onerror = function () {
-        log('⚠️ WebSocket hiccup detected: ' + error);
-        console.error('[webforJ DevTools] WebSocket error details:', error);
         stopHeartbeat();
       };
 
@@ -141,6 +139,7 @@
     if (Date.now() - disconnectedAt >= reconnectMaxWaitMs) {
       log('😔 The app has not come back in ' + Math.round(reconnectMaxWaitMs / 1000)
         + 's, giving up. Reload the page to reconnect.');
+      hideStatus();
       return;
     }
 
@@ -178,6 +177,7 @@
         if (body.indexOf('webapp/webapp.min.js') !== -1
           || body.indexOf('webapp/webapp.js') !== -1) {
           log('✅ App is ready, reloading.');
+          showStatus('Reloading…');
           window.location.reload();
         } else {
           scheduleProbe();
@@ -226,68 +226,63 @@
     return path ? path.split('\\').join('/') : '';
   }
 
-  function showProgressBar() {
-    // Remove any existing progress bar
-    const existing = document.getElementById('webforj-devtools-progressbar');
-    if (existing) {
-      existing.remove();
+  function showStatus(text) {
+    const host = document.getElementById('webforj-devtools-status') || buildStatus();
+    const label = host.querySelector('[data-webforj-status]');
+    if (label) {
+      label.textContent = text;
+    }
+  }
+
+  function buildStatus() {
+    if (!document.getElementById('webforj-devtools-status-style')) {
+      const style = document.createElement('style');
+      style.id = 'webforj-devtools-status-style';
+      style.textContent = [
+        '@keyframes webforjDevToolsSpin{to{transform:rotate(360deg)}}',
+        '@keyframes webforjDevToolsIn{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:none}}',
+        '#webforj-devtools-veil{position:fixed;inset:0;z-index:2147483646;cursor:progress;'
+          + 'background:var(--dwc-overlay-background,rgba(17,20,30,0.16))}',
+        '#webforj-devtools-status{position:fixed;bottom:18px;right:18px;z-index:2147483647;'
+          + 'display:flex;align-items:center;gap:9px;padding:9px 16px;'
+          + 'border-radius:var(--dwc-border-radius-pill,999px);background:var(--dwc-surface-3,#fff);'
+          + 'color:var(--dwc-color-default-text,#222);'
+          + 'font:500 13px/1 var(--dwc-font-family,system-ui,sans-serif);'
+          + 'box-shadow:var(--dwc-shadow-l,0 8px 24px rgba(0,0,0,0.2));'
+          + 'animation:webforjDevToolsIn 0.22s ease both}',
+        '#webforj-devtools-status .webforj-devtools-spin{width:14px;height:14px;border-radius:50%;'
+          + 'border:2px solid rgba(128,128,128,0.3);'
+          + 'border-top-color:var(--dwc-color-primary,#6c7bff);'
+          + 'animation:webforjDevToolsSpin 0.7s linear infinite}'
+      ].join('');
+      document.head.appendChild(style);
     }
 
-    // Remove any existing style
-    const existingStyle = document.getElementById('webforj-devtools-progress-style');
-    if (existingStyle) {
-      existingStyle.remove();
+    if (!document.getElementById('webforj-devtools-veil')) {
+      const veil = document.createElement('div');
+      veil.id = 'webforj-devtools-veil';
+      document.body.appendChild(veil);
     }
 
-    // Create progress bar container
-    const progressBar = document.createElement('div');
-    progressBar.id = 'webforj-devtools-progressbar';
+    const host = document.createElement('div');
+    host.id = 'webforj-devtools-status';
 
-    // Create the pulse bar
-    const pulseBar = document.createElement('div');
+    const spinner = document.createElement('span');
+    spinner.className = 'webforj-devtools-spin';
 
-    // Apply styles
-    Object.assign(progressBar.style, {
-      width: '100%',
-      position: 'fixed',
-      top: '0',
-      left: '0',
-      zIndex: '10000',
-      height: '3px',
-      backgroundColor: 'var(--dwc-color-primary, #4c47ff)',
-      overflow: 'hidden'
-    });
+    const label = document.createElement('span');
+    label.setAttribute('data-webforj-status', '');
 
-    Object.assign(pulseBar.style, {
-      width: '100%',
-      height: '100%',
-      backgroundColor: 'rgba(255, 255, 255, 0.7)',
-      animation: 'webforjDevToolsPulse 1.5s infinite'
-    });
+    host.appendChild(spinner);
+    host.appendChild(label);
+    document.body.appendChild(host);
 
-    // Add animation keyframes
-    const style = document.createElement('style');
-    style.id = 'webforj-devtools-progress-style';
-    style.textContent = `
-      @keyframes webforjDevToolsPulse {
-        0% {
-          transform: translateX(-100%);
-          opacity: 0;
-        }
-        50% {
-          opacity: 1;
-        }
-        100% {
-          transform: translateX(100%);
-          opacity: 0;
-        }
-      }
-    `;
-    document.head.appendChild(style);
+    return host;
+  }
 
-    // Assemble and add to page
-    progressBar.appendChild(pulseBar);
-    document.body.appendChild(progressBar);
+  function hideStatus() {
+    document.getElementById('webforj-devtools-status')?.remove();
+    document.getElementById('webforj-devtools-veil')?.remove();
   }
 
   function handleResourceUpdate(message) {
@@ -304,13 +299,13 @@
       case 'js':
         // For JavaScript changes, trigger full reload
         log('⚡ JavaScript updated: ' + resourcePath + ' - full refresh incoming!');
-        showProgressBar();
+        showStatus('Reloading…');
         window.location.reload();
         break;
       case 'other':
         // For other file types, trigger full reload
         log('📝 File modified: ' + resourcePath + ' - refreshing to apply changes!');
-        showProgressBar();
+        showStatus('Reloading…');
         window.location.reload();
         break;
       default:
@@ -377,6 +372,7 @@
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
     }
+
     if (ws) {
       ws.close();
     }


### PR DESCRIPTION
After a server change the browser holds until the application can serve again, then reloads. A reachable reload port alone no longer triggers a refresh, so the page no longer reloads into a half started server and lands on an error or holding page.

While the application is restarting a status indicator appears in the corner and the page is held until the reload completes.
