### PR TITLE
fix: keep the development watch and live reload current across restarts

### DIFF
--- a/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/BundleContext.java
+++ b/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/BundleContext.java
@@ -42,6 +42,7 @@ public final class BundleContext {
   private final Map<String, BundleEntryDeclaration> entries = new LinkedHashMap<>();
   private final Map<String, Set<String>> bindings = new LinkedHashMap<>();
   private final Map<String, BunPlugin> plugins = new LinkedHashMap<>();
+  private final Set<Path> watchPaths = new LinkedHashSet<>();
 
   BundleContext() {}
 
@@ -222,6 +223,25 @@ public final class BundleContext {
 
   private void bind(String key, String source) {
     bindings.computeIfAbsent(key, name -> new LinkedHashSet<>()).add(source);
+  }
+
+  /**
+   * Adds a directory the development watch rebuilds on when its contents change.
+   *
+   * <p>
+   * An extension that builds from sources outside the frontend root, such as a stylesheet generated
+   * from the classes a project uses, registers those sources here so editing them regenerates the
+   * bundle during a watch.
+   * </p>
+   *
+   * @param path the directory to watch
+   */
+  public void addWatchPath(Path path) {
+    watchPaths.add(path);
+  }
+
+  Set<Path> getWatchPaths() {
+    return watchPaths;
   }
 
   List<BundlePackageDeclaration> getPackages() {

--- a/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/BundleEntrySet.java
+++ b/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/BundleEntrySet.java
@@ -1,0 +1,58 @@
+package com.webforj.bundle.bun;
+
+import com.webforj.bundle.bun.discovery.BundlePackageDeclaration;
+import com.webforj.bundle.bun.discovery.ClasspathPackageScanner;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The set of inputs a bundle is built from, captured so two scans can be compared by value.
+ *
+ * <p>
+ * A development restart can change which entries the build covers. Comparing the entries, the debug
+ * only entries, the declared npm packages and the class to entry bindings of a fresh scan against
+ * the set the running watcher was built from tells the watch whether the restart changed anything.
+ * </p>
+ *
+ * @param entries the entry sources to build
+ * @param debugEntries the entry sources built only for the development bundle
+ * @param packages the declared npm packages as {@code name@version} coordinates, suffixed with
+ *        {@code :dev} for a development only package
+ * @param bindings the routed class to entry key bindings
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+// @formatter:off
+record BundleEntrySet(Set<String> entries, Set<String> debugEntries, Set<String> packages,
+    Map<String, Set<String>> bindings) {
+
+  /**
+   * Captures the entry set of a scan.
+   *
+   * @param scan the scan to capture
+   * @return the entry set
+   */
+  static BundleEntrySet from(ClasspathPackageScanner.Result scan) {
+    Set<String> packages = new HashSet<>();
+    for (BundlePackageDeclaration declaration : scan.getPackages()) {
+      packages.add(declaration.getName() + "@" + declaration.getVersion()
+          + (declaration.isDev() ? ":dev" : ""));
+    }
+
+    return new BundleEntrySet(new HashSet<>(scan.getSources()),
+        new HashSet<>(scan.getDebugSources()), packages, new HashMap<>(scan.getBindings()));
+  }
+
+  /**
+   * Indicates whether there is nothing to build, no entry source and no debug only entry source.
+   *
+   * @return {@code true} when there are no entries to build
+   */
+  boolean isEmpty() {
+    return entries.isEmpty() && debugEntries.isEmpty();
+  }
+}
+// @formatter:on

--- a/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/BundlerExecution.java
+++ b/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/BundlerExecution.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -136,11 +137,11 @@ public final class BundlerExecution {
    *
    * @param request the parameters for this run
    *
-   * @return the running Bun watcher process, or {@code null} when there was nothing to watch
+   * @return the running watch, or {@code null} when there was nothing to watch
    * @throws IOException on any IO failure
    * @throws InterruptedException if the initial build is interrupted
    */
-  public Process watch(Request request) throws IOException, InterruptedException {
+  public WatchSession watch(Request request) throws IOException, InterruptedException {
     return watch(request, null, null);
   }
 
@@ -152,11 +153,11 @@ public final class BundlerExecution {
    * @param rebuildListener notified with the changed served paths after each rebuild, never empty,
    *        may be null
    *
-   * @return the running Bun watcher process, or {@code null} when there was nothing to watch
+   * @return the running watch, or {@code null} when there was nothing to watch
    * @throws IOException on any IO failure
    * @throws InterruptedException if the initial build is interrupted
    */
-  public Process watch(Request request, Consumer<List<String>> rebuildListener)
+  public WatchSession watch(Request request, Consumer<List<String>> rebuildListener)
       throws IOException, InterruptedException {
     return watch(request, rebuildListener, null);
   }
@@ -171,62 +172,63 @@ public final class BundlerExecution {
    * @param logger where the watch output is reported, a watch passes one that forwards to the
    *        running application, may be null
    *
-   * @return the running Bun watcher process, or {@code null} when there was nothing to watch
+   * @return the running watch, or {@code null} when there was nothing to watch
    * @throws IOException on any IO failure
    * @throws InterruptedException if the initial build is interrupted
    */
-  public Process watch(Request request, Consumer<List<String>> rebuildListener, BundleLogger logger)
-      throws IOException, InterruptedException {
+  public WatchSession watch(Request request, Consumer<List<String>> rebuildListener,
+      BundleLogger logger) throws IOException, InterruptedException {
     // During a watch every bundler line is forwarded to the running application, so nothing is
     // written to the build console while the application is up.
     useLogger(logger);
     CompileContext compileContext = createCompileContext(request, false);
     Path servedDir = getServedOutputDir(request);
     Path stagingDir = request.getWorkDir().resolve(WATCH_STAGING_DIR);
-    Prepared prepared = compile(compileContext, stagingDir);
+
+    Prepared prepared = buildWatch(compileContext, servedDir, stagingDir);
     if (prepared == null) {
       return null;
     }
 
-    // The driver rebuilds the whole graph and reemits every output on each change, so it writes to
-    // a private staging directory. Only the files whose content actually changed are copied into
-    // the directory the server serves. An edit that affects only a stylesheet therefore leaves the
-    // scripts untouched, and the dev tools see a stylesheet change rather than a full page reload.
-    Files.createDirectories(servedDir);
-    syncChangedFiles(stagingDir, servedDir);
+    // A development restart can change the set of entries the Bun watcher builds, so the session
+    // rescans on every restart and rebuilds only when the set actually changed. Each rebuild builds
+    // a fresh context so a source extension introduced at watch time, such as the first scss file,
+    // is picked up by the rescan that the fresh context runs.
+    Process watcher =
+        startWatcher(compileContext, servedDir, stagingDir, prepared, rebuildListener, false);
 
-    // The watch runs in the Maven process, so the index is written to the project output once,
-    // where the application reads it from the classpath. It is written under the static folder,
-    // which the development servers exclude from their reload scan, so the application never
-    // redeploys when it appears. Development output names are stable, so a content edit never
-    // changes the index and the watcher leaves it untouched on every later rebuild.
-    writeIndex(request, prepared, true);
-    notifyDidBundle(compileContext, servedDir, false);
+    AtomicReference<Prepared> current = new AtomicReference<>(prepared);
 
-    List<String> watchArgs = new ArrayList<>(prepared.getRunArgs());
-    watchArgs.add("--watch");
-    log.info("starting bun watch, edit sources to rebuild");
+    WatchSession.WatchHost host = new WatchSession.WatchHost() {
+      @Override
+      public BundleEntrySet currentEntrySet() {
+        return scanEntrySet(request);
+      }
 
-    AtomicBoolean baselineEstablished = new AtomicBoolean(false);
-
-    return bun.start(request.getBundleSourceRoot(), watchArgs, line -> {
-      log.info("{}", line);
-
-      if (isRebuildComplete(line)) {
-        List<String> changed = syncQuietly(stagingDir, servedDir);
-        notifyDidBundle(compileContext, servedDir, true);
-        // The watcher emits its own build when it starts. That first build is the baseline: it
-        // realigns the served directory with the watch output and never reloads the browser. Every
-        // later rebuild is driven by a developer edit and reaches the reload listener.
-        if (baselineEstablished.compareAndSet(false, true)) {
-          return;
-        }
-
-        if (rebuildListener != null && !changed.isEmpty()) {
-          rebuildListener.accept(changed);
+      @Override
+      public void syncOutput() throws IOException {
+        Prepared prepared = current.get();
+        if (prepared == null) {
+          clearOutput(request, servedDir);
+        } else {
+          BundlerExecution.this.syncOutput(request, servedDir, stagingDir, prepared);
         }
       }
-    });
+
+      @Override
+      public Process restartWatcher() throws IOException, InterruptedException {
+        CompileContext context = createCompileContext(request, false);
+        Prepared rebuilt = buildWatch(context, servedDir, stagingDir);
+        current.set(rebuilt);
+        if (rebuilt == null) {
+          return null;
+        }
+
+        return startWatcher(context, servedDir, stagingDir, rebuilt, rebuildListener, true);
+      }
+    };
+
+    return new WatchSession(watcher, host, log);
   }
 
   /**
@@ -277,6 +279,11 @@ public final class BundlerExecution {
     return bun.execute(sourceRoot, args, line -> log.info("{}", line));
   }
 
+  private void useLogger(BundleLogger logger) {
+    this.log = logger != null ? logger : BundleLogger.system();
+    bun.setLogger(this.log);
+  }
+
   private CompileContext createCompileContext(Request request, boolean production) {
     List<BundleExtension> extensions = loadExtensions(request);
     Set<String> sourceExtensions = scanSourceExtensions(request.getBundleSourceRoot());
@@ -311,49 +318,43 @@ public final class BundlerExecution {
     return extensions;
   }
 
-  private Path getServedOutputDir(Request request) {
-    return request.getClassesOutputDir().resolve(OUTPUT_RESOURCE_PREFIX);
+  private static Set<String> scanSourceExtensions(Path sourceRoot) {
+    if (sourceRoot == null || !Files.isDirectory(sourceRoot)) {
+      return Set.of();
+    }
+
+    Set<String> extensions = new LinkedHashSet<>();
+    try (Stream<Path> walk = Files.walk(sourceRoot)) {
+      for (Path path : (Iterable<Path>) walk::iterator) {
+        if (!Files.isRegularFile(path) || isInsideNodeModules(sourceRoot, path)) {
+          continue;
+        }
+
+        String name = path.getFileName().toString();
+        int dot = name.lastIndexOf('.');
+        if (dot > 0 && dot < name.length() - 1) {
+          extensions.add(name.substring(dot + 1).toLowerCase(Locale.ROOT));
+        }
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    return extensions;
   }
 
-  private void notifyDidBundle(CompileContext compileContext, Path outputDir, boolean rebuild) {
-    BundleContext context = createContext(compileContext, outputDir, rebuild);
-    for (BundleExtension extension : compileContext.getExtensions()) {
-      if (!isExtensionActive(extension, context,
-          compileContext.getRequest().getExtensionOverrides())) {
-        continue;
-      }
-
-      try {
-        extension.onDidBundle(context);
-      } catch (RuntimeException e) {
-        log.warn("extension {} failed: {}", extension.getId(), e.getMessage());
+  private static boolean isInsideNodeModules(Path root, Path path) {
+    for (Path segment : root.relativize(path)) {
+      if (segment.toString().equals("node_modules")) {
+        return true;
       }
     }
+
+    return false;
   }
 
-  private boolean isExtensionActive(BundleExtension extension, BundleContext context,
-      Map<String, Boolean> overrides) {
-    Boolean override = overrides.get(extension.getId());
-
-    return override != null ? override : extension.isEnabledByDefault(context);
-  }
-
-  private BundleContext createContext(CompileContext compileContext, Path outputDir,
-      boolean rebuild) {
-    Request request = compileContext.getRequest();
-    Path sourceRoot = request.getBundleSourceRoot();
-    BundleContext context = new BundleContext();
-    context.setClasspath(getUris(request.getClasspathRoots()));
-    context.setFrontendPath(sourceRoot);
-    context.setSourcePaths(request.getSourceScanRoots());
-    context.setGeneratedPath(sourceRoot.resolve(NPM_ENTRY_DIR));
-    context.setOutputPath(outputDir);
-    context.setSourceExtensions(compileContext.getSourceExtensions());
-    context.setProduction(compileContext.isProduction());
-    context.setRebuild(rebuild);
-    context.setLog(log);
-
-    return context;
+  private static Path getServedOutputDir(Request request) {
+    return request.getClassesOutputDir().resolve(OUTPUT_RESOURCE_PREFIX);
   }
 
   private Prepared compile(CompileContext compileContext, Path outputDir)
@@ -389,7 +390,7 @@ public final class BundlerExecution {
             generatedDir, sourceRoot));
 
     BundleContext context = createContext(compileContext, outputDir, false);
-    runExtensions(compileContext.getExtensions(), context, request.getExtensionOverrides());
+    notifyWillBundle(compileContext.getExtensions(), context, request.getExtensionOverrides());
 
     entries.addAll(context.getEntries());
 
@@ -435,11 +436,24 @@ public final class BundlerExecution {
 
     Path metafile = workDir.resolve(META_FILE);
     BundleDriverWriter.Config config = createDriverConfig(request, driverEntries, outputDir,
-        metafile, plugins, compileContext.isProduction(), !eager);
+        metafile, plugins, compileContext.isProduction(), !eager, context.getWatchPaths());
     List<String> runArgs = writeDriverFiles(workDir, plugins, config);
 
     return new Prepared().setMetafile(metafile).setRunArgs(runArgs).setBindings(bindings)
         .setDebugSources(debugSources).setEager(eager);
+  }
+
+  private static Set<URI> getUris(List<File> roots) {
+    Set<URI> uris = new LinkedHashSet<>();
+    for (File root : roots) {
+      if (root == null || !root.exists()) {
+        continue;
+      }
+
+      uris.add(root.toURI());
+    }
+
+    return uris;
   }
 
   private ClasspathPackageScanner.Result scanClasspath(Set<URI> classpath,
@@ -455,29 +469,7 @@ public final class BundlerExecution {
     return scan;
   }
 
-  private Set<URI> getUris(List<File> roots) {
-    Set<URI> uris = new LinkedHashSet<>();
-    for (File root : roots) {
-      if (root == null || !root.exists()) {
-        continue;
-      }
-
-      uris.add(root.toURI());
-    }
-
-    return uris;
-  }
-
-  private void extractDependencyFrontend(Set<URI> classpath, Path generatedDir) throws IOException {
-    // A dependency can ship its own frontend inside its JAR. Extract it into the generated sources
-    // directory before resolving entries, so the single build compiles it the same as local source.
-    int extracted = new DependencyEntryExtractor().extract(classpath, generatedDir);
-    if (extracted > 0) {
-      log.info("extracted {} frontend file(s) shipped by dependencies", extracted);
-    }
-  }
-
-  private void clearGeneratedDir(Path generatedDir) throws IOException {
+  private static void clearGeneratedDir(Path generatedDir) throws IOException {
     // Remove a previous run's generated sources. This only deletes, it never creates, so a run that
     // generates nothing leaves no directory behind.
     if (Files.isDirectory(generatedDir)) {
@@ -486,12 +478,27 @@ public final class BundlerExecution {
     }
   }
 
-  private void writeGeneratedGitignore(Path generatedDir) throws IOException {
-    // The directory exists only when this run wrote a generated source into it, so keep whatever it
-    // holds out of version control. When nothing needed generating the directory was never created,
-    // and there is nothing to ignore or to clean up.
-    if (Files.isDirectory(generatedDir)) {
-      Files.writeString(generatedDir.resolve(".gitignore"), "*\n");
+  private static void clearDirectory(Path dir) throws IOException {
+    try (Stream<Path> walk = Files.walk(dir)) {
+      walk.sorted((a, b) -> b.getNameCount() - a.getNameCount()).filter(p -> !p.equals(dir))
+          .forEach(p -> {
+            try {
+              Files.deleteIfExists(p);
+            } catch (IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          });
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private void extractDependencyFrontend(Set<URI> classpath, Path generatedDir) throws IOException {
+    // A dependency can ship its own frontend inside its JAR. Extract it into the generated sources
+    // directory before resolving entries, so the single build compiles it the same as local source.
+    int extracted = new DependencyEntryExtractor().extract(classpath, generatedDir);
+    if (extracted > 0) {
+      log.info("extracted {} frontend file(s) shipped by dependencies", extracted);
     }
   }
 
@@ -509,8 +516,8 @@ public final class BundlerExecution {
     return resolved;
   }
 
-  private List<BundleEntryDeclaration> prepareBaseEntries(List<BundleEntryDeclaration> entries,
-      Path generatedDir, Path sourceRoot) throws IOException {
+  private static List<BundleEntryDeclaration> prepareBaseEntries(
+      List<BundleEntryDeclaration> entries, Path generatedDir, Path sourceRoot) throws IOException {
     for (BundleEntryDeclaration entry : entries) {
       if (entry.isNpm()) {
         String stubPath = getNpmStubPath(entry.getSource());
@@ -549,7 +556,42 @@ public final class BundlerExecution {
     return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
   }
 
-  private BundleEntryDeclaration writeEagerEntry(Path generatedDir,
+  private BundleContext createContext(CompileContext compileContext, Path outputDir,
+      boolean rebuild) {
+    Request request = compileContext.getRequest();
+    Path sourceRoot = request.getBundleSourceRoot();
+    BundleContext context = new BundleContext();
+    context.setClasspath(getUris(request.getClasspathRoots()));
+    context.setFrontendPath(sourceRoot);
+    context.setSourcePaths(request.getSourceScanRoots());
+    context.setGeneratedPath(sourceRoot.resolve(NPM_ENTRY_DIR));
+    context.setOutputPath(outputDir);
+    context.setSourceExtensions(compileContext.getSourceExtensions());
+    context.setProduction(compileContext.isProduction());
+    context.setRebuild(rebuild);
+    context.setLog(log);
+
+    return context;
+  }
+
+  private void notifyWillBundle(List<BundleExtension> extensions, BundleContext context,
+      Map<String, Boolean> overrides) throws IOException {
+    for (BundleExtension extension : extensions) {
+      if (isExtensionActive(extension, context, overrides)) {
+        log.info("enabled extension '{}'", extension.getId());
+        extension.onWillBundle(context);
+      }
+    }
+  }
+
+  private static boolean isExtensionActive(BundleExtension extension, BundleContext context,
+      Map<String, Boolean> overrides) {
+    Boolean override = overrides.get(extension.getId());
+
+    return override != null ? override : extension.isEnabledByDefault(context);
+  }
+
+  private static BundleEntryDeclaration writeEagerEntry(Path generatedDir,
       List<BundleEntryDeclaration> entries) throws IOException {
     StringBuilder module = new StringBuilder();
     for (BundleEntryDeclaration entry : entries) {
@@ -573,52 +615,13 @@ public final class BundlerExecution {
     }
   }
 
-  private void runExtensions(List<BundleExtension> extensions, BundleContext context,
-      Map<String, Boolean> overrides) throws IOException {
-    for (BundleExtension extension : extensions) {
-      if (isExtensionActive(extension, context, overrides)) {
-        log.info("enabled extension '{}'", extension.getId());
-        extension.onWillBundle(context);
-      } else {
-        log.info("extension '{}' is off, enable it with the plugins configuration",
-            extension.getId());
-      }
+  private static void writeGeneratedGitignore(Path generatedDir) throws IOException {
+    // The directory exists only when this run wrote a generated source into it, so keep whatever it
+    // holds out of version control. When nothing needed generating the directory was never created,
+    // and there is nothing to ignore or to clean up.
+    if (Files.isDirectory(generatedDir)) {
+      Files.writeString(generatedDir.resolve(".gitignore"), "*\n");
     }
-  }
-
-  private Set<String> scanSourceExtensions(Path sourceRoot) {
-    if (sourceRoot == null || !Files.isDirectory(sourceRoot)) {
-      return Set.of();
-    }
-
-    Set<String> extensions = new LinkedHashSet<>();
-    try (Stream<Path> walk = Files.walk(sourceRoot)) {
-      for (Path path : (Iterable<Path>) walk::iterator) {
-        if (!Files.isRegularFile(path) || isInsideNodeModules(sourceRoot, path)) {
-          continue;
-        }
-
-        String name = path.getFileName().toString();
-        int dot = name.lastIndexOf('.');
-        if (dot > 0 && dot < name.length() - 1) {
-          extensions.add(name.substring(dot + 1).toLowerCase(Locale.ROOT));
-        }
-      }
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-
-    return extensions;
-  }
-
-  private boolean isInsideNodeModules(Path root, Path path) {
-    for (Path segment : root.relativize(path)) {
-      if (segment.toString().equals("node_modules")) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   private static List<BundlePackageDeclaration> mergeDeclarations(
@@ -667,7 +670,7 @@ public final class BundlerExecution {
     }
   }
 
-  private void prepareOutputDir(Path outputDir) throws IOException {
+  private static void prepareOutputDir(Path outputDir) throws IOException {
     if (Files.isDirectory(outputDir)) {
       clearDirectory(outputDir);
     }
@@ -675,35 +678,27 @@ public final class BundlerExecution {
     Files.createDirectories(outputDir);
   }
 
-  private static void clearDirectory(Path dir) throws IOException {
-    try (Stream<Path> walk = Files.walk(dir)) {
-      walk.sorted((a, b) -> b.getNameCount() - a.getNameCount()).filter(p -> !p.equals(dir))
-          .forEach(p -> {
-            try {
-              Files.deleteIfExists(p);
-            } catch (IOException e) {
-              throw new UncheckedIOException(e);
-            }
-          });
-    } catch (UncheckedIOException e) {
-      throw e.getCause();
-    }
-  }
-
-  private BundleDriverWriter.Config createDriverConfig(Request request,
+  private static BundleDriverWriter.Config createDriverConfig(Request request,
       List<BundleEntryDeclaration> entries, Path outputDir, Path metafile, List<BunPlugin> plugins,
-      boolean production, boolean splitting) {
+      boolean production, boolean splitting, Set<Path> watchPaths) {
     String entryNaming = production ? "[dir]/[name]-[hash].[ext]" : "[dir]/[name].[ext]";
     Path userConfig = request.getBundleSourceRoot().resolve(USER_CONFIG_NAME);
     String userConfigPath =
         Files.isRegularFile(userConfig) ? userConfig.toAbsolutePath().toString() : null;
+
+    List<String> watchDirs = new ArrayList<>();
+    for (Path path : watchPaths) {
+      if (Files.isDirectory(path)) {
+        watchDirs.add(path.toAbsolutePath().toString());
+      }
+    }
 
     return new BundleDriverWriter.Config().setEntries(entries)
         .setOutdir(outputDir.toAbsolutePath().toString())
         .setRoot(request.getBundleSourceRoot().toAbsolutePath().toString())
         .setMetafile(metafile.toAbsolutePath().toString()).setEntryNaming(entryNaming)
         .setMinify(production).setHashed(production).setSplitting(splitting).setPlugins(plugins)
-        .setUserConfig(userConfigPath);
+        .setUserConfig(userConfigPath).setWatchPaths(watchDirs);
   }
 
   private List<String> writeDriverFiles(Path workDir, List<BunPlugin> plugins,
@@ -715,15 +710,6 @@ public final class BundlerExecution {
     return List.of("run", scriptPath.toAbsolutePath().toString());
   }
 
-  /**
-   * Writes the index to disk and removes the index of the other mode, so a single index file is on
-   * the classpath. A built run writes under {@code META-INF}, the development watch writes under
-   * the static folder, which the development servers exclude from their reload scan.
-   *
-   * @param request the parameters for this run
-   * @param prepared the prepared build
-   * @param development whether to write the development index rather than the built index
-   */
   private void writeIndex(Request request, Prepared prepared, boolean development)
       throws IOException {
     Map<String, List<String>> bindings = buildBindings(prepared,
@@ -737,19 +723,6 @@ public final class BundlerExecution {
     log.info("wrote {}", indexPath);
   }
 
-  /**
-   * Folds the entry outputs into the routed class to output binding the index is written from.
-   *
-   * <p>
-   * Eager mode produced a single output already keyed under the reserved eager marker, so the
-   * mapping is the binding as is. Otherwise the entry key to output mapping is folded into a routed
-   * class to output binding, and the debug only outputs are added under the reserved debug key.
-   * </p>
-   *
-   * @param prepared the prepared build
-   * @param keyToFiles the entry key to output files mapping from the build
-   * @return the routed class to output files binding
-   */
   private Map<String, List<String>> buildBindings(Prepared prepared,
       Map<String, List<String>> keyToFiles) {
     if (prepared.isEager()) {
@@ -763,14 +736,6 @@ public final class BundlerExecution {
     return bindings;
   }
 
-  /**
-   * Adds the output files of the debug only entries under the reserved index key, so the runtime
-   * injects them only in debug mode.
-   *
-   * @param target the routed class to output files binding the index is built from
-   * @param keyToFiles the entry key to output files mapping from the build
-   * @param debugSources the entry sources declared {@code debug = true}
-   */
   static void addDebugFiles(Map<String, List<String>> target, Map<String, List<String>> keyToFiles,
       Set<String> debugSources) {
     if (debugSources.isEmpty()) {
@@ -796,21 +761,113 @@ public final class BundlerExecution {
     }
   }
 
-  private List<String> syncQuietly(Path from, Path to) {
-    try {
-      List<String> changed = syncChangedFiles(from, to);
-      if (!changed.isEmpty()) {
-        log.info("synced {} changed bundle file(s)", changed.size());
+  private void notifyDidBundle(CompileContext compileContext, Path outputDir, boolean rebuild) {
+    BundleContext context = createContext(compileContext, outputDir, rebuild);
+    for (BundleExtension extension : compileContext.getExtensions()) {
+      if (!isExtensionActive(extension, context,
+          compileContext.getRequest().getExtensionOverrides())) {
+        continue;
       }
 
-      return changed;
-    } catch (IOException | RuntimeException e) {
-      // The watch rewrites the staging tree under the sync, so a transient filesystem race must
-      // never kill the watch thread. Report it and let the next rebuild reconcile.
-      log.warn("failed to sync watch output: {}", e.getMessage());
-
-      return List.of();
+      try {
+        extension.onDidBundle(context);
+      } catch (RuntimeException e) {
+        log.warn("extension {} failed: {}", extension.getId(), e.getMessage());
+      }
     }
+  }
+
+  private Prepared buildWatch(CompileContext compileContext, Path servedDir, Path stagingDir)
+      throws IOException, InterruptedException {
+    Prepared prepared = compile(compileContext, stagingDir);
+    if (prepared == null) {
+      // Nothing resolved to build, so clear the served output and the index, so a removed entry
+      // stops being served instead of lingering as stale content from the last build.
+      clearOutput(compileContext.getRequest(), servedDir);
+
+      return null;
+    }
+
+    syncOutput(compileContext.getRequest(), servedDir, stagingDir, prepared);
+    notifyDidBundle(compileContext, servedDir, false);
+
+    return prepared;
+  }
+
+  private Process startWatcher(CompileContext compileContext, Path servedDir, Path stagingDir,
+      Prepared prepared, Consumer<List<String>> rebuildListener, boolean reloadOnBaseline)
+      throws IOException, InterruptedException {
+    List<String> watchArgs = new ArrayList<>(prepared.getRunArgs());
+    watchArgs.add("--watch");
+    log.info("starting bun watch, edit sources to rebuild");
+
+    AtomicBoolean baselineEstablished = new AtomicBoolean(false);
+
+    return bun.start(compileContext.getRequest().getBundleSourceRoot(), watchArgs, line -> {
+      log.info("{}", line);
+
+      if (isRebuildComplete(line)) {
+        // The watcher reemits the whole graph to its staging tree on every rebuild, including when
+        // a
+        // source file is added or removed, so sync the served output from what was built. The watch
+        // thread must survive a transient filesystem race while bun rewrites staging under it, so a
+        // failure here is logged and left for the next rebuild to reconcile.
+        List<String> changed;
+        try {
+          changed = syncOutput(compileContext.getRequest(), servedDir, stagingDir, prepared);
+        } catch (IOException | RuntimeException e) {
+          log.warn("failed to sync watch output after a rebuild: {}", e.getMessage());
+
+          return;
+        }
+
+        if (!changed.isEmpty()) {
+          log.info("synced {} changed bundle file(s)", changed.size());
+          notifyDidBundle(compileContext, servedDir, true);
+        }
+
+        // The watcher emits its own build when it starts. On the initial start that baseline only
+        // syncs the served directory and never reloads the browser. After an entry change the
+        // baseline is the new bundle, so it must reach the reload listener.
+        if (baselineEstablished.compareAndSet(false, true) && !reloadOnBaseline) {
+          return;
+        }
+
+        if (rebuildListener != null && !changed.isEmpty()) {
+          rebuildListener.accept(changed);
+        }
+      }
+    });
+  }
+
+  private static boolean isRebuildComplete(String line) {
+    return line.contains("Bundled ");
+  }
+
+  private BundleEntrySet scanEntrySet(Request request) {
+    ClasspathPackageScanner.Result scan =
+        scanner.scan(getUris(request.getClasspathRoots()), request.getExcludedPackages());
+
+    return BundleEntrySet.from(scan);
+  }
+
+  private List<String> syncOutput(Request request, Path servedDir, Path stagingDir,
+      Prepared prepared) throws IOException {
+    Files.createDirectories(servedDir);
+    List<String> changed = syncChangedFiles(stagingDir, servedDir);
+    writeIndex(request, prepared, true);
+
+    return changed;
+  }
+
+  private void clearOutput(Request request, Path servedDir) throws IOException {
+    if (Files.isDirectory(servedDir)) {
+      clearDirectory(servedDir);
+    }
+
+    Path index = indexWriter.write(request.getClassesOutputDir(), Map.of(),
+        BundleIndexDocument.DEVELOPMENT_RESOURCE);
+    log.info("wrote {}", index);
   }
 
   static List<String> syncChangedFiles(Path from, Path to) throws IOException {
@@ -887,16 +944,6 @@ public final class BundlerExecution {
     return Arrays.equals(Files.readAllBytes(a), Files.readAllBytes(b));
   }
 
-  private static boolean isRebuildComplete(String line) {
-    return line.contains("Bundled ");
-  }
-
-  private void installDependencies(Request request) throws IOException, InterruptedException {
-    ClasspathPackageScanner.Result scan =
-        scanner.scan(getUris(request.getClasspathRoots()), request.getExcludedPackages());
-    installAtRoot(request, scan.getPackages());
-  }
-
   private static boolean hasTestFiles(Path sourceRoot) throws IOException {
     try (Stream<Path> walk = Files.walk(sourceRoot)) {
       return walk.filter(Files::isRegularFile)
@@ -917,12 +964,13 @@ public final class BundlerExecution {
         || stem.endsWith("_spec");
   }
 
-  private void useLogger(BundleLogger logger) {
-    this.log = logger != null ? logger : BundleLogger.system();
-    bun.setLogger(this.log);
+  private void installDependencies(Request request) throws IOException, InterruptedException {
+    ClasspathPackageScanner.Result scan =
+        scanner.scan(getUris(request.getClasspathRoots()), request.getExcludedPackages());
+    installAtRoot(request, scan.getPackages());
   }
 
-  private static final class CompileContext { // NOSONAR
+  private static final class CompileContext {
 
     private final Request request;
     private final List<BundleExtension> extensions;
@@ -962,112 +1010,52 @@ public final class BundlerExecution {
     private Set<String> debugSources = Set.of();
     private boolean eager = false;
 
-    /**
-     * Sets the metafile path.
-     *
-     * @param metafile the metafile path
-     * @return the prepared run
-     */
     private Prepared setMetafile(Path metafile) {
       this.metafile = metafile;
 
       return this;
     }
 
-    /**
-     * Gets the metafile path.
-     *
-     * @return the metafile path
-     * @see #setMetafile(Path)
-     */
     private Path getMetafile() {
       return metafile;
     }
 
-    /**
-     * Sets the run arguments passed to Bun.
-     *
-     * @param runArgs the run arguments
-     * @return the prepared run
-     */
     private Prepared setRunArgs(List<String> runArgs) {
       this.runArgs = runArgs;
 
       return this;
     }
 
-    /**
-     * Gets the run arguments passed to Bun.
-     *
-     * @return the run arguments
-     * @see #setRunArgs(List)
-     */
     private List<String> getRunArgs() {
       return runArgs;
     }
 
-    /**
-     * Sets the routed class to entry key binding the runtime resolves a class by.
-     *
-     * @param bindings the routed class to entry key binding
-     * @return the prepared run
-     */
     private Prepared setBindings(Map<String, Set<String>> bindings) {
       this.bindings = bindings;
 
       return this;
     }
 
-    /**
-     * Gets the routed class to entry key binding the runtime resolves a class by.
-     *
-     * @return the routed class to entry key binding
-     * @see #setBindings(Map)
-     */
     private Map<String, Set<String>> getBindings() {
       return bindings;
     }
 
-    /**
-     * Sets the entry sources declared debug only, injected by the runtime only in debug mode.
-     *
-     * @param debugSources the debug only entry sources
-     * @return the prepared run
-     */
     private Prepared setDebugSources(Set<String> debugSources) {
       this.debugSources = debugSources;
 
       return this;
     }
 
-    /**
-     * Gets the entry sources declared debug only, injected by the runtime only in debug mode.
-     *
-     * @return the debug only entry sources
-     * @see #setDebugSources(Set)
-     */
     private Set<String> getDebugSources() {
       return debugSources;
     }
 
-    /**
-     * Sets whether the run produced a single eager bundle.
-     *
-     * @param eager {@code true} for a single eager bundle
-     * @return the prepared run
-     */
     private Prepared setEager(boolean eager) {
       this.eager = eager;
 
       return this;
     }
 
-    /**
-     * Indicates whether the run produced a single eager bundle.
-     *
-     * @return {@code true} for a single eager bundle
-     * @see #setEager(boolean)
-     */
     private boolean isEager() {
       return eager;
     }

--- a/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/WatchSession.java
+++ b/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/WatchSession.java
@@ -1,0 +1,128 @@
+package com.webforj.bundle.bun;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A running development watch.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.01
+ */
+public final class WatchSession implements AutoCloseable {
+
+  /**
+   * The operations a watch session calls back into its host to keep the bundle current across
+   * development restarts.
+   */
+  public interface WatchHost {
+
+    /**
+     * Computes the current set of bundle entries, compared against the running set to decide
+     * whether a restart changed what the watcher must build.
+     *
+     * @return the current set of bundle entries
+     */
+    BundleEntrySet currentEntrySet();
+
+    /**
+     * Syncs the development bundle output, the served files and the index, so it is current for the
+     * restarted application.
+     *
+     * @throws IOException on any IO failure
+     */
+    void syncOutput() throws IOException;
+
+    /**
+     * Rebuilds the bundle and starts a fresh watcher on the changed entry set.
+     *
+     * @return the new watcher process, or {@code null} when there is nothing left to bundle
+     * @throws IOException on any IO failure
+     * @throws InterruptedException if the rebuild is interrupted
+     */
+    Process restartWatcher() throws IOException, InterruptedException;
+  }
+
+  private final WatchHost host;
+  private final BundleLogger log;
+  private final ExecutorService rescans = Executors.newSingleThreadExecutor(runnable -> {
+    Thread thread = new Thread(runnable, "webforj-watch-rescan");
+    thread.setDaemon(true);
+
+    return thread;
+  });
+
+  private volatile Process watcher;
+  private volatile BundleEntrySet entrySet;
+  private volatile boolean closed;
+
+  WatchSession(Process watcher, WatchHost host, BundleLogger log) {
+    this.watcher = watcher;
+    this.host = host;
+    this.entrySet = host.currentEntrySet();
+    this.log = log;
+  }
+
+  /**
+   * Rescans for a changed set of bundle entries and rebuilds when it changed.
+   */
+  public void rescan() {
+    if (!closed) {
+      rescans.submit(this::run);
+    }
+  }
+
+  private void run() {
+    if (closed) {
+      return;
+    }
+
+    try {
+      // A recompile can wipe the served bundle files and the index out of the output directory, so
+      // sync them on every restart. This keeps the running set both served and resolvable for the
+      // restarted application even when the entries are unchanged and nothing is rebuilt.
+      host.syncOutput();
+
+      BundleEntrySet current = host.currentEntrySet();
+      // The restart left the entries untouched, so the running watcher already builds the right
+      // set. Nothing more to rebuild.
+      if (current.equals(entrySet)) {
+        return;
+      }
+
+      log.info("bundle entries changed, rebuilding the development bundle");
+      Process previous = watcher;
+      if (previous != null) {
+        previous.destroy();
+      }
+
+      watcher = host.restartWatcher();
+      // Advance the baseline when the rebuild produced a watcher, or when there are no entries left
+      // to build at all, so a removed entry settles to the empty state and a re-added one rebuilds.
+      // A non empty set that still produced nothing has a source not in place yet, so the baseline
+      // stays for the next restart to retry once the source is back.
+      if (watcher != null || current.isEmpty()) {
+        entrySet = current;
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (IOException | RuntimeException e) {
+      log.warn("failed to sync the development bundle after a restart: {}", e.getMessage());
+    }
+  }
+
+  /**
+   * Stops the rescans and the running watcher.
+   */
+  @Override
+  public void close() {
+    closed = true;
+    rescans.shutdownNow();
+    Process current = watcher;
+
+    if (current != null) {
+      current.destroy();
+    }
+  }
+}

--- a/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/discovery/BundleEntryResolver.java
+++ b/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/discovery/BundleEntryResolver.java
@@ -51,11 +51,14 @@ public final class BundleEntryResolver {
 
       if (file != null) {
         entries.add(new BundleEntryDeclaration().setResolvedFile(file).setSource(path));
-      } else if (isBareSpecifier(path)) {
+      } else if (isNpmSpecifier(path)) {
         // Not a local file and not an explicit path, so treat it as an npm specifier Bun resolves
         // from node_modules. This is how a project consumes a package with no frontend source.
         entries.add(new BundleEntryDeclaration().setSource(path).setNpm(true));
       }
+
+      // A local file name that matched nothing is dropped rather than turned into an npm stub, so a
+      // single dangling entry never fails the whole build. It is reported by getUnresolved.
     }
 
     return List.copyOf(entries);
@@ -95,7 +98,7 @@ public final class BundleEntryResolver {
     for (String path : entryPaths) {
       boolean resolved = (root != null && resolveFile(root, path) != null)
           || (extractedRoot != null && resolveFile(extractedRoot, path) != null);
-      if (!resolved && !isBareSpecifier(path)) {
+      if (!resolved && !isNpmSpecifier(path)) {
         missing.add(path);
       }
     }
@@ -103,8 +106,17 @@ public final class BundleEntryResolver {
     return List.copyOf(missing);
   }
 
-  private static boolean isBareSpecifier(String value) {
-    return !value.startsWith("./") && !value.startsWith("../") && !value.startsWith("/");
+  /**
+   * Indicates whether a value is an npm specifier rather than a local file that simply matched no
+   * source. An npm specifier is a scoped package, which always starts with {@code @}, such as
+   * {@code @scope/pkg/dist/Button.js}. Anything else is a local file under the source root, so a
+   * missing one is a dangling entry rather than a package to install.
+   *
+   * @param value the declared entry value
+   * @return {@code true} when the value is an npm specifier
+   */
+  private static boolean isNpmSpecifier(String value) {
+    return value.startsWith("@");
   }
 
   private Path resolveFile(Path root, String path) {

--- a/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/plugin/TailwindBundleRegistrar.java
+++ b/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/plugin/TailwindBundleRegistrar.java
@@ -52,6 +52,14 @@ public class TailwindBundleRegistrar implements BundleExtension {
           .warn("Tailwind found no application sources to scan, no utilities will be generated");
     }
 
+    // The utilities are generated from the classes the sources use, so editing a source changes the
+    // output. The sources sit outside the frontend root the watch already follows, so register them
+    // to rebuild on, which regenerates the utilities when a class is added or removed during a
+    // watch.
+    for (Path source : sources) {
+      context.addWatchPath(source);
+    }
+
     Path entryDir = context.getGeneratedPath().resolve(SUBDIR);
     Files.createDirectories(entryDir);
     Path entryFile = entryDir.resolve(ENTRY_FILE);

--- a/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/writer/BundleDriverWriter.java
+++ b/webforj-bundle/webforj-bundle-bun/src/main/java/com/webforj/bundle/bun/writer/BundleDriverWriter.java
@@ -123,6 +123,7 @@ public final class BundleDriverWriter {
     private boolean splitting = true;
     private List<BunPlugin> plugins = null;
     private String userConfig = null;
+    private List<String> watchPaths = List.of();
 
     /**
      * Sets the entries to build.
@@ -333,6 +334,28 @@ public final class BundleDriverWriter {
       this.userConfig = userConfig;
 
       return this;
+    }
+
+    /**
+     * Sets the extra directories the watch rebuilds on, beyond the bundle source root.
+     *
+     * @param watchPaths the absolute directories to watch
+     * @return the config
+     */
+    public Config setWatchPaths(List<String> watchPaths) {
+      this.watchPaths = watchPaths;
+
+      return this;
+    }
+
+    /**
+     * Gets the extra directories the watch rebuilds on, beyond the bundle source root.
+     *
+     * @return the absolute directories to watch
+     * @see #setWatchPaths(List)
+     */
+    public List<String> getWatchPaths() {
+      return watchPaths;
     }
 
     /**

--- a/webforj-bundle/webforj-bundle-bun/src/main/resources/com/webforj/bundle/bun/driver.mjs
+++ b/webforj-bundle/webforj-bundle-bun/src/main/resources/com/webforj/bundle/bun/driver.mjs
@@ -4,7 +4,7 @@
  * @author Hyyan Abo Fakher
  */
 
-import { watch, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { watch, writeFileSync, mkdirSync, readFileSync, existsSync, rmSync } from 'node:fs';
 import { relative, dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -54,9 +54,35 @@ for (const ref of cfg.entries) {
   }
 }
 
+function writeMetafile(outputs) {
+  mkdirSync(dirname(cfg.metafile), { recursive: true });
+  writeFileSync(cfg.metafile, JSON.stringify({ outputs }));
+}
+
 async function runBuild() {
+  // Only build entries whose source file still exists. A file removed at watch time is dropped from
+  // the build instead of failing it, and the output tree is rebuilt from scratch so the output of a
+  // removed entry does not linger as stale served content.
+  const entries = cfg.entries.filter((e) => existsSync(resolve(cfg.root, e.buildPath)));
+  for (const ref of cfg.entries) {
+    if (!entries.includes(ref)) {
+      console.error("dropping @BundleEntry '" + ref.source + "', its source file no longer exists");
+    }
+  }
+
+  rmSync(cfg.outdir, { recursive: true, force: true });
+  mkdirSync(cfg.outdir, { recursive: true });
+
+  const count = entries.length;
+  if (count === 0) {
+    writeMetafile({});
+    console.log('Bundled 0 entries');
+
+    return true;
+  }
+
   const result = await Bun.build({
-    entrypoints: cfg.entries.map((e) => e.buildPath),
+    entrypoints: entries.map((e) => e.buildPath),
     outdir: cfg.outdir,
     root: cfg.root,
     target: 'browser',
@@ -80,10 +106,7 @@ async function runBuild() {
     outputs[rel] = key ? { entryPoint: key } : {};
   }
 
-  mkdirSync(dirname(cfg.metafile), { recursive: true });
-  writeFileSync(cfg.metafile, JSON.stringify({ outputs }));
-
-  const count = cfg.entries.length;
+  writeMetafile(outputs);
   console.log('Bundled ' + count + ' entr' + (count === 1 ? 'y' : 'ies'));
 
   return result.success;
@@ -93,7 +116,7 @@ const watching = process.argv.includes('--watch');
 const ok = await runBuild();
 if (watching) {
   let timer;
-  const watcher = watch(cfg.root, { recursive: true }, (event, file) => {
+  const onChange = (event, file) => {
     if (file?.split(/[\\/]/).includes('node_modules')) {
       return;
     }
@@ -102,13 +125,20 @@ if (watching) {
     timer = setTimeout(() => {
       runBuild().catch((e) => console.error(String(e)));
     }, 60);
-  });
+  };
+
+  // Watch the bundle source root and any extra directories a plugin builds from, such as the
+  // application sources a generated stylesheet scans, so editing them rebuilds during the watch.
+  const watchers = [cfg.root, ...(cfg.watchPaths || [])]
+    .map((dir) => watch(dir, { recursive: true }, onChange));
 
   const stop = () => {
-    try {
-      watcher.close();
-    } catch (e) {
-      // closing on shutdown, ignore
+    for (const watcher of watchers) {
+      try {
+        watcher.close();
+      } catch (e) {
+        // closing on shutdown, ignore
+      }
     }
 
     process.exit(0);
@@ -116,6 +146,17 @@ if (watching) {
 
   process.on('SIGINT', stop);
   process.on('SIGTERM', stop);
+
+  // Poll whether the parent is still there and exit once it is gone, so the watcher never lingers as
+  // an orphan.
+  const parentPid = process.ppid;
+  setInterval(() => {
+    try {
+      process.kill(parentPid, 0);
+    } catch (e) {
+      stop();
+    }
+  }, 1000);
 } else if (!ok) {
   process.exit(1);
 }

--- a/webforj-bundle/webforj-bundle-bun/src/test/java/com/webforj/bundle/bun/WatchSessionTest.java
+++ b/webforj-bundle/webforj-bundle-bun/src/test/java/com/webforj/bundle/bun/WatchSessionTest.java
@@ -1,0 +1,227 @@
+package com.webforj.bundle.bun;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class WatchSessionTest {
+
+  @Test
+  void shouldSyncTheOutputButNotRebuildWhenTheEntrySetIsUnchanged() throws InterruptedException {
+    FakeProcess running = new FakeProcess();
+    CountDownLatch synced = new CountDownLatch(1);
+    CountDownLatch rebuilt = new CountDownLatch(1);
+    WatchSession session =
+        new WatchSession(running, host(() -> entrySet("a"), synced::countDown, () -> {
+          rebuilt.countDown();
+
+          return new FakeProcess();
+        }), BundleLogger.system());
+
+    session.rescan();
+
+    // A restart always syncs the served output, since a recompile can wipe it, even when the
+    // entries are unchanged and nothing is rebuilt.
+    assertTrue(synced.await(1, TimeUnit.SECONDS), "the output is synced on every restart");
+    assertFalse(rebuilt.await(300, TimeUnit.MILLISECONDS),
+        "an unchanged entry set does not rebuild");
+    assertFalse(running.isDestroyed(), "the running watcher keeps going");
+
+    session.close();
+  }
+
+  @Test
+  void shouldRebuildAndReplaceTheWatcherWhenTheEntrySetChanged() throws InterruptedException {
+    FakeProcess first = new FakeProcess();
+    FakeProcess second = new FakeProcess();
+    CountDownLatch rebuilt = new CountDownLatch(1);
+    AtomicReference<BundleEntrySet> live = new AtomicReference<>(entrySet("a"));
+    WatchSession session = new WatchSession(first, host(live::get, () -> {
+    }, () -> {
+      rebuilt.countDown();
+
+      return second;
+    }), BundleLogger.system());
+
+    live.set(entrySet("a", "b"));
+    session.rescan();
+
+    assertTrue(rebuilt.await(2, TimeUnit.SECONDS), "a changed entry set rebuilds");
+    assertTrue(first.awaitDestroyed(2, TimeUnit.SECONDS), "the old watcher is stopped");
+
+    session.close();
+
+    assertTrue(second.isDestroyed(), "closing stops the new watcher");
+  }
+
+  @Test
+  void shouldRetryOnTheNextRestartWhenARebuildProducesNothing() throws InterruptedException {
+    FakeProcess running = new FakeProcess();
+    AtomicReference<BundleEntrySet> live = new AtomicReference<>(entrySet("a"));
+    CountDownLatch rebuilds = new CountDownLatch(2);
+    WatchSession session = new WatchSession(running, host(live::get, () -> {
+    }, () -> {
+      rebuilds.countDown();
+
+      return null;
+    }), BundleLogger.system());
+
+    live.set(entrySet("a", "b"));
+    session.rescan();
+    session.rescan();
+
+    assertTrue(rebuilds.await(2, TimeUnit.SECONDS),
+        "an unbuildable entry set is retried on the next restart");
+
+    session.close();
+  }
+
+  @Test
+  void shouldRebuildWhenAnEntrySetReturnsAfterBecomingEmpty() throws InterruptedException {
+    FakeProcess running = new FakeProcess();
+    // The scan returns the baseline, then the empty set when the entry is removed, then the entry
+    // again when it is added back. The queue is drained once per scan, so the order is fixed.
+    Queue<BundleEntrySet> scans =
+        new ConcurrentLinkedQueue<>(List.of(entrySet("a"), entrySet(), entrySet("a")));
+    AtomicReference<BundleEntrySet> last = new AtomicReference<>(entrySet("a"));
+    CountDownLatch rebuilt = new CountDownLatch(1);
+    WatchSession session = new WatchSession(running, host(() -> {
+      BundleEntrySet next = scans.poll();
+      last.set(next != null ? next : last.get());
+
+      return last.get();
+    }, () -> {
+    }, () -> {
+      if (last.get().isEmpty()) {
+        return null;
+      }
+
+      rebuilt.countDown();
+
+      return new FakeProcess();
+    }), BundleLogger.system());
+
+    session.rescan();
+    session.rescan();
+
+    assertTrue(rebuilt.await(2, TimeUnit.SECONDS),
+        "a re-added entry set rebuilds after the set went empty");
+
+    session.close();
+  }
+
+  @Test
+  void shouldStopTheWatcherOnClose() {
+    FakeProcess running = new FakeProcess();
+    WatchSession session = new WatchSession(running, host(() -> entrySet("a"), () -> {
+    }, () -> null), BundleLogger.system());
+
+    session.close();
+
+    assertTrue(running.isDestroyed());
+  }
+
+  @Test
+  void shouldIgnoreARescanAfterClose() throws InterruptedException {
+    FakeProcess running = new FakeProcess();
+    CountDownLatch rebuilt = new CountDownLatch(1);
+    AtomicReference<BundleEntrySet> live = new AtomicReference<>(entrySet("a"));
+    WatchSession session = new WatchSession(running, host(live::get, () -> {
+    }, () -> {
+      rebuilt.countDown();
+
+      return new FakeProcess();
+    }), BundleLogger.system());
+
+    live.set(entrySet("a", "b"));
+    session.close();
+    session.rescan();
+
+    assertFalse(rebuilt.await(300, TimeUnit.MILLISECONDS), "a closed session does not rebuild");
+  }
+
+  private static WatchSession.WatchHost host(Supplier<BundleEntrySet> entries, Runnable sync,
+      Restart restart) {
+    return new WatchSession.WatchHost() {
+      @Override
+      public BundleEntrySet currentEntrySet() {
+        return entries.get();
+      }
+
+      @Override
+      public void syncOutput() {
+        sync.run();
+      }
+
+      @Override
+      public Process restartWatcher() throws IOException, InterruptedException {
+        return restart.get();
+      }
+    };
+  }
+
+  private static BundleEntrySet entrySet(String... entries) {
+    return new BundleEntrySet(Set.of(entries), Set.of(), Set.of(), Map.of());
+  }
+
+  @FunctionalInterface
+  private interface Restart {
+    Process get() throws IOException, InterruptedException;
+  }
+
+  private static final class FakeProcess extends Process {
+
+    private final CountDownLatch destroyed = new CountDownLatch(1);
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {
+      destroyed.countDown();
+    }
+
+    private boolean isDestroyed() {
+      return destroyed.getCount() == 0;
+    }
+
+    private boolean awaitDestroyed(long timeout, TimeUnit unit) throws InterruptedException {
+      return destroyed.await(timeout, unit);
+    }
+  }
+}

--- a/webforj-bundle/webforj-bundle-foundation/src/main/java/com/webforj/bundle/BundleIndexStore.java
+++ b/webforj-bundle/webforj-bundle-foundation/src/main/java/com/webforj/bundle/BundleIndexStore.java
@@ -16,7 +16,7 @@ import java.nio.charset.StandardCharsets;
  * {@code META-INF}. A development application reads the index the watch emitted under the static
  * folder, which the development servers exclude from their reload scan so refreshing it never
  * redeploys the application. The development index is read first, so it supersedes a stale built
- * index left next to it. The file is read once through the context classloader and cached.
+ * index left next to it.
  * </p>
  *
  * @author Hyyan Abo Fakher
@@ -32,15 +32,22 @@ public final class BundleIndexStore {
   private BundleIndexStore() {}
 
   /**
-   * Gets the index read from disk once through the context classloader.
+   * Gets the index read from disk.
    *
    * @return the current index, or {@code null} when no index file is on the classpath
    */
   public static BundleIndex get() {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+    BundleIndex development = read(classLoader, BundleIndexDocument.DEVELOPMENT_RESOURCE);
+    if (development != null) {
+      return development;
+    }
+
     if (!diskRead) {
       synchronized (BundleIndexStore.class) {
         if (!diskRead) {
-          onDisk = read(Thread.currentThread().getContextClassLoader());
+          onDisk = read(classLoader, BundleIndexDocument.RESOURCE);
           diskRead = true;
         }
       }

--- a/webforj-bundle/webforj-bundle-foundation/src/test/java/com/webforj/bundle/BundleIndexStoreTest.java
+++ b/webforj-bundle/webforj-bundle-foundation/src/test/java/com/webforj/bundle/BundleIndexStoreTest.java
@@ -39,6 +39,29 @@ class BundleIndexStoreTest {
   }
 
   @Test
+  void shouldReadTheDevelopmentIndexFreshOnEveryCall(@TempDir Path tmp) throws IOException {
+    writeIndex(tmp, BundleIndexDocument.DEVELOPMENT_RESOURCE, """
+        {"bindings":{"View":["app.css"]}}
+        """);
+
+    ClassLoader previous = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(loader(tmp));
+    try {
+      BundleIndexStore.reset();
+      assertEquals(List.of("app.css"), BundleIndexStore.get().getBindings().get("View"));
+
+      writeIndex(tmp, BundleIndexDocument.DEVELOPMENT_RESOURCE, """
+          {"bindings":{"View":["app.css","styles.scss"]}}
+          """);
+
+      assertEquals(List.of("app.css", "styles.scss"),
+          BundleIndexStore.get().getBindings().get("View"));
+    } finally {
+      Thread.currentThread().setContextClassLoader(previous);
+    }
+  }
+
+  @Test
   void shouldPreferTheDevelopmentIndexOverTheBuiltIndex(@TempDir Path tmp) throws IOException {
     writeIndex(tmp, BundleIndexDocument.RESOURCE, """
         {"bindings":{"View":["built.js"]}}

--- a/webforj-devtools/src/main/resources/META-INF/resources/webforj/devtools-reload-client.js
+++ b/webforj-devtools/src/main/resources/META-INF/resources/webforj/devtools-reload-client.js
@@ -30,7 +30,7 @@
   let pendingReload = false;
   let disconnectedAt = 0;
   let probeStartedAt = 0;
-  let progressbarObserver;
+  let leaving = false;
 
   function log(message) {
     console.log(
@@ -113,7 +113,7 @@
       };
 
       ws.onclose = function (event) {
-        if (!hasDisconnected) {
+        if (!leaving && !hasDisconnected) {
           log('📡 Connection closed (code: ' + event.code
             + ') - standing by until the app is back...');
           showStatus('Server restarting…');
@@ -287,28 +287,16 @@
     document.getElementById('webforj-devtools-veil')?.remove();
   }
 
-  // The dwc client raises its own page progress bar the moment it loses the server, ahead of
-  // the reload socket noticing. Treat that as another disconnect signal: take the bar down and
-  // bring up the reload pill so a redeploy always shows the same single indicator.
-  function takeOverServerProgressbar() {
-    const bar = document.getElementById(serverProgressbarId);
-    if (!bar) {
+  // Hide the dwc client's own page progress bar.
+  function hideServerProgressbar() {
+    if (document.getElementById('webforj-devtools-progressbar-style')) {
       return;
     }
 
-    bar.remove();
-    showStatus('Server restarting…');
-  }
-
-  function watchForServerProgressbar() {
-    if (progressbarObserver || typeof MutationObserver === 'undefined' || !document.body) {
-      return;
-    }
-
-    progressbarObserver = new MutationObserver(takeOverServerProgressbar);
-    progressbarObserver.observe(document.body, { childList: true });
-    // It may already be on the page if it appeared before this started watching.
-    takeOverServerProgressbar();
+    const style = document.createElement('style');
+    style.id = 'webforj-devtools-progressbar-style';
+    style.textContent = '#' + serverProgressbarId + '{display:none!important}';
+    (document.head || document.documentElement).appendChild(style);
   }
 
   function handleResourceUpdate(message) {
@@ -391,17 +379,14 @@
 
   // Start connection
   connect();
-  watchForServerProgressbar();
+  hideServerProgressbar();
 
-  // Clean up on page unload
+  // Clean up on page unload.
   window.addEventListener('beforeunload', function () {
+    leaving = true;
     stopHeartbeat();
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
-    }
-
-    if (progressbarObserver) {
-      progressbarObserver.disconnect();
     }
 
     if (ws) {

--- a/webforj-plugins/webforj-plugin/webforj-gradle-plugin/src/main/java/com/webforj/plugin/gradle/WatchLifecycle.java
+++ b/webforj-plugins/webforj-plugin/webforj-gradle-plugin/src/main/java/com/webforj/plugin/gradle/WatchLifecycle.java
@@ -1,5 +1,6 @@
 package com.webforj.plugin.gradle;
 
+import com.webforj.bundle.bun.WatchSession;
 import com.webforj.plugin.foundation.WatchSocketServer;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,19 +25,19 @@ import org.gradle.api.services.BuildServiceParameters;
 public abstract class WatchLifecycle
     implements BuildService<BuildServiceParameters.None>, AutoCloseable {
 
-  private Process watcher;
+  private WatchSession session;
   private WatchSocketServer socket;
   private Path portFile;
 
   /**
-   * Records the watcher resources to release when the build ends.
+   * Records the watch resources to release when the build ends.
    *
-   * @param watcher the running Bun watcher process
+   * @param session the running watch
    * @param socket the watch socket server
    * @param portFile the discovery file keyed by the project path
    */
-  synchronized void track(Process watcher, WatchSocketServer socket, Path portFile) {
-    this.watcher = watcher;
+  synchronized void track(WatchSession session, WatchSocketServer socket, Path portFile) {
+    this.session = session;
     this.socket = socket;
     this.portFile = portFile;
   }
@@ -46,20 +47,23 @@ public abstract class WatchLifecycle
    */
   @Override
   public synchronized void close() {
-    if (watcher != null) {
-      watcher.destroy();
-      watcher = null;
+    if (session != null) {
+      session.close();
+      session = null;
     }
+
     if (socket != null) {
       socket.close();
       socket = null;
     }
+
     if (portFile != null) {
       try {
         Files.deleteIfExists(portFile);
       } catch (IOException e) {
         // shutting down, ignore
       }
+
       portFile = null;
     }
   }

--- a/webforj-plugins/webforj-plugin/webforj-gradle-plugin/src/main/java/com/webforj/plugin/gradle/WatchTask.java
+++ b/webforj-plugins/webforj-plugin/webforj-gradle-plugin/src/main/java/com/webforj/plugin/gradle/WatchTask.java
@@ -2,6 +2,7 @@ package com.webforj.plugin.gradle;
 
 import com.webforj.bundle.bun.BundleLogger;
 import com.webforj.bundle.bun.BundlerExecution;
+import com.webforj.bundle.bun.WatchSession;
 import com.webforj.plugin.foundation.WatchPortFile;
 import com.webforj.plugin.foundation.WatchProtocol;
 import com.webforj.plugin.foundation.WatchSocketServer;
@@ -72,14 +73,20 @@ public abstract class WatchTask extends AbstractBundlerTask {
 
     BundlerExecution execution = createExecution();
     try {
-      Process watcher =
+      WatchSession session =
           execution.watch(createRequest(), changed -> socket.send(WatchProtocol.rebuild(changed)),
               (level, line) -> sink.get().log(level, line));
       sink.set((level, line) -> socket
           .send(level == System.Logger.Level.WARNING ? WatchProtocol.warn(line)
               : WatchProtocol.log(line)));
-      installShutdownHook(watcher, socket, portFile);
-      getWatchLifecycle().get().track(watcher, socket, portFile);
+      // The application rescans for new bundle entries every time it connects, which is every
+      // development restart.
+      if (session != null) {
+        socket.setOnConnect(session::rescan);
+      }
+
+      installShutdownHook(session, socket, portFile);
+      getWatchLifecycle().get().track(session, socket, portFile);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       closeSocket(socket, portFile);
@@ -116,10 +123,10 @@ public abstract class WatchTask extends AbstractBundlerTask {
     }
   }
 
-  private void installShutdownHook(Process watcher, WatchSocketServer socket, Path portFile) {
+  private void installShutdownHook(WatchSession session, WatchSocketServer socket, Path portFile) {
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-      if (watcher != null) {
-        watcher.destroy();
+      if (session != null) {
+        session.close();
       }
 
       closeSocket(socket, portFile);

--- a/webforj-plugins/webforj-plugin/webforj-gradle-plugin/src/test/java/com/webforj/plugin/gradle/WatchTaskTest.java
+++ b/webforj-plugins/webforj-plugin/webforj-gradle-plugin/src/test/java/com/webforj/plugin/gradle/WatchTaskTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.webforj.bundle.bun.BundlerExecution;
+import com.webforj.bundle.bun.WatchSession;
 import com.webforj.plugin.foundation.WatchPortFile;
 import java.io.File;
 import java.nio.file.Files;
@@ -70,7 +71,7 @@ class WatchTaskTest {
   @Test
   void shouldOpenTheSocketAndWriteThePortFile(@TempDir Path tmp) throws Exception {
     BundlerExecution execution = mock(BundlerExecution.class);
-    when(execution.watch(any(), any(), any())).thenReturn(mock(Process.class));
+    when(execution.watch(any(), any(), any())).thenReturn(mock(WatchSession.class));
     Project project = ProjectBuilder.builder().withProjectDir(tmp.toFile()).build();
     TestableWatchTask task = task(project, tmp, tmp.toFile());
     task.setExecution(execution);

--- a/webforj-plugins/webforj-plugin/webforj-maven-plugin/src/main/java/com/webforj/plugin/maven/WatchMojo.java
+++ b/webforj-plugins/webforj-plugin/webforj-maven-plugin/src/main/java/com/webforj/plugin/maven/WatchMojo.java
@@ -2,6 +2,7 @@ package com.webforj.plugin.maven;
 
 import com.webforj.bundle.bun.BundleLogger;
 import com.webforj.bundle.bun.BundlerExecution;
+import com.webforj.bundle.bun.WatchSession;
 import com.webforj.plugin.foundation.WatchPortFile;
 import com.webforj.plugin.foundation.WatchProtocol;
 import com.webforj.plugin.foundation.WatchSocketServer;
@@ -63,13 +64,19 @@ public class WatchMojo extends AbstractBundlerMojo {
 
     BundlerExecution execution = createExecution();
     try {
-      Process watcher =
+      WatchSession session =
           execution.watch(createRequest(), changed -> socket.send(WatchProtocol.rebuild(changed)),
               (level, line) -> sink.get().log(level, line));
       sink.set((level, line) -> socket
           .send(level == System.Logger.Level.WARNING ? WatchProtocol.warn(line)
               : WatchProtocol.log(line)));
-      installShutdownHook(watcher, socket, portFile);
+      // The application rescans for new bundle entries every time it connects, which is every
+      // development restart.
+      if (session != null) {
+        socket.setOnConnect(session::rescan);
+      }
+
+      installShutdownHook(session, socket, portFile);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       closeSocket(socket, portFile);
@@ -106,10 +113,10 @@ public class WatchMojo extends AbstractBundlerMojo {
     }
   }
 
-  private void installShutdownHook(Process watcher, WatchSocketServer socket, Path portFile) {
+  private void installShutdownHook(WatchSession session, WatchSocketServer socket, Path portFile) {
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-      if (watcher != null) {
-        watcher.destroy();
+      if (session != null) {
+        session.close();
       }
 
       closeSocket(socket, portFile);

--- a/webforj-plugins/webforj-plugin/webforj-maven-plugin/src/test/java/com/webforj/plugin/maven/WatchMojoTest.java
+++ b/webforj-plugins/webforj-plugin/webforj-maven-plugin/src/test/java/com/webforj/plugin/maven/WatchMojoTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.webforj.bundle.bun.BundlerExecution;
+import com.webforj.bundle.bun.WatchSession;
 import com.webforj.plugin.foundation.WatchPortFile;
 import java.io.File;
 import java.nio.file.Files;
@@ -34,7 +35,7 @@ class WatchMojoTest {
   @Test
   void shouldOpenTheSocketAndWriteThePortFile(@TempDir Path tmp) throws Exception {
     BundlerExecution execution = mock(BundlerExecution.class);
-    when(execution.watch(any(), any(), any())).thenReturn(mock(Process.class));
+    when(execution.watch(any(), any(), any())).thenReturn(mock(WatchSession.class));
     WatchMojo mojo = newMojo(execution, tmp);
     Path portFile = WatchPortFile.resolve(tmp.toAbsolutePath().toString());
 

--- a/webforj-plugins/webforj-plugin/webforj-plugin-foundation/src/main/java/com/webforj/plugin/foundation/WatchSocketServer.java
+++ b/webforj-plugins/webforj-plugin/webforj-plugin-foundation/src/main/java/com/webforj/plugin/foundation/WatchSocketServer.java
@@ -41,6 +41,8 @@ public final class WatchSocketServer implements AutoCloseable {
   private final Thread acceptThread;
   private final List<String> pending = new ArrayList<>();
   private boolean replayed = false;
+  private volatile Runnable onConnect = () -> {
+  };
 
   /**
    * Opens the server on a free loopback port chosen by the operating system.
@@ -95,6 +97,22 @@ public final class WatchSocketServer implements AutoCloseable {
         pending.clear();
       }
     }
+
+    // A connection means an application started or restarted, the one moment its compiled classes
+    // can carry a new set of bundle entries. The callback runs off the write lock so a slow rescan
+    // never holds up output to the other connections.
+    onConnect.run();
+  }
+
+  /**
+   * Sets the callback invoked whenever an application connects, used to rescan for bundle entry
+   * changes a development restart may have introduced.
+   *
+   * @param onConnect the callback, or {@code null} to clear it
+   */
+  public void setOnConnect(Runnable onConnect) {
+    this.onConnect = onConnect != null ? onConnect : () -> {
+    };
   }
 
   /**


### PR DESCRIPTION
The development watch now holds together when you work against a running server. Editing a file, adding or removing what gets bundled, and restarting all keep the browser in step with the source instead of drifting out of sync or leaving the page in a stale state, and the watch winds down cleanly with the build when you stop it.
