### PR TITLE
feat: synchronize element properties and attributes with the client

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/element/ElementComposite.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/ElementComposite.java
@@ -4,21 +4,26 @@ import com.google.gson.Gson;
 import com.webforj.component.Composite;
 import com.webforj.component.element.annotation.ElementAnnotationProcessor;
 import com.webforj.component.element.annotation.EventName;
+import com.webforj.component.element.annotation.Synchronize;
 import com.webforj.component.element.event.ElementEvent;
 import com.webforj.component.element.event.ElementEventOptions;
 import com.webforj.component.event.ComponentEvent;
+import com.webforj.component.window.Window;
 import com.webforj.conceiver.Conceiver;
 import com.webforj.conceiver.ConceiverProvider;
 import com.webforj.dispatcher.EventDispatcher;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.exceptions.WebforjRuntimeException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -44,6 +49,7 @@ public abstract class ElementComposite extends Composite<Element> {
   private final HashMap<String, Class<?>> eventNameToClassMap = new HashMap<>();
   private final Map<ListenerRegistration<ElementEvent>, EventListener<? extends ComponentEvent<?>>> listenerRegistrations =
       new HashMap<>();
+  private boolean synchronizeAnnotationsRegistered = false;
 
   private static final Map<Class<?>, Function<String, Object>> SIMPLE_CONVERTERS =
       Map.ofEntries(Map.entry(String.class, s -> s), Map.entry(Byte.class, Byte::valueOf),
@@ -51,6 +57,17 @@ public abstract class ElementComposite extends Composite<Element> {
           Map.entry(Long.class, Long::valueOf), Map.entry(Float.class, Float::valueOf),
           Map.entry(Double.class, Double::valueOf), Map.entry(BigDecimal.class, BigDecimal::new),
           Map.entry(BigInteger.class, BigInteger::new));
+
+  private static final ClassValue<SynchronizeFields> SYNCHRONIZE_FIELDS = new ClassValue<>() {
+    @Override
+    protected SynchronizeFields computeValue(Class<?> type) {
+      try {
+        return new SynchronizeFields(scanSynchronizeFields(type), null);
+      } catch (WebforjRuntimeException e) {
+        return new SynchronizeFields(null, e);
+      }
+    }
+  };
 
   /**
    * Gets the listeners for the given event class.
@@ -132,21 +149,7 @@ public abstract class ElementComposite extends Composite<Element> {
         return;
       }
 
-      // Attribute values are serialized according to value's current type (regardless of the
-      // property's type value):
-      //
-      // 1. Strings and Numbers No serialization required. The value is converted to a its
-      // string representation using String.valueOf.
-      //
-      // 2. Everything else The value is serialized using Gson.
-      String serializedValue;
-      if (isSimpleType(value.getClass())) {
-        serializedValue = String.valueOf(value);
-      } else {
-        Gson gson = new Gson();
-        serializedValue = gson.toJson(value);
-      }
-
+      String serializedValue = serializeAttributeValue(value);
       getElement().setAttribute(name, serializedValue);
       attributes.put(name, serializedValue);
     }
@@ -218,12 +221,118 @@ public abstract class ElementComposite extends Composite<Element> {
   }
 
   /**
+   * Keeps the given property or attribute in sync with the client.
+   *
+   * <p>
+   * When the given client event fires, the current value of the property or attribute is read on
+   * the client and sent to the server with the event payload. The reported value is stored in the
+   * server cache so that {@link #get(PropertyDescriptor)} returns the value the client last
+   * reported instead of the value the server last wrote.
+   * </p>
+   *
+   * <p>
+   * The method is shorthand for adding a listener for the client event and updating the property or
+   * attribute from the reported value in the listener.
+   * </p>
+   *
+   * <p>
+   * Synchronization is not required to read the current client value on demand.
+   * {@link #get(PropertyDescriptor, boolean)} reads the value live from the client when its
+   * {@code fromClient} argument is {@code true}. Synchronization is for components that report a
+   * value change only through an event, where the reported value rides the event payload rather
+   * than a property or attribute the server can read back.
+   * </p>
+   *
+   * @param <V> the type of the property
+   * @param property the property descriptor
+   * @param event the name of the client event which reports the value
+   *
+   * @return a listener registration for removing the synchronization
+   * @throws NullPointerException if the property or the event is null
+   *
+   * @since 26.02
+   * @see Synchronize
+   */
+  protected <V> ListenerRegistration<ElementEvent> synchronize(PropertyDescriptor<V> property,
+      String event) {
+    return synchronize(property, event, "");
+  }
+
+  /**
+   * Keeps the given property or attribute in sync with the client.
+   *
+   * <p>
+   * When the given client event fires, the value is read from the given client expression, for
+   * example {@code event.detail}, sent to the server with the event payload, and written back to
+   * the element. Use this form when the element does not maintain the value itself. The reported
+   * value is stored in the server cache so that {@link #get(PropertyDescriptor)} returns the value
+   * the client last reported instead of the value the server last wrote.
+   * </p>
+   *
+   * <p>
+   * The method is shorthand for adding a listener for the client event and updating the property or
+   * attribute from the reported value in the listener.
+   * </p>
+   *
+   * <p>
+   * Synchronization is not required to read the current client value on demand.
+   * {@link #get(PropertyDescriptor, boolean)} reads the value live from the client when its
+   * {@code fromClient} argument is {@code true}. Synchronization is for components that report a
+   * value change only through an event, where the reported value rides the event payload rather
+   * than a property or attribute the server can read back.
+   * </p>
+   *
+   * @param <V> the type of the property
+   * @param property the property descriptor
+   * @param event the name of the client event which reports the value
+   * @param expression the client expression which produces the value when the event fires
+   *
+   * @return a listener registration for removing the synchronization
+   * @throws NullPointerException if the property or the event is null
+   *
+   * @since 26.02
+   * @see Synchronize
+   */
+  protected <V> ListenerRegistration<ElementEvent> synchronize(PropertyDescriptor<V> property,
+      String event, String expression) {
+    Objects.requireNonNull(property, "The PropertyDescriptor cannot be null");
+    Objects.requireNonNull(event, "The event name cannot be null");
+
+    String name = property.getName();
+    boolean isAttribute = property.isAttribute();
+    String valueExpression = expression == null ? "" : expression.trim();
+    ElementEventOptions options = new ElementEventOptions();
+
+    if (valueExpression.isEmpty()) {
+      options.addData(name,
+          isAttribute ? "component.getAttribute('" + name + "')" : "component['" + name + "']");
+    } else {
+      options.addData(name, valueExpression);
+      options
+          .setCode(isAttribute ? "component.setAttribute('" + name + "', " + valueExpression + ");"
+              : "component['" + name + "'] = " + valueExpression + ";");
+    }
+
+    return getElement().addEventListener(event,
+        elementEvent -> handleSynchronizeEvent(property, elementEvent), options, false);
+  }
+
+  /**
    * Gets the event dispatcher.
    *
    * @return the event dispatcher
    */
   protected EventDispatcher getEventDispatcher() {
     return dispatcher;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void onCreate(Window window) {
+    registerSynchronizeAnnotations();
+    super.onCreate(window);
   }
 
   /**
@@ -483,6 +592,30 @@ public abstract class ElementComposite extends Composite<Element> {
   }
 
   /**
+   * Serializes the given value to the string form stored in the attributes cache and sent to the
+   * client.
+   *
+   * <p>
+   * Attribute values are serialized according to the value's current type. Simple types are
+   * converted to their string representation using {@code String.valueOf}. Everything else is
+   * serialized using Gson.
+   * </p>
+   *
+   * @param value the value to serialize
+   *
+   * @return the serialized value
+   */
+  private String serializeAttributeValue(Object value) {
+    if (isSimpleType(value.getClass())) {
+      return String.valueOf(value);
+    }
+
+    Gson gson = new Gson();
+
+    return gson.toJson(value);
+  }
+
+  /**
    * Checks if a given type is a simple type. Simple types are String, Byte, Short, Integer, Long,
    * Float, Double, BigDecimal and BigInteger.
    *
@@ -492,6 +625,193 @@ public abstract class ElementComposite extends Composite<Element> {
   private boolean isSimpleType(Type type) {
     return type instanceof Class<?> targetType && SIMPLE_CONVERTERS.containsKey(targetType);
   }
+
+  /**
+   * Handles a client event which reports the value of a synchronized property or attribute and
+   * stores the reported value in the server cache.
+   *
+   * @param <V> the type of the property
+   * @param property the property descriptor
+   * @param event the element event carrying the reported value
+   */
+  <V> void handleSynchronizeEvent(PropertyDescriptor<V> property, ElementEvent event) {
+    String name = property.getName();
+    Map<String, Object> eventMap = event.getEventMap();
+    if (!eventMap.containsKey(name)) {
+      return;
+    }
+
+    Object raw = eventMap.get(name);
+    if (property.isAttribute()) {
+      if (raw == null) {
+        attributes.remove(name);
+      } else {
+        attributes.put(name, serializeAttributeValue(raw));
+      }
+    } else {
+      Object value = convertClientValue(raw, property.getType());
+      properties.put(name, value);
+
+      if (value != null) {
+        propertyTypes.put(name, value.getClass());
+      }
+    }
+  }
+
+  /**
+   * Converts a value reported by the client to the given type.
+   *
+   * @param raw the reported value
+   * @param type the target type
+   *
+   * @return the converted value
+   */
+  private Object convertClientValue(Object raw, Type type) {
+    if (raw == null) {
+      return null;
+    }
+
+    if (type instanceof Class<?> targetType && targetType.isInstance(raw)) {
+      return raw;
+    }
+
+    Gson gson = new Gson();
+    if (raw instanceof String json && !String.class.equals(type)) {
+      return gson.fromJson(json, type);
+    }
+
+    return gson.fromJson(gson.toJsonTree(raw), type);
+  }
+
+  /**
+   * Registers the synchronizations declared with the {@link Synchronize} annotation on the
+   * {@code PropertyDescriptor} fields of the class hierarchy.
+   */
+  private void registerSynchronizeAnnotations() {
+    if (synchronizeAnnotationsRegistered) {
+      return;
+    }
+
+    synchronizeAnnotationsRegistered = true;
+
+    for (SynchronizeField synchronizeField : getSynchronizeFields(getClass())) {
+      PropertyDescriptor<?> descriptor = readSynchronizeField(synchronizeField.field());
+      for (String event : synchronizeField.events()) {
+        synchronize(descriptor, event, synchronizeField.exp());
+      }
+    }
+  }
+
+  /**
+   * Returns the {@code @Synchronize} annotated fields of the given class hierarchy.
+   *
+   * <p>
+   * The scan is performed once per class and cached in a {@link ClassValue}, so the reflection cost
+   * is paid once per class rather than once per instance. The cache entry is tied to the class and
+   * collected with it, so it does not leak across a hot redeploy. The reported values are read from
+   * the instance separately, since they are instance state.
+   * </p>
+   *
+   * @param composite the composite class
+   *
+   * @return the annotated fields
+   */
+  private static List<SynchronizeField> getSynchronizeFields(Class<?> composite) {
+    SynchronizeFields entry = SYNCHRONIZE_FIELDS.get(composite);
+    if (entry.error() != null) {
+      throw entry.error();
+    }
+
+    return entry.fields();
+  }
+
+  /**
+   * Scans the given class hierarchy for {@code @Synchronize} annotated {@code PropertyDescriptor}
+   * fields.
+   *
+   * @param composite the composite class
+   *
+   * @return the annotated fields
+   * @throws WebforjRuntimeException if an annotated field is not a PropertyDescriptor or declares
+   *         no events
+   */
+  private static List<SynchronizeField> scanSynchronizeFields(Class<?> composite) {
+    List<SynchronizeField> fields = new ArrayList<>();
+    Class<?> clazz = composite;
+
+    while (clazz != null && !ElementComposite.class.equals(clazz)) {
+      for (Field field : clazz.getDeclaredFields()) {
+        Synchronize synchronize = field.getAnnotation(Synchronize.class);
+        if (synchronize == null) {
+          continue;
+        }
+
+        if (!PropertyDescriptor.class.isAssignableFrom(field.getType())) {
+          throw new WebforjRuntimeException(
+              "The field '" + field.getName() + "' in class '" + clazz.getName()
+                  + "' is annotated with @Synchronize but is not a PropertyDescriptor");
+        }
+
+        String[] events = synchronize.value();
+        if (events.length == 0) {
+          throw new WebforjRuntimeException("The field '" + field.getName() + "' in class '"
+              + clazz.getName() + "' is annotated with @Synchronize but declares no events");
+        }
+
+        field.setAccessible(true); // NOSONAR
+        fields.add(new SynchronizeField(field, List.of(events), synchronize.exp()));
+      }
+
+      clazz = clazz.getSuperclass();
+    }
+
+    return fields;
+  }
+
+  /**
+   * Reads the {@code PropertyDescriptor} value of the given annotated field.
+   *
+   * @param field the annotated field
+   *
+   * @return the property descriptor
+   * @throws WebforjRuntimeException if the field cannot be read or its value is null
+   */
+  private PropertyDescriptor<?> readSynchronizeField(Field field) {
+    try {
+      PropertyDescriptor<?> descriptor = (PropertyDescriptor<?>) field.get(this);
+
+      if (descriptor == null) {
+        throw new WebforjRuntimeException(
+            "The field '" + field.getName() + "' in class '" + field.getDeclaringClass().getName()
+                + "' is annotated with @Synchronize but its value is null");
+      }
+
+      return descriptor;
+    } catch (IllegalAccessException e) {
+      throw new WebforjRuntimeException("Failed to read the @Synchronize field '" + field.getName()
+          + "' in class '" + field.getDeclaringClass().getName() + "'", e);
+    }
+  }
+
+  /**
+   * A {@code @Synchronize} annotated {@code PropertyDescriptor} field with its declared events and
+   * expression.
+   *
+   * @param field the annotated field
+   * @param events the client events which report the value
+   * @param exp the client expression which produces the value
+   */
+  private static final record SynchronizeField(Field field, List<String> events, String exp) {}
+
+  /**
+   * The cached scan result for a composite class, holding either the annotated fields or the error
+   * raised while scanning them.
+   *
+   * @param fields the annotated fields
+   * @param error the error raised while scanning, or null when the scan succeeded
+   */
+  private static final record SynchronizeFields(List<SynchronizeField> fields,
+      WebforjRuntimeException error) {}
 
   /**
    * A custom Element listener registration that will remove the listener from the element and the

--- a/webforj-foundation/src/main/java/com/webforj/component/element/annotation/Synchronize.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/annotation/Synchronize.java
@@ -1,0 +1,61 @@
+package com.webforj.component.element.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Keeps the property or attribute described by the annotated {@code PropertyDescriptor} field in
+ * sync with the client.
+ *
+ * <p>
+ * When one of the given client events fires, the current value of the property or attribute is read
+ * on the client and sent to the server with the event payload. The reported value is stored in the
+ * server cache so that reading the descriptor returns the value the client last reported instead of
+ * the value the server last wrote.
+ * </p>
+ *
+ * <p>
+ * Synchronization is not required to read the current client value on demand. The {@code get}
+ * method reads the value live from the client when its {@code fromClient} argument is {@code true}.
+ * Synchronization is for components that report a value change only through an event, where the
+ * reported value rides the event payload rather than a property or attribute the server can read
+ * back.
+ * </p>
+ *
+ * <p>
+ * The annotation is the declarative form of the {@code synchronize} method in
+ * {@code ElementComposite}. Use the method directly when the registration needs to be removed or
+ * replaced at runtime.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.02
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Synchronize {
+
+  /**
+   * The names of the client events which report the value to the server.
+   *
+   * @return the event names
+   */
+  String[] value();
+
+  /**
+   * An optional client expression which produces the value when the event fires.
+   *
+   * <p>
+   * When set, the value is read from the given expression instead of the element, for example
+   * {@code event.detail}, and the produced value is also written back to the element. Use this form
+   * when the element does not maintain the value itself.
+   * </p>
+   *
+   * @return the client expression
+   */
+  String exp() default "";
+}

--- a/webforj-foundation/src/test/java/com/webforj/component/element/ElementCompositeTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/ElementCompositeTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
@@ -15,19 +16,30 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.basis.bbj.proxies.event.BBjWebEvent;
+import com.basis.bbj.proxies.event.BBjWebEventOptions;
+import com.basis.bbj.proxies.sysgui.BBjWebComponent;
+import com.basis.startup.type.BBjException;
 import com.google.gson.Gson;
+import com.webforj.component.ReflectionUtils;
 import com.webforj.component.element.annotation.EventName;
+import com.webforj.component.element.annotation.NodeName;
+import com.webforj.component.element.annotation.Synchronize;
 import com.webforj.component.element.event.ElementEvent;
 import com.webforj.component.element.event.ElementEventOptions;
+import com.webforj.component.element.sink.ElementEventSink;
 import com.webforj.component.event.ComponentEvent;
+import com.webforj.component.window.Window;
 import com.webforj.conceiver.ConceiverProvider;
 import com.webforj.conceiver.DefaultConceiver;
 import com.webforj.dispatcher.EventDispatcher;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
+import com.webforj.exceptions.WebforjRuntimeException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -38,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 class ElementCompositeTest {
@@ -344,6 +357,218 @@ class ElementCompositeTest {
 
       listenerRegistration.remove();
       verify(elementRegistration, times(1)).remove();
+    }
+  }
+
+  @Nested
+  @DisplayName("Synchronize API")
+  class SynchronizeApi {
+
+    @NodeName("x-color")
+    static class SynchronizedColorComposite extends ElementComposite {
+      @Synchronize("change")
+      final PropertyDescriptor<String> colorProp = PropertyDescriptor.property("color", "blue");
+
+      @Synchronize("toggle")
+      final PropertyDescriptor<String> badgeAttr = PropertyDescriptor.attribute("badge", "none");
+
+      public String getColor() {
+        return get(colorProp);
+      }
+
+      public String getBadge() {
+        return get(badgeAttr);
+      }
+    }
+
+    @NodeName("x-detail-color")
+    static class SynchronizedDetailColorComposite extends ElementComposite {
+      @Synchronize(value = "change", exp = "event.detail")
+      final PropertyDescriptor<String> colorProp = PropertyDescriptor.property("color", "blue");
+
+      public String getColor() {
+        return get(colorProp);
+      }
+    }
+
+    @NodeName("x-checked")
+    static class SynchronizedCheckedComposite extends ElementComposite {
+      @Synchronize("toggle")
+      final PropertyDescriptor<Boolean> checkedAttr =
+          PropertyDescriptor.attribute("checked", false);
+
+      public boolean isChecked() {
+        return get(checkedAttr);
+      }
+    }
+
+    @NodeName("x-count")
+    static class SynchronizedCountComposite extends ElementComposite {
+      final PropertyDescriptor<Integer> countProp = PropertyDescriptor.property("count", 0);
+
+      public void synchronizeCount() {
+        synchronize(countProp, "input");
+      }
+
+      public int getCount() {
+        return get(countProp);
+      }
+    }
+
+    @NodeName("x-broken")
+    static class BrokenSynchronizedComposite extends ElementComposite {
+      @Synchronize("change")
+      final String colorProp = "color";
+    }
+
+    static class BaseSynchronizedComposite extends ElementComposite {
+      @Synchronize("change")
+      final PropertyDescriptor<String> colorProp = PropertyDescriptor.property("color", "blue");
+
+      public String getColor() {
+        return get(colorProp);
+      }
+    }
+
+    @NodeName("x-inherited-color")
+    static class InheritedSynchronizedComposite extends BaseSynchronizedComposite {
+    }
+
+    BBjWebComponent control;
+    BBjWebEventOptions controlOptions;
+
+    @BeforeEach
+    void setUpControl() throws BBjException {
+      control = mock(BBjWebComponent.class);
+      controlOptions = mock(BBjWebEventOptions.class);
+      when(control.newEventOptions()).thenReturn(controlOptions);
+    }
+
+    ElementEventSink attachAndCaptureSink(ElementComposite composite, String event, int callbackId)
+        throws BBjException, IllegalAccessException {
+      when(control.setCallback(eq(event), any(), anyString(), any(BBjWebEventOptions.class)))
+          .thenReturn(callbackId);
+
+      Element element = composite.getElement();
+      ReflectionUtils.unNullifyControl(element, control);
+      element.attachControlCallbacks();
+
+      ArgumentCaptor<Object> handler = ArgumentCaptor.forClass(Object.class);
+      verify(control).setCallback(eq(event), handler.capture(), anyString(),
+          any(BBjWebEventOptions.class));
+
+      return (ElementEventSink) handler.getValue();
+    }
+
+    BBjWebEvent webEvent(int callbackId, Map<String, Object> eventMap) {
+      BBjWebEvent event = mock(BBjWebEvent.class);
+      when(event.getCallbackID()).thenReturn(callbackId);
+      when(event.getEventMap()).thenReturn(eventMap);
+
+      return event;
+    }
+
+    @Test
+    @DisplayName("should sync annotated property with the client")
+    void shouldSyncAnnotatedProperty() throws BBjException, IllegalAccessException {
+      SynchronizedColorComposite composite = new SynchronizedColorComposite();
+      composite.onCreate(mock(Window.class));
+
+      ElementEventSink sink = attachAndCaptureSink(composite, "change", 1);
+      verify(controlOptions).addItem("color", "component['color']");
+
+      assertEquals("blue", composite.getColor());
+      sink.handleEvent(webEvent(1, Map.of("color", "red")));
+      assertEquals("red", composite.getColor());
+    }
+
+    @Test
+    @DisplayName("should sync annotated attribute with the client")
+    void shouldSyncAnnotatedAttribute() throws BBjException, IllegalAccessException {
+      SynchronizedColorComposite composite = new SynchronizedColorComposite();
+      composite.onCreate(mock(Window.class));
+
+      ElementEventSink sink = attachAndCaptureSink(composite, "toggle", 2);
+      verify(controlOptions).addItem("badge", "component.getAttribute('badge')");
+
+      assertEquals("none", composite.getBadge());
+      sink.handleEvent(webEvent(2, Map.of("badge", "new")));
+      assertEquals("new", composite.getBadge());
+    }
+
+    @Test
+    @DisplayName("should sync boolean attribute presence with the client")
+    void shouldSyncBooleanAttribute() throws BBjException, IllegalAccessException {
+      SynchronizedCheckedComposite composite = new SynchronizedCheckedComposite();
+      composite.onCreate(mock(Window.class));
+
+      ElementEventSink sink = attachAndCaptureSink(composite, "toggle", 3);
+
+      assertFalse(composite.isChecked());
+      sink.handleEvent(webEvent(3, Map.of("checked", "")));
+      assertTrue(composite.isChecked());
+    }
+
+    @Test
+    @DisplayName("should sync from the given expression and write the value back to the element")
+    void shouldSyncFromExpression() throws BBjException, IllegalAccessException {
+      SynchronizedDetailColorComposite composite = new SynchronizedDetailColorComposite();
+      composite.onCreate(mock(Window.class));
+
+      ElementEventSink sink = attachAndCaptureSink(composite, "change", 4);
+      verify(controlOptions).addItem("color", "event.detail");
+      verify(controlOptions).setCode("component['color'] = event.detail;");
+
+      sink.handleEvent(webEvent(4, Map.of("color", "green")));
+      assertEquals("green", composite.getColor());
+    }
+
+    @Test
+    @DisplayName("should sync programmatically and convert the reported value to the property type")
+    void shouldSyncProgrammatically() throws BBjException, IllegalAccessException {
+      SynchronizedCountComposite composite = new SynchronizedCountComposite();
+      composite.synchronizeCount();
+
+      ElementEventSink sink = attachAndCaptureSink(composite, "input", 5);
+      sink.handleEvent(webEvent(5, Map.of("count", 4.0d)));
+
+      assertEquals(4, composite.getCount());
+    }
+
+    @Test
+    @DisplayName("should keep the cached value when the event carries no value")
+    void shouldKeepCachedValueWhenEventCarriesNoValue()
+        throws BBjException, IllegalAccessException {
+      SynchronizedColorComposite composite = new SynchronizedColorComposite();
+      composite.onCreate(mock(Window.class));
+
+      ElementEventSink sink = attachAndCaptureSink(composite, "change", 6);
+      sink.handleEvent(webEvent(6, Map.of()));
+
+      assertEquals("blue", composite.getColor());
+    }
+
+    @Test
+    @DisplayName("should throw when the annotated field is not a PropertyDescriptor")
+    void shouldThrowWhenAnnotatedFieldIsNotDescriptor() {
+      BrokenSynchronizedComposite composite = new BrokenSynchronizedComposite();
+      Window window = mock(Window.class);
+
+      assertThrows(WebforjRuntimeException.class, () -> composite.onCreate(window));
+    }
+
+    @Test
+    @DisplayName("should sync a property annotated on a superclass field")
+    void shouldSyncInheritedAnnotatedProperty() throws BBjException, IllegalAccessException {
+      InheritedSynchronizedComposite composite = new InheritedSynchronizedComposite();
+      composite.onCreate(mock(Window.class));
+
+      ElementEventSink sink = attachAndCaptureSink(composite, "change", 7);
+      verify(controlOptions).addItem("color", "component['color']");
+
+      assertEquals("blue", composite.getColor());
+      sink.handleEvent(webEvent(7, Map.of("color", "red")));
+      assertEquals("red", composite.getColor());
     }
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/component/element/ElementCompositeTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/ElementCompositeTest.java
@@ -471,104 +471,105 @@ class ElementCompositeTest {
     @Test
     @DisplayName("should sync annotated property with the client")
     void shouldSyncAnnotatedProperty() throws BBjException, IllegalAccessException {
-      SynchronizedColorComposite composite = new SynchronizedColorComposite();
-      composite.onCreate(mock(Window.class));
+      SynchronizedColorComposite colorComposite = new SynchronizedColorComposite();
+      colorComposite.onCreate(mock(Window.class));
 
-      ElementEventSink sink = attachAndCaptureSink(composite, "change", 1);
+      ElementEventSink sink = attachAndCaptureSink(colorComposite, "change", 1);
       verify(controlOptions).addItem("color", "component['color']");
 
-      assertEquals("blue", composite.getColor());
+      assertEquals("blue", colorComposite.getColor());
       sink.handleEvent(webEvent(1, Map.of("color", "red")));
-      assertEquals("red", composite.getColor());
+      assertEquals("red", colorComposite.getColor());
     }
 
     @Test
     @DisplayName("should sync annotated attribute with the client")
     void shouldSyncAnnotatedAttribute() throws BBjException, IllegalAccessException {
-      SynchronizedColorComposite composite = new SynchronizedColorComposite();
-      composite.onCreate(mock(Window.class));
+      SynchronizedColorComposite colorComposite = new SynchronizedColorComposite();
+      colorComposite.onCreate(mock(Window.class));
 
-      ElementEventSink sink = attachAndCaptureSink(composite, "toggle", 2);
+      ElementEventSink sink = attachAndCaptureSink(colorComposite, "toggle", 2);
       verify(controlOptions).addItem("badge", "component.getAttribute('badge')");
 
-      assertEquals("none", composite.getBadge());
+      assertEquals("none", colorComposite.getBadge());
       sink.handleEvent(webEvent(2, Map.of("badge", "new")));
-      assertEquals("new", composite.getBadge());
+      assertEquals("new", colorComposite.getBadge());
     }
 
     @Test
     @DisplayName("should sync boolean attribute presence with the client")
     void shouldSyncBooleanAttribute() throws BBjException, IllegalAccessException {
-      SynchronizedCheckedComposite composite = new SynchronizedCheckedComposite();
-      composite.onCreate(mock(Window.class));
+      SynchronizedCheckedComposite checkedComposite = new SynchronizedCheckedComposite();
+      checkedComposite.onCreate(mock(Window.class));
 
-      ElementEventSink sink = attachAndCaptureSink(composite, "toggle", 3);
+      ElementEventSink sink = attachAndCaptureSink(checkedComposite, "toggle", 3);
 
-      assertFalse(composite.isChecked());
+      assertFalse(checkedComposite.isChecked());
       sink.handleEvent(webEvent(3, Map.of("checked", "")));
-      assertTrue(composite.isChecked());
+      assertTrue(checkedComposite.isChecked());
     }
 
     @Test
     @DisplayName("should sync from the given expression and write the value back to the element")
     void shouldSyncFromExpression() throws BBjException, IllegalAccessException {
-      SynchronizedDetailColorComposite composite = new SynchronizedDetailColorComposite();
-      composite.onCreate(mock(Window.class));
+      SynchronizedDetailColorComposite detailColorComposite =
+          new SynchronizedDetailColorComposite();
+      detailColorComposite.onCreate(mock(Window.class));
 
-      ElementEventSink sink = attachAndCaptureSink(composite, "change", 4);
+      ElementEventSink sink = attachAndCaptureSink(detailColorComposite, "change", 4);
       verify(controlOptions).addItem("color", "event.detail");
       verify(controlOptions).setCode("component['color'] = event.detail;");
 
       sink.handleEvent(webEvent(4, Map.of("color", "green")));
-      assertEquals("green", composite.getColor());
+      assertEquals("green", detailColorComposite.getColor());
     }
 
     @Test
     @DisplayName("should sync programmatically and convert the reported value to the property type")
     void shouldSyncProgrammatically() throws BBjException, IllegalAccessException {
-      SynchronizedCountComposite composite = new SynchronizedCountComposite();
-      composite.synchronizeCount();
+      SynchronizedCountComposite countComposite = new SynchronizedCountComposite();
+      countComposite.synchronizeCount();
 
-      ElementEventSink sink = attachAndCaptureSink(composite, "input", 5);
+      ElementEventSink sink = attachAndCaptureSink(countComposite, "input", 5);
       sink.handleEvent(webEvent(5, Map.of("count", 4.0d)));
 
-      assertEquals(4, composite.getCount());
+      assertEquals(4, countComposite.getCount());
     }
 
     @Test
     @DisplayName("should keep the cached value when the event carries no value")
     void shouldKeepCachedValueWhenEventCarriesNoValue()
         throws BBjException, IllegalAccessException {
-      SynchronizedColorComposite composite = new SynchronizedColorComposite();
-      composite.onCreate(mock(Window.class));
+      SynchronizedColorComposite colorComposite = new SynchronizedColorComposite();
+      colorComposite.onCreate(mock(Window.class));
 
-      ElementEventSink sink = attachAndCaptureSink(composite, "change", 6);
+      ElementEventSink sink = attachAndCaptureSink(colorComposite, "change", 6);
       sink.handleEvent(webEvent(6, Map.of()));
 
-      assertEquals("blue", composite.getColor());
+      assertEquals("blue", colorComposite.getColor());
     }
 
     @Test
     @DisplayName("should throw when the annotated field is not a PropertyDescriptor")
     void shouldThrowWhenAnnotatedFieldIsNotDescriptor() {
-      BrokenSynchronizedComposite composite = new BrokenSynchronizedComposite();
+      BrokenSynchronizedComposite brokenComposite = new BrokenSynchronizedComposite();
       Window window = mock(Window.class);
 
-      assertThrows(WebforjRuntimeException.class, () -> composite.onCreate(window));
+      assertThrows(WebforjRuntimeException.class, () -> brokenComposite.onCreate(window));
     }
 
     @Test
     @DisplayName("should sync a property annotated on a superclass field")
     void shouldSyncInheritedAnnotatedProperty() throws BBjException, IllegalAccessException {
-      InheritedSynchronizedComposite composite = new InheritedSynchronizedComposite();
-      composite.onCreate(mock(Window.class));
+      InheritedSynchronizedComposite inheritedComposite = new InheritedSynchronizedComposite();
+      inheritedComposite.onCreate(mock(Window.class));
 
-      ElementEventSink sink = attachAndCaptureSink(composite, "change", 7);
+      ElementEventSink sink = attachAndCaptureSink(inheritedComposite, "change", 7);
       verify(controlOptions).addItem("color", "component['color']");
 
-      assertEquals("blue", composite.getColor());
+      assertEquals("blue", inheritedComposite.getColor());
       sink.handleEvent(webEvent(7, Map.of("color", "red")));
-      assertEquals("red", composite.getColor());
+      assertEquals("red", inheritedComposite.getColor());
     }
   }
 }


### PR DESCRIPTION
A `PropertyDescriptor` field annotated with `@Synchronize` keeps its property or attribute in step with the client. When one of the named client events fires, the current value is read on the client and stored on the server, so reading the descriptor returns the value the client last reported instead of the value the server last wrote.

```java
@NodeName("app-color-picker")
class ColorPicker extends ElementComposite {

  @Synchronize(value = "change", exp = "event.detail")
  private final PropertyDescriptor<String> color =
      PropertyDescriptor.property("color", "#000000");

  String getColor() {
    return get(color);
  }
}
```

The `exp` member reads the value from a client expression, such as `event.detail`, and writes it back to the element. It covers elements that report a value on an event without holding it as a property or attribute of their own. Without `exp`, the value is read from the property or attribute named by the descriptor.

The annotation is the declarative form of the `synchronize` method. Calling `synchronize(color, "change")` registers the same synchronization and returns a `ListenerRegistration` that removes it, for the cases where the synchronization changes at runtime.
