### PR TITLE
feat: add hasAttribute method to HasAttribute concern

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/DwcComponent.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/DwcComponent.java
@@ -324,6 +324,22 @@ public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
    * {@inheritDoc}
    */
   @Override
+  public boolean hasAttribute(String attribute) {
+    if (control != null) {
+      try {
+        return control.hasAttribute(attribute);
+      } catch (BBjException e) {
+        throw new WebforjRuntimeException(e);
+      }
+    }
+
+    return attributes.containsKey(attribute);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public T removeAttribute(String attribute) {
     if (control != null) {
       try {

--- a/webforj-foundation/src/main/java/com/webforj/concern/HasAttribute.java
+++ b/webforj-foundation/src/main/java/com/webforj/concern/HasAttribute.java
@@ -21,6 +21,12 @@ public interface HasAttribute<T extends Component> {
   /**
    * Retrieves the value of a specified attribute.
    *
+   * <p>
+   * This method may return a value even when the attribute is not present, so a {@code null} check
+   * is not a reliable way to detect a missing attribute. Use {@link #hasAttribute(String)} to test
+   * whether an attribute is present.
+   * </p>
+   *
    * @param attribute the name of the attribute to retrieve
    * @return the value of the attribute
    */
@@ -48,6 +54,24 @@ public interface HasAttribute<T extends Component> {
     if (component instanceof HasAttribute) {
       ((HasAttribute<?>) component).setAttribute(attribute, value);
       return (T) this;
+    }
+
+    throw new UnsupportedOperationException("The component does not support attributes");
+  }
+
+  /**
+   * Checks whether the component has the specified attribute.
+   *
+   * @param attribute the name of the attribute to check
+   * @return {@code true} if the component has the attribute, {@code false} otherwise
+   *
+   * @since 26.02
+   */
+  public default boolean hasAttribute(String attribute) {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasAttribute) {
+      return ((HasAttribute<?>) component).hasAttribute(attribute);
     }
 
     throw new UnsupportedOperationException("The component does not support attributes");

--- a/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/DwcComponentTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -243,6 +244,38 @@ class DwcComponentTest {
         assertThrows(WebforjRestrictedAccessException.class,
             () -> component.setAttribute(restrictedAttribute, "value"));
       }
+    }
+
+    @Test
+    @DisplayName("hasAttribute when control is null")
+    void hasAttributeWhenControlIsNull() throws IllegalAccessException, BBjException {
+      ReflectionUtils.nullifyControl(component);
+
+      assertFalse(component.hasAttribute("key"));
+      component.setAttribute("key", "value");
+      assertTrue(component.hasAttribute("key"));
+
+      verify(control, times(0)).hasAttribute("key");
+    }
+
+    @Test
+    @DisplayName("hasAttribute when control is not null")
+    void hasAttributeWhenControlIsNotNull() throws BBjException {
+      doReturn(true).when(control).hasAttribute("key");
+
+      assertTrue(component.hasAttribute("key"));
+
+      verify(control, times(1)).hasAttribute("key");
+    }
+
+    @Test
+    @DisplayName("""
+        hasAttribute when control throws
+        BBjException a DwcjRuntimeException is thrown
+        """)
+    void hasAttributeWhenControlThrowsBbjException() throws BBjException {
+      doThrow(BBjException.class).when(control).hasAttribute("key");
+      assertThrows(WebforjRuntimeException.class, () -> component.hasAttribute("key"));
     }
 
     @Test

--- a/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
@@ -87,6 +87,11 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
   }
 
   @Override
+  public boolean hasAttribute(String attribute) {
+    return attributes.containsKey(attribute);
+  }
+
+  @Override
   public ConcernComponentMock removeAttribute(String attribute) {
     attributes.remove(attribute);
     return this;

--- a/webforj-foundation/src/test/java/com/webforj/concern/HasAttributeTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/HasAttributeTest.java
@@ -1,8 +1,10 @@
 package com.webforj.concern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.webforj.component.Composite;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +23,17 @@ class HasAttributeTest {
   void shouldSetGetAttribute() {
     assertSame(component.setAttribute("name", "value"), component);
     assertEquals("value", component.getAttribute("name"));
+  }
+
+  @Test
+  void shouldReportWhetherAttributeExists() {
+    assertFalse(component.hasAttribute("name"));
+
+    component.setAttribute("name", "value");
+    assertTrue(component.hasAttribute("name"));
+
+    component.removeAttribute("name");
+    assertFalse(component.hasAttribute("name"));
   }
 
   @Test


### PR DESCRIPTION
Add a `hasAttribute(String)` method to the `HasAttribute` interface and implement it in DwcComponent, so components can test whether an attribute is present.