### PR TITLE
fix: destroy the webforJ servlet when the Spring context closes

### DIFF
--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringAutoConfiguration.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/SpringAutoConfiguration.java
@@ -23,9 +23,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.event.ContextClosedEvent;
 
 /**
  * Auto-configuration for the Webforj servlet.
@@ -111,6 +113,28 @@ public class SpringAutoConfiguration {
         + WebforjServletConfiguration.WEBFORJ_SERVLET_NAME + "' at mapping: " + mapping);
 
     return registrationBean;
+  }
+
+  /**
+   * Destroys the {@link WebforjServlet} when the application context closes.
+   *
+   * <p>
+   * The servlet cleanup releases licensing and terminates the runtime threads. Closing the context
+   * is the only signal that fires on every shutdown, including restarts triggered by Spring
+   * devtools, so the servlet is destroyed here explicitly instead of relying on the embedded
+   * container.
+   * </p>
+   *
+   * @param registration the webforJ servlet registration
+   * @return the {@link ApplicationListener} for {@link ContextClosedEvent}
+   */
+  @Bean
+  ApplicationListener<ContextClosedEvent> webforjServletShutdown(
+      ServletRegistrationBean<WebforjServlet> registration) {
+    return event -> {
+      logger.log(Logger.Level.DEBUG, "Destroying WebforjServlet on context close");
+      registration.getServlet().destroy();
+    };
   }
 
   /**


### PR DESCRIPTION
When a Spring Boot application restarts through devtools, the application context closes and a fresh one starts inside the same JVM. The webforJ servlet destroy method was not invoked on this path, so the resources held by the previous application were never released. Over a development session every restart left behind the previous application in memory, and the JVM eventually failed with `OutOfMemoryError: Metaspace`.

This change registers an `ApplicationListener` that destroys the webforJ servlet explicitly when the application context closes. 