### PR TITLE
fix: #1022 element composite.get() throws class cast exception when retrieving boolean properties from client with from client=true

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/element/ElementComposite.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/ElementComposite.java
@@ -14,11 +14,20 @@ import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.exceptions.WebforjRuntimeException;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.DoubleAccumulator;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
 
 /**
  * The {@code ElementComposite} class serves as an abstract base class for creating composite
@@ -41,6 +50,36 @@ public abstract class ElementComposite extends Composite<Element> {
   private final HashMap<String, Class<?>> eventNameToClassMap = new HashMap<>();
   private final Map<ListenerRegistration<ElementEvent>, EventListener<? extends ComponentEvent<?>>> listenerRegistrations =
       new HashMap<>();
+
+  private static final Map<Class<?>, Function<String, Object>> SIMPLE_CONVERTERS =
+      Map.ofEntries(Map.entry(String.class, s -> s), Map.entry(Boolean.class, Boolean::valueOf),
+          Map.entry(boolean.class, Boolean::valueOf), Map.entry(Byte.class, Byte::valueOf),
+          Map.entry(byte.class, Byte::valueOf), Map.entry(Short.class, Short::valueOf),
+          Map.entry(short.class, Short::valueOf), Map.entry(Integer.class, Integer::valueOf),
+          Map.entry(int.class, Integer::valueOf), Map.entry(Long.class, Long::valueOf),
+          Map.entry(long.class, Long::valueOf), Map.entry(Float.class, Float::valueOf),
+          Map.entry(float.class, Float::valueOf), Map.entry(Double.class, Double::valueOf),
+          Map.entry(double.class, Double::valueOf),
+          Map.entry(AtomicInteger.class, s -> new AtomicInteger(Integer.parseInt(s))),
+          Map.entry(AtomicLong.class, s -> new AtomicLong(Long.parseLong(s))),
+          Map.entry(BigDecimal.class, BigDecimal::new),
+          Map.entry(BigInteger.class, BigInteger::new), Map.entry(DoubleAccumulator.class, s -> {
+            DoubleAccumulator accumulator = new DoubleAccumulator((a, b) -> a + b, 0);
+            accumulator.accumulate(Double.parseDouble(s));
+            return accumulator;
+          }), Map.entry(DoubleAdder.class, s -> {
+            DoubleAdder adder = new DoubleAdder();
+            adder.add(Double.parseDouble(s));
+            return adder;
+          }), Map.entry(LongAccumulator.class, s -> {
+            LongAccumulator accumulator = new LongAccumulator((a, b) -> a + b, 0);
+            accumulator.accumulate(Long.parseLong(s));
+            return accumulator;
+          }), Map.entry(LongAdder.class, s -> {
+            LongAdder adder = new LongAdder();
+            adder.add(Long.parseLong(s));
+            return adder;
+          }));
 
   /**
    * Gets the listeners for the given event class.
@@ -148,7 +187,7 @@ public abstract class ElementComposite extends Composite<Element> {
    * Gets a property or an attribute of the element.
    *
    * @param <V> the type of the property
-   * @param the property descriptor
+   * @param property the property descriptor
    * @param fromClient true if the property should be read from the client
    * @param type the type of the property
    *
@@ -363,7 +402,7 @@ public abstract class ElementComposite extends Composite<Element> {
 
     if (value != null) {
       if (isSimpleType(type)) {
-        return (V) value;
+        return convertSimpleAttributeValue(value, type);
       } else {
         Gson gson = new Gson();
         return gson.fromJson(value, type);
@@ -373,6 +412,15 @@ public abstract class ElementComposite extends Composite<Element> {
     }
   }
 
+  @SuppressWarnings("unchecked")
+  private <V> V convertSimpleAttributeValue(String value, Type type) {
+    if (!(type instanceof Class<?> targetType)) {
+      return (V) value;
+    }
+    Function<String, Object> converter = ElementComposite.SIMPLE_CONVERTERS.get(targetType);
+    return (V) (converter != null ? converter.apply(value) : value);
+  }
+
   /**
    * Checks if a given type is a simple type (String, Boolean, or a Number).
    *
@@ -380,8 +428,8 @@ public abstract class ElementComposite extends Composite<Element> {
    * @return true if the type is a simple type, false otherwise
    */
   private boolean isSimpleType(Type type) {
-    return type.equals(String.class) || type.equals(Boolean.class)
-        || Number.class.isAssignableFrom((Class<?>) type);
+    return type instanceof Class<?> targetType
+        && (SIMPLE_CONVERTERS.containsKey(targetType));
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/element/ElementComposite.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/ElementComposite.java
@@ -428,8 +428,7 @@ public abstract class ElementComposite extends Composite<Element> {
    * @return true if the type is a simple type, false otherwise
    */
   private boolean isSimpleType(Type type) {
-    return type instanceof Class<?> targetType
-        && (SIMPLE_CONVERTERS.containsKey(targetType));
+    return type instanceof Class<?> targetType && (SIMPLE_CONVERTERS.containsKey(targetType));
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/element/ElementComposite.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/ElementComposite.java
@@ -20,13 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.DoubleAccumulator;
-import java.util.concurrent.atomic.DoubleAdder;
-import java.util.concurrent.atomic.LongAccumulator;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
 /**
@@ -52,34 +46,11 @@ public abstract class ElementComposite extends Composite<Element> {
       new HashMap<>();
 
   private static final Map<Class<?>, Function<String, Object>> SIMPLE_CONVERTERS =
-      Map.ofEntries(Map.entry(String.class, s -> s), Map.entry(Boolean.class, Boolean::valueOf),
-          Map.entry(boolean.class, Boolean::valueOf), Map.entry(Byte.class, Byte::valueOf),
-          Map.entry(byte.class, Byte::valueOf), Map.entry(Short.class, Short::valueOf),
-          Map.entry(short.class, Short::valueOf), Map.entry(Integer.class, Integer::valueOf),
-          Map.entry(int.class, Integer::valueOf), Map.entry(Long.class, Long::valueOf),
-          Map.entry(long.class, Long::valueOf), Map.entry(Float.class, Float::valueOf),
-          Map.entry(float.class, Float::valueOf), Map.entry(Double.class, Double::valueOf),
-          Map.entry(double.class, Double::valueOf),
-          Map.entry(AtomicInteger.class, s -> new AtomicInteger(Integer.parseInt(s))),
-          Map.entry(AtomicLong.class, s -> new AtomicLong(Long.parseLong(s))),
-          Map.entry(BigDecimal.class, BigDecimal::new),
-          Map.entry(BigInteger.class, BigInteger::new), Map.entry(DoubleAccumulator.class, s -> {
-            DoubleAccumulator accumulator = new DoubleAccumulator((a, b) -> a + b, 0);
-            accumulator.accumulate(Double.parseDouble(s));
-            return accumulator;
-          }), Map.entry(DoubleAdder.class, s -> {
-            DoubleAdder adder = new DoubleAdder();
-            adder.add(Double.parseDouble(s));
-            return adder;
-          }), Map.entry(LongAccumulator.class, s -> {
-            LongAccumulator accumulator = new LongAccumulator((a, b) -> a + b, 0);
-            accumulator.accumulate(Long.parseLong(s));
-            return accumulator;
-          }), Map.entry(LongAdder.class, s -> {
-            LongAdder adder = new LongAdder();
-            adder.add(Long.parseLong(s));
-            return adder;
-          }));
+      Map.ofEntries(Map.entry(String.class, s -> s), Map.entry(Byte.class, Byte::valueOf),
+          Map.entry(Short.class, Short::valueOf), Map.entry(Integer.class, Integer::valueOf),
+          Map.entry(Long.class, Long::valueOf), Map.entry(Float.class, Float::valueOf),
+          Map.entry(Double.class, Double::valueOf), Map.entry(BigDecimal.class, BigDecimal::new),
+          Map.entry(BigInteger.class, BigInteger::new));
 
   /**
    * Gets the listeners for the given event class.
@@ -153,10 +124,18 @@ public abstract class ElementComposite extends Composite<Element> {
       // keep track of the attribute types
       attributeTypes.put(name, value.getClass());
 
+      if (value instanceof Boolean booleanValue) {
+        // Boolean attributes follow the HTML contract: a true value adds the attribute with an
+        // empty string, a false value removes it entirely.
+        writeBooleanAttribute(name, booleanValue);
+
+        return;
+      }
+
       // Attribute values are serialized according to value's current type (regardless of the
       // property's type value):
       //
-      // 1. Strings, Numbers and Booleans No serialization required. The value is converted to a its
+      // 1. Strings and Numbers No serialization required. The value is converted to a its
       // string representation using String.valueOf.
       //
       // 2. Everything else The value is serialized using Gson.
@@ -397,12 +376,16 @@ public abstract class ElementComposite extends Composite<Element> {
    * @return The value of the attribute, or the default value if not set.
    */
   private <V> V getAttributeValue(PropertyDescriptor<V> property, boolean fromClient, Type type) {
+    if (Boolean.class.equals(type)) {
+      return resolveBooleanAttribute(property, fromClient);
+    }
+
     String name = property.getName();
     String value = fromClient ? getElement().getAttribute(name) : attributes.get(name);
 
     if (value != null) {
       if (isSimpleType(type)) {
-        return convertSimpleAttributeValue(value, type);
+        return convertSimpleAttributeValue(property, value, type);
       } else {
         Gson gson = new Gson();
         return gson.fromJson(value, type);
@@ -412,23 +395,102 @@ public abstract class ElementComposite extends Composite<Element> {
     }
   }
 
+  /**
+   * Converts a simple attribute string value to the declared attribute type.
+   *
+   * @param <V> the type of the attribute
+   * @param property the property descriptor
+   * @param value the raw attribute value
+   * @param type the declared type of the attribute
+   *
+   * @return the converted value, or the descriptor default value when the value cannot be parsed as
+   *         the declared type
+   */
   @SuppressWarnings("unchecked")
-  private <V> V convertSimpleAttributeValue(String value, Type type) {
+  private <V> V convertSimpleAttributeValue(PropertyDescriptor<V> property, String value,
+      Type type) {
     if (!(type instanceof Class<?> targetType)) {
       return (V) value;
     }
-    Function<String, Object> converter = ElementComposite.SIMPLE_CONVERTERS.get(targetType);
-    return (V) (converter != null ? converter.apply(value) : value);
+
+    Function<String, Object> converter = SIMPLE_CONVERTERS.get(targetType);
+    if (converter == null) {
+      return (V) value;
+    }
+
+    try {
+      return (V) converter.apply(value);
+    } catch (NumberFormatException e) {
+      return property.getDefaultValue();
+    }
   }
 
   /**
-   * Checks if a given type is a simple type (String, Boolean, or a Number).
+   * Writes a {@link Boolean} attribute following the HTML boolean attribute contract.
+   *
+   * <p>
+   * A {@code true} value adds the attribute with an empty string, while a {@code false} value
+   * removes the attribute entirely.
+   * </p>
+   *
+   * @see <a href="https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML">MDN Boolean
+   *      attribute</a>
+   *
+   * @param name the attribute name
+   * @param value the boolean value
+   */
+  private void writeBooleanAttribute(String name, boolean value) {
+    if (value) {
+      getElement().setAttribute(name, "");
+      attributes.put(name, "");
+    } else {
+      getElement().removeAttribute(name);
+      attributes.remove(name);
+    }
+  }
+
+  /**
+   * Resolves a {@link Boolean} attribute.
+   *
+   * <p>
+   * An absent attribute reads as {@code false} and a present attribute reads as {@code true},
+   * following the HTML boolean attribute rule. As the single exception, a present attribute whose
+   * value is the literal string {@code "false"} reads as {@code false}, so a component that
+   * reflects a false value as that string is honored rather than read as present.
+   * </p>
+   *
+   * @see <a href="https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML">MDN Boolean
+   *      attribute</a>
+   *
+   * @param <V> the type of the attribute
+   * @param property the property descriptor
+   * @param fromClient true if the attribute should be read from the client
+   *
+   * @return the resolved boolean value
+   */
+  @SuppressWarnings("unchecked")
+  private <V> V resolveBooleanAttribute(PropertyDescriptor<V> property, boolean fromClient) {
+    String name = property.getName();
+    boolean present = fromClient ? getElement().hasAttribute(name) : attributes.containsKey(name);
+
+    if (!present) {
+      return (V) Boolean.FALSE;
+    }
+
+    String value = fromClient ? getElement().getAttribute(name) : attributes.get(name);
+
+    return (V) Boolean.valueOf(!"false".equals(value));
+  }
+
+  /**
+   * Checks if a given type is a simple type. Simple types are String, Byte, Short, Integer, Long,
+   * Float, Double, BigDecimal and BigInteger.
    *
    * @param type the type to check
    * @return true if the type is a simple type, false otherwise
    */
   private boolean isSimpleType(Type type) {
-    return type instanceof Class<?> targetType && (SIMPLE_CONVERTERS.containsKey(targetType));
+    return type instanceof Class<?> targetType && SIMPLE_CONVERTERS.containsKey(targetType);
   }
 
   /**

--- a/webforj-foundation/src/test/java/com/webforj/component/element/ElementCompositeTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/ElementCompositeTest.java
@@ -23,8 +23,16 @@ import com.webforj.conceiver.DefaultConceiver;
 import com.webforj.dispatcher.EventDispatcher;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.DoubleAccumulator;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -132,16 +140,6 @@ class ElementCompositeTest {
       assertEquals(johnDoe, composite.get(attr, true));
     }
 
-    @ParameterizedTest
-    @MethodSource("primitivePropertyProvider")
-    @DisplayName("should get primitive properties and attributes without adding a Type")
-    void shouldGetPrimitivePropertiesAndAttributes(PropertyDescriptor<?> prop, Object defaultValue,
-        Object expectedValue) {
-      composite.set(prop);
-      Object result = composite.get(prop);
-      assertEquals(expectedValue, result);
-    }
-
     static Stream<Arguments> primitivePropertyProvider() {
       return Stream.of(
           // PropertyDescriptor.property cases
@@ -155,6 +153,104 @@ class ElementCompositeTest {
           Arguments.of(PropertyDescriptor.attribute("doubleAttribute", "2.718"), "0.0", "2.718"),
           Arguments.of(PropertyDescriptor.attribute("booleanAttribute", "false"), "true", "false"),
           Arguments.of(PropertyDescriptor.attribute("stringAttribute", "World"), null, "World"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("primitivePropertyProvider")
+    @DisplayName("should get primitive properties and attributes without adding a Type")
+    void shouldGetPrimitivePropertiesAndAttributes(PropertyDescriptor<?> prop, Object defaultValue,
+        Object expectedValue) {
+      composite.set(prop);
+      Object result = composite.get(prop);
+      assertEquals(expectedValue, result);
+    }
+
+    static Stream<Arguments> simpleAttributeConversionProvider() {
+      return Stream.of(
+          Arguments.of(PropertyDescriptor.attribute("stringAttr", "hello"), "hello", String.class),
+          Arguments.of(PropertyDescriptor.attribute("booleanAttr", true), true, Boolean.class),
+          Arguments.of(PropertyDescriptor.attribute("byteAttr", (byte) 5), (byte) 5, Byte.class),
+          Arguments.of(PropertyDescriptor.attribute("shortAttr", (short) 42), (short) 42,
+              Short.class),
+          Arguments.of(PropertyDescriptor.attribute("intAttr", 100), 100, Integer.class),
+          Arguments.of(PropertyDescriptor.attribute("longAttr", 9_000_000_000L), 9_000_000_000L,
+              Long.class),
+          Arguments.of(PropertyDescriptor.attribute("floatAttr", 3.14f), 3.14f, Float.class),
+          Arguments.of(PropertyDescriptor.attribute("doubleAttr", 2.718d), 2.718d, Double.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("simpleAttributeConversionProvider")
+    @DisplayName("should convert simple attribute string values back to their declared type")
+    void shouldConvertSimpleAttributeValues(PropertyDescriptor<?> attribute, Object expectedValue,
+        Class<?> expectedType) {
+      composite.set(attribute);
+
+      Object result = composite.get(attribute);
+
+      assertEquals(expectedValue, result);
+      assertEquals(expectedType, result.getClass());
+    }
+
+    static Stream<Arguments> numberProvider() {
+      return Stream.of(
+          Arguments.of(PropertyDescriptor.attribute("atomicInteger", new AtomicInteger(42)),
+              new AtomicInteger(42), AtomicInteger.class),
+          Arguments.of(PropertyDescriptor.attribute("atomicLong", new AtomicLong(123L)),
+              new AtomicLong(123L), AtomicLong.class),
+          Arguments.of(PropertyDescriptor.attribute("bigDecimal", new BigDecimal("123.456")),
+              new BigDecimal("123.456"), BigDecimal.class),
+          Arguments.of(PropertyDescriptor.attribute("bigInteger", new BigInteger("123456789")),
+              new BigInteger("123456789"), BigInteger.class),
+          Arguments.of(
+              PropertyDescriptor.attribute("doubleAccumulator",
+                  new DoubleAccumulator(Double::sum, 1.1)),
+              new DoubleAccumulator(Double::sum, 1.1), DoubleAccumulator.class),
+          Arguments.of(PropertyDescriptor.attribute("doubleAdder", new DoubleAdder()),
+              new DoubleAdder(), DoubleAdder.class),
+          Arguments.of(
+              PropertyDescriptor.attribute("longAccumulator", new LongAccumulator(Long::sum, 10L)),
+              new LongAccumulator(Long::sum, 10L), LongAccumulator.class),
+          Arguments.of(PropertyDescriptor.attribute("longAdder", new LongAdder()), new LongAdder(),
+              LongAdder.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("numberProvider")
+    void shouldHandleExtendedNumberTypesAsAttributes(PropertyDescriptor<?> attribute,
+        Object expectedValue, Class<?> expectedType) {
+      composite.set(attribute);
+      Object result = composite.get(attribute);
+
+      assertEquals(expectedType, result.getClass());
+      if (result instanceof AtomicInteger) {
+        assertEquals(((AtomicInteger) expectedValue).get(), ((AtomicInteger) result).get());
+      } else if (result instanceof AtomicLong) {
+        assertEquals(((AtomicLong) expectedValue).get(), ((AtomicLong) result).get());
+      } else if (result instanceof DoubleAccumulator) {
+        assertEquals(((DoubleAccumulator) expectedValue).get(), ((DoubleAccumulator) result).get());
+      } else if (result instanceof DoubleAdder) {
+        assertEquals(((DoubleAdder) expectedValue).sum(), ((DoubleAdder) result).sum());
+      } else if (result instanceof LongAccumulator) {
+        assertEquals(((LongAccumulator) expectedValue).get(), ((LongAccumulator) result).get());
+      } else if (result instanceof LongAdder) {
+        assertEquals(((LongAdder) expectedValue).sum(), ((LongAdder) result).sum());
+      } else {
+        assertEquals(expectedValue, result);
+      }
+    }
+
+    @ParameterizedTest
+    @MethodSource("numberProvider")
+    void shouldHandleExtendedNumberTypesAsProperties(PropertyDescriptor<?> property,
+        Object expectedValue, Class<?> expectedType) {
+      PropertyDescriptor<Object> prop =
+          PropertyDescriptor.property(property.getName(), expectedValue);
+      composite.set(prop, expectedValue);
+      Object result = composite.get(prop);
+
+      assertEquals(expectedValue, result);
+      assertEquals(expectedType, result.getClass());
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/component/element/ElementCompositeTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/ElementCompositeTest.java
@@ -1,8 +1,10 @@
 package com.webforj.component.element;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,12 +29,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.DoubleAccumulator;
-import java.util.concurrent.atomic.DoubleAdder;
-import java.util.concurrent.atomic.LongAccumulator;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +54,7 @@ class ElementCompositeTest {
   class PropertiesApi {
 
     class User {
+
       private String fname;
       private String lname;
 
@@ -140,6 +137,16 @@ class ElementCompositeTest {
       assertEquals(johnDoe, composite.get(attr, true));
     }
 
+    @ParameterizedTest
+    @MethodSource("primitivePropertyProvider")
+    @DisplayName("should get primitive properties and attributes without adding a Type")
+    void shouldGetPrimitivePropertiesAndAttributes(PropertyDescriptor<?> prop, Object defaultValue,
+        Object expectedValue) {
+      composite.set(prop);
+      Object result = composite.get(prop);
+      assertEquals(expectedValue, result);
+    }
+
     static Stream<Arguments> primitivePropertyProvider() {
       return Stream.of(
           // PropertyDescriptor.property cases
@@ -156,13 +163,16 @@ class ElementCompositeTest {
     }
 
     @ParameterizedTest
-    @MethodSource("primitivePropertyProvider")
-    @DisplayName("should get primitive properties and attributes without adding a Type")
-    void shouldGetPrimitivePropertiesAndAttributes(PropertyDescriptor<?> prop, Object defaultValue,
-        Object expectedValue) {
-      composite.set(prop);
-      Object result = composite.get(prop);
+    @MethodSource("simpleAttributeConversionProvider")
+    @DisplayName("should convert simple attribute string values back to their declared type")
+    void shouldConvertSimpleAttributeValues(PropertyDescriptor<?> attribute, Object expectedValue,
+        Class<?> expectedType) {
+      composite.set(attribute);
+
+      Object result = composite.get(attribute);
+
       assertEquals(expectedValue, result);
+      assertEquals(expectedType, result.getClass());
     }
 
     static Stream<Arguments> simpleAttributeConversionProvider() {
@@ -176,81 +186,70 @@ class ElementCompositeTest {
           Arguments.of(PropertyDescriptor.attribute("longAttr", 9_000_000_000L), 9_000_000_000L,
               Long.class),
           Arguments.of(PropertyDescriptor.attribute("floatAttr", 3.14f), 3.14f, Float.class),
-          Arguments.of(PropertyDescriptor.attribute("doubleAttr", 2.718d), 2.718d, Double.class));
-    }
-
-    @ParameterizedTest
-    @MethodSource("simpleAttributeConversionProvider")
-    @DisplayName("should convert simple attribute string values back to their declared type")
-    void shouldConvertSimpleAttributeValues(PropertyDescriptor<?> attribute, Object expectedValue,
-        Class<?> expectedType) {
-      composite.set(attribute);
-
-      Object result = composite.get(attribute);
-
-      assertEquals(expectedValue, result);
-      assertEquals(expectedType, result.getClass());
-    }
-
-    static Stream<Arguments> numberProvider() {
-      return Stream.of(
-          Arguments.of(PropertyDescriptor.attribute("atomicInteger", new AtomicInteger(42)),
-              new AtomicInteger(42), AtomicInteger.class),
-          Arguments.of(PropertyDescriptor.attribute("atomicLong", new AtomicLong(123L)),
-              new AtomicLong(123L), AtomicLong.class),
-          Arguments.of(PropertyDescriptor.attribute("bigDecimal", new BigDecimal("123.456")),
+          Arguments.of(PropertyDescriptor.attribute("doubleAttr", 2.718d), 2.718d, Double.class),
+          Arguments.of(PropertyDescriptor.attribute("bigDecimalAttr", new BigDecimal("123.456")),
               new BigDecimal("123.456"), BigDecimal.class),
-          Arguments.of(PropertyDescriptor.attribute("bigInteger", new BigInteger("123456789")),
-              new BigInteger("123456789"), BigInteger.class),
-          Arguments.of(
-              PropertyDescriptor.attribute("doubleAccumulator",
-                  new DoubleAccumulator(Double::sum, 1.1)),
-              new DoubleAccumulator(Double::sum, 1.1), DoubleAccumulator.class),
-          Arguments.of(PropertyDescriptor.attribute("doubleAdder", new DoubleAdder()),
-              new DoubleAdder(), DoubleAdder.class),
-          Arguments.of(
-              PropertyDescriptor.attribute("longAccumulator", new LongAccumulator(Long::sum, 10L)),
-              new LongAccumulator(Long::sum, 10L), LongAccumulator.class),
-          Arguments.of(PropertyDescriptor.attribute("longAdder", new LongAdder()), new LongAdder(),
-              LongAdder.class));
+          Arguments.of(PropertyDescriptor.attribute("bigIntegerAttr", new BigInteger("123456789")),
+              new BigInteger("123456789"), BigInteger.class));
     }
 
-    @ParameterizedTest
-    @MethodSource("numberProvider")
-    void shouldHandleExtendedNumberTypesAsAttributes(PropertyDescriptor<?> attribute,
-        Object expectedValue, Class<?> expectedType) {
-      composite.set(attribute);
-      Object result = composite.get(attribute);
+    @Test
+    @DisplayName("should convert simple attribute values read from the client")
+    void shouldConvertSimpleAttributeValuesFromClient() {
+      PropertyDescriptor<Integer> attr = PropertyDescriptor.attribute("count", 0);
+      composite.set(attr, 42);
 
-      assertEquals(expectedType, result.getClass());
-      if (result instanceof AtomicInteger) {
-        assertEquals(((AtomicInteger) expectedValue).get(), ((AtomicInteger) result).get());
-      } else if (result instanceof AtomicLong) {
-        assertEquals(((AtomicLong) expectedValue).get(), ((AtomicLong) result).get());
-      } else if (result instanceof DoubleAccumulator) {
-        assertEquals(((DoubleAccumulator) expectedValue).get(), ((DoubleAccumulator) result).get());
-      } else if (result instanceof DoubleAdder) {
-        assertEquals(((DoubleAdder) expectedValue).sum(), ((DoubleAdder) result).sum());
-      } else if (result instanceof LongAccumulator) {
-        assertEquals(((LongAccumulator) expectedValue).get(), ((LongAccumulator) result).get());
-      } else if (result instanceof LongAdder) {
-        assertEquals(((LongAdder) expectedValue).sum(), ((LongAdder) result).sum());
-      } else {
-        assertEquals(expectedValue, result);
-      }
+      assertEquals(42, composite.get(attr, true));
     }
 
-    @ParameterizedTest
-    @MethodSource("numberProvider")
-    void shouldHandleExtendedNumberTypesAsProperties(PropertyDescriptor<?> property,
-        Object expectedValue, Class<?> expectedType) {
-      PropertyDescriptor<Object> prop =
-          PropertyDescriptor.property(property.getName(), expectedValue);
-      composite.set(prop, expectedValue);
-      Object result = composite.get(prop);
+    @Test
+    @DisplayName("should read a present boolean attribute as true regardless of its value")
+    void shouldReadPresentBooleanAttributeAsTrue() {
+      PropertyDescriptor<Boolean> attr = PropertyDescriptor.attribute("disabled", false);
+      composite.getElement().setAttribute("disabled", "");
 
-      assertEquals(expectedValue, result);
-      assertEquals(expectedType, result.getClass());
+      assertTrue(composite.get(attr, true));
+    }
+
+    @Test
+    @DisplayName("should read an absent boolean attribute as false")
+    void shouldReadAbsentBooleanAttributeAsFalse() {
+      PropertyDescriptor<Boolean> attr = PropertyDescriptor.attribute("disabled", false);
+
+      assertFalse(composite.get(attr, true));
+    }
+
+    @Test
+    @DisplayName("should read a present boolean attribute with a \"false\" value as false")
+    void shouldReadFalseStringBooleanAttributeAsFalse() {
+      PropertyDescriptor<Boolean> attr = PropertyDescriptor.attribute("disabled", false);
+      composite.getElement().setAttribute("disabled", "false");
+
+      assertFalse(composite.get(attr, true));
+    }
+
+    @Test
+    @DisplayName("should add the attribute for a true value and remove it for a false value")
+    void shouldWriteBooleanAttributeByPresence() {
+      PropertyDescriptor<Boolean> attr = PropertyDescriptor.attribute("disabled", false);
+
+      composite.set(attr, true);
+      assertTrue(composite.getElement().hasAttribute("disabled"));
+      assertTrue(composite.get(attr));
+
+      composite.set(attr, false);
+      assertFalse(composite.getElement().hasAttribute("disabled"));
+      assertFalse(composite.get(attr));
+    }
+
+    @Test
+    @DisplayName("should return the default value when the client value cannot be parsed")
+    void shouldFallBackToDefaultWhenClientValueIsNotParseable() {
+      PropertyDescriptor<Integer> attr = PropertyDescriptor.attribute("count", 7);
+      composite.set(attr, 100);
+      composite.getElement().setAttribute("count", "abc");
+
+      assertEquals(7, composite.get(attr, true));
     }
   }
 
@@ -260,6 +259,7 @@ class ElementCompositeTest {
 
     @EventName("click")
     static class ClickEvent extends ComponentEvent<ElementCompositeMock> {
+
       public ClickEvent(ElementCompositeMock component, Map<String, Object> eventMap) {
         super(component, eventMap);
       }
@@ -270,6 +270,7 @@ class ElementCompositeTest {
     void shouldThrowExceptionIfEventIsMapped() {
       @EventName("click")
       class ClickEvent2 extends ComponentEvent<ElementCompositeMock> {
+
         public ClickEvent2(ElementCompositeMock component, Map<String, Object> eventMap) {
           super(component, eventMap);
         }
@@ -344,6 +345,5 @@ class ElementCompositeTest {
       listenerRegistration.remove();
       verify(elementRegistration, times(1)).remove();
     }
-
   }
 }


### PR DESCRIPTION
Conversion includes all Number types and simple types