### PR TITLE
fix: empty state readers throw instead of returning their defaults

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/field/MaskedNumberField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/MaskedNumberField.java
@@ -353,7 +353,12 @@ public sealed class MaskedNumberField extends DwcMaskedField<MaskedNumberField, 
    */
   @Override
   public String getMaskedValue() {
-    return MaskDecorator.forNumber(getValue(), getMask());
+    Double theValue = getValue();
+    if (theValue == null) {
+      return "";
+    }
+
+    return MaskDecorator.forNumber(theValue, getMask());
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/navigator/Navigator.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/navigator/Navigator.java
@@ -465,7 +465,7 @@ public final class Navigator extends DwcFocusableComponent<Navigator>
     }
 
     if (prop != null) {
-      return !(boolean) getProperty(prop);
+      return !Boolean.TRUE.equals(getProperty(prop));
     }
 
     if (part == Part.PAGE_BUTTON) {

--- a/webforj-foundation/src/main/java/com/webforj/component/tabbedpane/TabbedPane.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/tabbedpane/TabbedPane.java
@@ -1054,15 +1054,20 @@ public final class TabbedPane extends DwcFocusableComponent<TabbedPane> implemen
   public Tab getSelected() {
     BBjTabCtrl tabCtrl = inferTabCtrl();
 
+    int index = selectedIndex;
     if (tabCtrl != null) {
       try {
-        return getTab(tabCtrl.getSelectedIndex());
+        index = tabCtrl.getSelectedIndex();
       } catch (BBjException e) {
         throw new WebforjRuntimeException(e);
       }
-    } else {
-      return getTab(selectedIndex);
     }
+
+    if (index < 0 || index >= tabs.size()) {
+      return null;
+    }
+
+    return getTab(index);
   }
 
   /**

--- a/webforj-foundation/src/test/java/com/webforj/component/field/MaskedNumberFieldSpinnerTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/field/MaskedNumberFieldSpinnerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 
 import com.basis.bbj.proxies.sysgui.BBjInputNSpinner;
 import com.webforj.component.Expanse;
+import com.webforj.component.ReflectionUtils;
 import com.webforj.data.event.ValueChangeEvent;
 import com.webforj.dispatcher.EventListener;
 import org.junit.jupiter.api.Nested;
@@ -89,6 +90,12 @@ class MaskedNumberFieldSpinnerTest {
       component = new MaskedNumberFieldSpinner();
       assertEquals(Expanse.MEDIUM, component.getExpanse());
     }
+  }
+
+  @Test
+  void shouldReturnEmptyMaskedValueWhenValueIsAbsent() throws IllegalAccessException {
+    ReflectionUtils.nullifyControl(component);
+    assertEquals("", component.getMaskedValue());
   }
 
   @Test

--- a/webforj-foundation/src/test/java/com/webforj/component/field/MaskedNumberFieldTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/field/MaskedNumberFieldTest.java
@@ -99,6 +99,12 @@ class MaskedNumberFieldTest {
     assertEquals("23.5", component.getText());
   }
 
+  @Test
+  void shouldReturnEmptyMaskedValueWhenValueIsAbsent() throws IllegalAccessException {
+    ReflectionUtils.nullifyControl(component);
+    assertEquals("", component.getMaskedValue());
+  }
+
   @Nested
   class SeparatorsApi {
 

--- a/webforj-foundation/src/test/java/com/webforj/component/navigator/NavigatorTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/navigator/NavigatorTest.java
@@ -112,6 +112,17 @@ class NavigatorTest {
     assertTrue(component.isVisible(Navigator.Part.LAST_BUTTON));
   }
 
+  @Test
+  void shouldReportMainButtonsVisibleByDefault() throws IllegalAccessException {
+    ReflectionUtils.nullifyControl(component);
+
+    assertFalse(component.isHideMainButtons());
+    assertTrue(component.isVisible(Navigator.Part.FIRST_BUTTON));
+    assertTrue(component.isVisible(Navigator.Part.PREVIOUS_BUTTON));
+    assertTrue(component.isVisible(Navigator.Part.NEXT_BUTTON));
+    assertTrue(component.isVisible(Navigator.Part.LAST_BUTTON));
+  }
+
   @ParameterizedTest
   @EnumSource(Navigator.Part.class)
   void shouldSetGetTextPart(Navigator.Part part) throws IllegalAccessException {

--- a/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/TabbedPaneTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/TabbedPaneTest.java
@@ -518,6 +518,20 @@ class TabbedPaneTest {
       verify(control, times(times)).setSelectedIndex(0, false);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldReportNoSelectionWhenPaneIsEmpty(boolean controlDefined)
+        throws IllegalAccessException, BBjException {
+      if (!controlDefined) {
+        ReflectionUtils.nullifyControl(component);
+      } else {
+        doReturn(-1).when(control).getSelectedIndex();
+      }
+
+      assertNull(component.getSelected());
+      assertEquals(-1, component.getSelectedIndex());
+    }
+
     @Test
     void selectedShouldThrowDwcjRuntimeException() throws BBjException {
       component.addTab("Tab1", new DwcComponentMock());


### PR DESCRIPTION
`MaskedNumberField.getMaskedValue` unboxed an absent value and threw `NullPointerException`. It now returns the empty string, matching the masked text, date and time fields.

`TabbedPane.getSelected` threw `IndexOutOfBoundsException` on an empty pane although its javadoc promises null, and `getSelectedIndex` promises -1. Both now honor their documented contract.

`Navigator.isVisible(Part)` unboxed an absent suppress property and threw `NullPointerException` on a fresh component. An absent property now means the part is visible, so `isHideMainButtons` returns false by default.