### PR TITLE
fix: skip livereload injection when the session ends during restart

### DIFF
--- a/webforj-devtools/src/main/java/com/webforj/devtools/livereload/LiveReloadScriptInjector.java
+++ b/webforj-devtools/src/main/java/com/webforj/devtools/livereload/LiveReloadScriptInjector.java
@@ -7,6 +7,7 @@ import com.webforj.Environment;
 import com.webforj.Page;
 import com.webforj.Request;
 import com.webforj.annotation.AppListenerPriority;
+import com.webforj.exceptions.WebforjRuntimeException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -52,6 +53,13 @@ public class LiveReloadScriptInjector implements AppLifecycleListener {
       page.addInlineJavaScript(composeScript(url, options.getHeartbeatInterval(), reloadScript),
           true);
       logger.log(System.Logger.Level.DEBUG, "webforJ livereload script injected into page");
+    } catch (WebforjRuntimeException e) {
+      // The request only becomes unreadable when its session is already ending, usually because
+      // a restart began while this page was still starting. The page is about to be replaced, so
+      // the injection is skipped quietly.
+      logger.log(System.Logger.Level.DEBUG,
+          "webforJ livereload script not injected, the session ended while the page was starting",
+          e);
     } catch (Exception e) {
       logger.log(System.Logger.Level.WARNING, "Failed to inject webforJ livereload script", e);
     }

--- a/webforj-devtools/src/test/java/com/webforj/devtools/livereload/LiveReloadScriptInjectorTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/livereload/LiveReloadScriptInjectorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.webforj.Page;
 import com.webforj.Request;
+import com.webforj.exceptions.WebforjRuntimeException;
 import org.junit.jupiter.api.Test;
 
 class LiveReloadScriptInjectorTest {
@@ -70,6 +71,18 @@ class LiveReloadScriptInjectorTest {
 
     verify(page).addInlineJavaScript(contains("ws://localhost:40000/webforj-devtools-ws"),
         eq(true));
+  }
+
+  @Test
+  void shouldSkipInjectionQuietlyWhenTheSessionEndsDuringStartup() {
+    Page page = mock(Page.class);
+    Request request = mock(Request.class);
+    when(request.getProtocol()).thenThrow(new WebforjRuntimeException("Failed to get the URL."));
+
+    new LiveReloadScriptInjector()
+        .inject(new LiveReloadOptions().setEnabled(true).setWebsocketPort(40000), page, request);
+
+    verify(page, never()).addInlineJavaScript(anyString(), eq(true));
   }
 
   @Test


### PR DESCRIPTION
A restart that begins while a page is still starting tears the session down under the script injection, and the injection then failed with a warning and a long stack trace in the application log. The page cannot use the script at that point and the restart replaces it, so the injection now skips quietly with a single debug line. Any other injection failure still logs the warning.