### PR TITLE
fix: apply a bundled stylesheet change to the browser once

### DIFF
--- a/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/livereload/LiveReloadResourceChangeListener.java
+++ b/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/livereload/LiveReloadResourceChangeListener.java
@@ -24,6 +24,8 @@ import org.springframework.context.ApplicationListener;
 public class LiveReloadResourceChangeListener
     implements ApplicationListener<ClassPathChangedEvent> {
 
+  private static final Set<String> BUNDLE_OUTPUT_DIRS =
+      Set.of("static/frontend/", "static/webforj/");
   private static final Set<String> CSS_EXTENSIONS = Set.of(".css");
   private static final Set<String> JS_EXTENSIONS = Set.of(".js");
   private static final Set<String> IMAGE_EXTENSIONS =
@@ -55,7 +57,12 @@ public class LiveReloadResourceChangeListener
   }
 
   private static boolean isStaticResource(ChangedFile file) {
-    return file.getFile().getPath().contains("static");
+    String path = file.getFile().getPath().replace('\\', '/');
+
+    // The bundler owns these folders and reports its own writes through the watch, so a change
+    // there would otherwise reach the browser twice.
+
+    return path.contains("static") && BUNDLE_OUTPUT_DIRS.stream().noneMatch(path::contains);
   }
 
   private static String getResourceType(ChangedFile file) {

--- a/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/livereload/LiveReloadResourceChangeListener.java
+++ b/webforj-spring/webforj-spring-devtools/src/main/java/com/webforj/spring/devtools/livereload/LiveReloadResourceChangeListener.java
@@ -24,8 +24,9 @@ import org.springframework.context.ApplicationListener;
 public class LiveReloadResourceChangeListener
     implements ApplicationListener<ClassPathChangedEvent> {
 
+  private static final String STATIC_DIR = "static";
   private static final Set<String> BUNDLE_OUTPUT_DIRS =
-      Set.of("static/frontend/", "static/webforj/");
+      Set.of(STATIC_DIR + "/frontend/", STATIC_DIR + "/webforj/");
   private static final Set<String> CSS_EXTENSIONS = Set.of(".css");
   private static final Set<String> JS_EXTENSIONS = Set.of(".js");
   private static final Set<String> IMAGE_EXTENSIONS =
@@ -62,7 +63,7 @@ public class LiveReloadResourceChangeListener
     // The bundler owns these folders and reports its own writes through the watch, so a change
     // there would otherwise reach the browser twice.
 
-    return path.contains("static") && BUNDLE_OUTPUT_DIRS.stream().noneMatch(path::contains);
+    return path.contains(STATIC_DIR) && BUNDLE_OUTPUT_DIRS.stream().noneMatch(path::contains);
   }
 
   private static String getResourceType(ChangedFile file) {
@@ -92,9 +93,9 @@ public class LiveReloadResourceChangeListener
   private static String getResourcePath(ChangedFile file) {
     String fullPath = file.getFile().getPath();
 
-    int index = fullPath.lastIndexOf("static");
+    int index = fullPath.lastIndexOf(STATIC_DIR);
     if (index >= 0) {
-      int startIndex = index + "static".length();
+      int startIndex = index + STATIC_DIR.length();
       if (startIndex < fullPath.length()
           && (fullPath.charAt(startIndex) == '/' || fullPath.charAt(startIndex) == '\\')) {
         startIndex++;

--- a/webforj-spring/webforj-spring-devtools/src/test/java/com/webforj/spring/devtools/livereload/LiveReloadResourceChangeListenerTest.java
+++ b/webforj-spring/webforj-spring-devtools/src/test/java/com/webforj/spring/devtools/livereload/LiveReloadResourceChangeListenerTest.java
@@ -45,6 +45,26 @@ class LiveReloadResourceChangeListenerTest {
   }
 
   @Test
+  void shouldIgnoreTheBundlerOutput() {
+    LiveReloadLifecycle lifecycle = mock(LiveReloadLifecycle.class);
+
+    new LiveReloadResourceChangeListener(lifecycle)
+        .onApplicationEvent(event("static/frontend/app.css", ChangedFile.Type.MODIFY));
+
+    verifyNoInteractions(lifecycle);
+  }
+
+  @Test
+  void shouldIgnoreTheBundleIndex() {
+    LiveReloadLifecycle lifecycle = mock(LiveReloadLifecycle.class);
+
+    new LiveReloadResourceChangeListener(lifecycle)
+        .onApplicationEvent(event("static/webforj/frontend-entries.json", ChangedFile.Type.MODIFY));
+
+    verifyNoInteractions(lifecycle);
+  }
+
+  @Test
   void shouldIgnoreFilesOutsideTheStaticDirectory() {
     LiveReloadLifecycle lifecycle = mock(LiveReloadLifecycle.class);
 


### PR DESCRIPTION
A stylesheet or image change under the bundle output folder reached the browser twice during development. The bundler watch reported the write, and the static resource watch reported the same write a second time, since the bundler produces its output inside the served folder.

The static resource watch now leaves the bundle output folder and the bundle index to the bundler watch, which reports those writes already. A resource placed directly under the served folder is reported as before, including when no bundler runs.

A file placed by hand inside the bundle output folder is no longer reported, since that folder holds generated output.