### PR TITLE
feat: add a search API to list components

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/list/ChoiceBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ChoiceBox.java
@@ -131,10 +131,11 @@ public final class ChoiceBox extends DwcSelectDropdown<ChoiceBox>
     properties.addAll(Arrays.asList("autoValidate", "autoValidateOnLoad", "autoWasValidated",
         "buttonHeight", "disabled", "distance", "expanse", "hasFocus", "invalid", "invalidMessage",
         "itemLabel", "itemValue", "items", "label", "maxRowCount", "openHeight", "openWidth",
-        "opened", "placement", "readonly", "renderItemPrefix", "selected", "skidding", "theme",
-        "type", "typeToSelect", "typeToSelectCaseSensitive", "typeToSelectTimeout", "valid",
-        "validationIcon", "validationPopoverDistance", "validationPopoverPlacement",
-        "validationPopoverSkidding", "validationStyle", "validator"));
+        "opened", "placement", "readonly", "renderItemPrefix", "searchInput", "searchNodata",
+        "searchPlaceholder", "searchTerm", "selected", "skidding", "theme", "type", "typeToSelect",
+        "typeToSelectCaseSensitive", "typeToSelectTimeout", "valid", "validationIcon",
+        "validationPopoverDistance", "validationPopoverPlacement", "validationPopoverSkidding",
+        "validationStyle", "validator"));
 
     return properties;
   }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/ComboBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ComboBox.java
@@ -234,9 +234,10 @@ public final class ComboBox extends DwcSelectDropdown<ComboBox>
         "customValue", "disabled", "distance", "expanse", "fieldHeight", "hasFocus",
         "highlightBehaviors", "invalid", "invalidMessage", "itemLabel", "itemValue", "items",
         "label", "maxRowCount", "maxlength", "openHeight", "openWidth", "opened", "placeholder",
-        "placement", "readonly", "renderer", "selected", "skidding", "toggleOnEnter", "type",
-        "valid", "validationIcon", "validationPopoverDistance", "validationPopoverPlacement",
-        "validationPopoverSkidding", "validationStyle", "validator", "value"));
+        "placement", "readonly", "renderer", "searchInput", "searchNodata", "searchPlaceholder",
+        "searchTerm", "selected", "skidding", "toggleOnEnter", "type", "valid", "validationIcon",
+        "validationPopoverDistance", "validationPopoverPlacement", "validationPopoverSkidding",
+        "validationStyle", "validator", "value"));
 
     return properties;
   }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/DwcList.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/DwcList.java
@@ -18,6 +18,7 @@ import com.webforj.concern.HasLabel;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import com.webforj.exceptions.WebforjRuntimeException;
+import com.webforj.utilities.HtmlText;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.AbstractMap;
@@ -60,6 +61,8 @@ public abstract class DwcList<T extends DwcValidatableComponent<T, V>, V>
   private final ComponentEventSinkRegistry<ListSelectEvent<V>> selectEventSinkListenerRegistry =
       new ComponentEventSinkRegistry<ListSelectEvent<V>>(
           new ListSelectEventSink<V>(this, getEventDispatcher()), ListSelectEvent.class);
+
+  private final Search search = new Search();
 
   private String label = "";
   private String helperText = "";
@@ -658,6 +661,16 @@ public abstract class DwcList<T extends DwcValidatableComponent<T, V>, V>
   }
 
   /**
+   * Returns the configuration object for the list's embedded search field.
+   *
+   * @return the search configuration
+   * @since 26.02
+   */
+  public Search getSearch() {
+    return search;
+  }
+
+  /**
    * Adds a {@link ListSelectEvent} listener for the component.
    *
    * @param listener the event listener to be added
@@ -802,6 +815,119 @@ public abstract class DwcList<T extends DwcValidatableComponent<T, V>, V>
       } catch (BBjException e) {
         throw new WebforjRuntimeException(e);
       }
+    }
+  }
+
+  /**
+   * Configures the list's embedded search field.
+   *
+   * @author Hyyan Abo Fakher
+   * @since 26.02
+   */
+  public final class Search {
+    private boolean fieldVisible = false;
+    private String term = "";
+    private String placeholder = "Search";
+    private String emptyMessage = "No data to display";
+
+    /**
+     * Sets whether the built in search field is shown.
+     *
+     * <p>
+     * When shown, the search field sits at the top of the component's list and filters the items by
+     * their text. Filtering only hides the items which do not match, the item indexes and the
+     * selection are untouched. The list can still be filtered through {@link #setTerm(String)}
+     * while the field is hidden.
+     * </p>
+     *
+     * @param fieldVisible {@code true} to show the search field, {@code false} to hide it
+     * @return the search configuration itself
+     */
+    public Search setFieldVisible(boolean fieldVisible) {
+      this.fieldVisible = fieldVisible;
+      setUnrestrictedProperty("searchInput", fieldVisible);
+
+      return this;
+    }
+
+    /**
+     * Checks whether the built in search field is shown.
+     *
+     * @return {@code true} if the search field is shown, {@code false} otherwise
+     */
+    public boolean isFieldVisible() {
+      return fieldVisible;
+    }
+
+    /**
+     * Sets the current search term.
+     *
+     * <p>
+     * The term seeds the search field and filters the list. Typing in the search field does not
+     * write the term back, {@link #getTerm()} always returns the last term set through this method.
+     * </p>
+     *
+     * @param term the search term
+     * @return the search configuration itself
+     */
+    public Search setTerm(String term) {
+      this.term = term;
+      setUnrestrictedProperty("searchTerm", term);
+
+      return this;
+    }
+
+    /**
+     * Gets the last search term set through {@link #setTerm(String)}.
+     *
+     * @return the search term
+     */
+    public String getTerm() {
+      return term;
+    }
+
+    /**
+     * Sets the placeholder text of the search field.
+     *
+     * @param placeholder the placeholder text
+     * @return the search configuration itself
+     */
+    public Search setPlaceholder(String placeholder) {
+      this.placeholder = placeholder;
+      setUnrestrictedProperty("searchPlaceholder", placeholder);
+
+      return this;
+    }
+
+    /**
+     * Gets the placeholder text of the search field.
+     *
+     * @return the placeholder text
+     */
+    public String getPlaceholder() {
+      return placeholder;
+    }
+
+    /**
+     * Sets the message shown when a search returns no results.
+     *
+     * @param emptyMessage the empty message
+     * @return the search configuration itself
+     */
+    public Search setEmptyMessage(String emptyMessage) {
+      this.emptyMessage = HtmlText.forHtmlSink(emptyMessage);
+      setUnrestrictedProperty("searchNodata", this.emptyMessage);
+
+      return this;
+    }
+
+    /**
+     * Gets the message shown when a search returns no results.
+     *
+     * @return the empty message
+     */
+    public String getEmptyMessage() {
+      return emptyMessage;
     }
   }
 

--- a/webforj-foundation/src/main/java/com/webforj/component/list/ListBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ListBox.java
@@ -277,9 +277,10 @@ public final class ListBox extends DwcList<ListBox, List<Object>>
     List<String> properties = super.getRestrictedProperties();
     properties.addAll(Arrays.asList("allowDeselection", "autoValidate", "autoValidateOnLoad",
         "autoWasValidated", "disabled", "expanse", "hasFocus", "invalid", "invalidMessage", "items",
-        "label", "multiSelection", "multiSelectionByClick", "readonly", "renderer", "selected",
-        "tabTraversable", "typeToSelect", "typeToSelectCaseSensitive", "typeToSelectTimeout",
-        "valid", "validationIcon", "validationPopoverDistance", "validationPopoverPlacement",
+        "label", "multiSelection", "multiSelectionByClick", "readonly", "renderer", "searchInput",
+        "searchNodata", "searchPlaceholder", "searchTerm", "selected", "tabTraversable",
+        "typeToSelect", "typeToSelectCaseSensitive", "typeToSelectTimeout", "valid",
+        "validationIcon", "validationPopoverDistance", "validationPopoverPlacement",
         "validationPopoverSkidding", "validationStyle", "validator"));
 
     return properties;

--- a/webforj-foundation/src/test/java/com/webforj/component/list/DwcListTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/DwcListTest.java
@@ -418,4 +418,57 @@ class DwcListTest {
 
     assertEquals("helper text", component.getProperty("helperText"));
   }
+
+  @Nested
+  @DisplayName("Search API")
+  class SearchApi {
+
+    @Test
+    void shouldSetGetFieldVisible() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      assertFalse(component.getSearch().isFieldVisible());
+
+      component.getSearch().setFieldVisible(true);
+
+      assertTrue(component.getSearch().isFieldVisible());
+      assertEquals(true, component.getProperty("searchInput"));
+    }
+
+    @Test
+    void shouldSetGetTerm() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      assertEquals("", component.getSearch().getTerm());
+
+      component.getSearch().setTerm("app");
+
+      assertEquals("app", component.getSearch().getTerm());
+      assertEquals("app", component.getProperty("searchTerm"));
+    }
+
+    @Test
+    void shouldSetGetPlaceholder() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      assertEquals("Search", component.getSearch().getPlaceholder());
+
+      component.getSearch().setPlaceholder("Filter items");
+
+      assertEquals("Filter items", component.getSearch().getPlaceholder());
+      assertEquals("Filter items", component.getProperty("searchPlaceholder"));
+    }
+
+    @Test
+    void shouldKeepPlainTextEmptyMessage() throws IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+
+      assertEquals("No data to display", component.getSearch().getEmptyMessage());
+
+      component.getSearch().setEmptyMessage("Nothing found");
+
+      assertEquals("Nothing found", component.getSearch().getEmptyMessage());
+      assertEquals("Nothing found", component.getProperty("searchNodata"));
+    }
+  }
 }


### PR DESCRIPTION
`DwcList` exposes a `Search` configuration object through `getSearch()`. It controls the embedded search field which sits at the top of the component's list and filters the items by their text.

```java
ListBox list = new ListBox("Countries");
list.getSearch()
    .setFieldVisible(true)
    .setPlaceholder("Filter countries")
    .setEmptyMessage("No matching countries");
```
<img width="390" height="461" alt="save" src="https://github.com/user-attachments/assets/bba365e6-435e-4170-b7e2-a5aea03bb152" />

## API

- `setFieldVisible(boolean)` / `isFieldVisible()`: shows or hides the search field.
- `setTerm(String)` / `getTerm()`: seeds the search field and filters the list. Typing in the field does not write the term back, `getTerm()` always returns the last term set through the API. The list can be filtered through `setTerm(String)` while the field is hidden.
- `setPlaceholder(String)` / `getPlaceholder()`: the placeholder text of the search field.
- `setEmptyMessage(String)` / `getEmptyMessage()`: the message shown when a search returns no results.

## Behavior

Filtering only hides the items which do not match. Item indexes and the selection are untouched, so index based APIs such as `selectIndex` and `getByIndex` keep working against the full item list.
