### PR TITLE
feat: add `find()` method to TranslationResolver for safe key probing

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/i18n/BundleTranslationResolver.java
+++ b/webforj-foundation/src/main/java/com/webforj/i18n/BundleTranslationResolver.java
@@ -6,6 +6,7 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 /**
@@ -140,6 +141,39 @@ public class BundleTranslationResolver implements TranslationResolver {
     }
 
     return value;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Optional<String> find(String key, Locale locale, Object... args) {
+    if (key == null || key.isEmpty()) {
+      return Optional.empty();
+    }
+
+    Locale resolvedLocale = locale != null ? locale : getDefaultLocale();
+    Object[] resolvedArgs = args != null ? args : new Object[0];
+
+    ResourceBundle bundle = getBundle(resolvedLocale);
+    if (bundle == null || !bundle.containsKey(key)) {
+      return Optional.empty();
+    }
+
+    String value = bundle.getString(key);
+    if (resolvedArgs.length > 0) {
+      try {
+        value = new MessageFormat(value, resolvedLocale).format(resolvedArgs);
+      } catch (IllegalArgumentException e) {
+        if (logger.isLoggable(Level.WARNING)) {
+          logger.log(Level.WARNING,
+              "Failed to format translation value ''{0}'' for key ''{1}'': {2}", value, key,
+              e.getMessage());
+        }
+      }
+    }
+
+    return Optional.of(value);
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/i18n/TranslationResolver.java
+++ b/webforj-foundation/src/main/java/com/webforj/i18n/TranslationResolver.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 /**
@@ -33,6 +34,32 @@ import java.util.ResourceBundle;
  * @see App#t(String, Object...)
  */
 public interface TranslationResolver extends Serializable {
+
+  /**
+   * Looks up a translation key and returns the localized string value if a translation exists.
+   *
+   * <p>
+   * This is the probing counterpart of {@link #resolve(String, Locale, Object...)}. It never logs
+   * and never falls back to the key. When no translation exists for the given key, an empty
+   * {@link Optional} is returned. Use this method when a missing translation is an expected
+   * outcome, for example when a value may be either a translation key or a literal display string.
+   * </p>
+   *
+   * <p>
+   * The default implementation returns an empty {@link Optional}. Implementations should override
+   * this method to report their translations.
+   * </p>
+   *
+   * @param key the translation key to look up
+   * @param locale the locale to use for translation
+   * @param args optional arguments for placeholder substitution
+   *
+   * @return the resolved text, or an empty {@link Optional} if no translation exists
+   * @since 26.02
+   */
+  default Optional<String> find(String key, Locale locale, Object... args) {
+    return Optional.empty();
+  }
 
   /**
    * Resolves a translation key to its localized string value.

--- a/webforj-foundation/src/test/java/com/webforj/i18n/BundleTranslationResolverTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/i18n/BundleTranslationResolverTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -108,6 +109,35 @@ class BundleTranslationResolverTest {
     @Test
     void shouldUseDefaultLocaleWhenNullLocalePassed() {
       assertEquals("Welcome", resolver.resolve("welcome", null));
+    }
+  }
+
+  @Nested
+  class KeyProbing {
+
+    @Test
+    void shouldFindExistingKey() {
+      assertEquals(Optional.of("Welcome"), resolver.find("welcome", Locale.ENGLISH));
+      assertEquals(Optional.of("Hello Hyyan"), resolver.find("greeting", Locale.ENGLISH, "Hyyan"));
+    }
+
+    @Test
+    void shouldReturnEmptyForMissingKey() {
+      assertEquals(Optional.empty(), resolver.find("nonexistent", Locale.ENGLISH));
+      assertEquals(Optional.empty(), resolver.find(null, Locale.ENGLISH));
+      assertEquals(Optional.empty(), resolver.find("", Locale.ENGLISH));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenBundleMissing() {
+      BundleTranslationResolver missing =
+          new BundleTranslationResolver("nonexistent", Collections.emptyList());
+
+      try (MockedStatic<App> appMock = mockStatic(App.class)) {
+        appMock.when(App::getLocale).thenReturn(Locale.ENGLISH);
+
+        assertEquals(Optional.empty(), missing.find("welcome", Locale.ENGLISH));
+      }
     }
   }
 


### PR DESCRIPTION
Add a new `find(String, Locale, Object...)` method to `TranslationResolver` that returns an `Optional<String>` instead of falling back to the key when no translation is found.