### PR TITLE
fix: register routes added while the application runs

### DIFF
--- a/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/ComponentRegistrar.java
+++ b/webforj-spring/webforj-spring-integration/src/main/java/com/webforj/spring/ComponentRegistrar.java
@@ -16,10 +16,12 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.Environment;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.stereotype.Component;
 
@@ -56,10 +58,22 @@ import org.springframework.stereotype.Component;
  * @since 25.02
  */
 @Component
-public class ComponentRegistrar implements BeanDefinitionRegistryPostProcessor {
+public class ComponentRegistrar implements BeanDefinitionRegistryPostProcessor, EnvironmentAware {
+  private static final String LIVE_RELOAD_ENABLED_KEY = "webforj.devtools.livereload.enabled";
+
   private final Logger logger = System.getLogger(ComponentRegistrar.class.getName());
   private static final BeanNameGenerator beanNameGenerator = AnnotationBeanNameGenerator.INSTANCE;
   private final Set<String> registeredPackages = ConcurrentHashMap.newKeySet();
+
+  private Environment environment;
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setEnvironment(Environment environment) {
+    this.environment = environment;
+  }
 
   /**
    * Ensures the specified packages are scanned for {@code @Route} components and registered as
@@ -74,8 +88,10 @@ public class ComponentRegistrar implements BeanDefinitionRegistryPostProcessor {
    * </p>
    *
    * <p>
-   * The method is thread-safe. Packages already scanned will be skipped. All registered route
-   * components receive PROTOTYPE scope and LAZY initialization.
+   * The method is thread-safe. Packages already scanned will be skipped, unless live reload is
+   * enabled, in which case every package is scanned again so classes written while the application
+   * runs are picked up. All registered route components receive PROTOTYPE scope and LAZY
+   * initialization.
    * </p>
    *
    * @param registry the bean definition registry to register components in
@@ -87,9 +103,10 @@ public class ComponentRegistrar implements BeanDefinitionRegistryPostProcessor {
       return;
     }
 
+    boolean rescanEveryPackage = isLiveReloadEnabled();
     Set<String> packagesToScan = new HashSet<>();
     for (String pkg : packages) {
-      if (!registeredPackages.contains(pkg)) {
+      if (rescanEveryPackage || !registeredPackages.contains(pkg)) {
         packagesToScan.add(pkg);
       }
     }
@@ -350,5 +367,23 @@ public class ComponentRegistrar implements BeanDefinitionRegistryPostProcessor {
    */
   int getRegisteredPackageCount() {
     return registeredPackages.size();
+  }
+
+  /**
+   * Indicates whether a class can appear in a package after that package has been scanned.
+   *
+   * <p>
+   * When live reload is off the result of a scan stays complete for the life of the application,
+   * because the classes on the classpath cannot change, so an already scanned package is skipped.
+   * When live reload is on the developer is editing the running application, a class compiled after
+   * the scan would never reach the registry, so the skip is dropped and the package is scanned
+   * again.
+   * </p>
+   *
+   * @return {@code true} when live reload is enabled
+   */
+  private boolean isLiveReloadEnabled() {
+    return environment != null
+        && Boolean.parseBoolean(environment.getProperty(LIVE_RELOAD_ENABLED_KEY, "false"));
   }
 }

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/ComponentRegistrarTest.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/ComponentRegistrarTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.mock.env.MockEnvironment;
 
 @ExtendWith(MockitoExtension.class)
 class ComponentRegistrarTest {
@@ -135,6 +137,41 @@ class ComponentRegistrarTest {
     }
   }
 
+  @Nested
+  class LiveReloadRescanning {
+
+    private static final String SCANNED_PACKAGE = "com.webforj.spring.routescan";
+    private static final String LIVE_RELOAD_KEY = "webforj.devtools.livereload.enabled";
+
+    @Test
+    void shouldScanAPackageOnlyOnceWhenLiveReloadIsDisabled() {
+      registrar.setEnvironment(new MockEnvironment().withProperty(LIVE_RELOAD_KEY, "false"));
+
+      registrar.ensurePackagesRegistered(registry, new String[] {SCANNED_PACKAGE});
+      registrar.ensurePackagesRegistered(registry, new String[] {SCANNED_PACKAGE});
+
+      verify(registry).registerBeanDefinition(anyString(), any(BeanDefinition.class));
+    }
+
+    @Test
+    void shouldScanAPackageAgainWhenLiveReloadIsEnabled() {
+      registrar.setEnvironment(new MockEnvironment().withProperty(LIVE_RELOAD_KEY, "true"));
+
+      registrar.ensurePackagesRegistered(registry, new String[] {SCANNED_PACKAGE});
+      registrar.ensurePackagesRegistered(registry, new String[] {SCANNED_PACKAGE});
+
+      verify(registry, times(2)).registerBeanDefinition(anyString(), any(BeanDefinition.class));
+    }
+
+    @Test
+    void shouldScanAPackageOnlyOnceWhenNoEnvironmentIsAvailable() {
+      registrar.ensurePackagesRegistered(registry, new String[] {SCANNED_PACKAGE});
+      registrar.ensurePackagesRegistered(registry, new String[] {SCANNED_PACKAGE});
+
+      verify(registry).registerBeanDefinition(anyString(), any(BeanDefinition.class));
+    }
+  }
+
   // Test classes for various scenarios
   @SpringBootApplication
   static class TestAppWithoutRoutify {
@@ -145,4 +182,3 @@ class ComponentRegistrarTest {
   static class TestAppWithRoutify {
   }
 }
-

--- a/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/routescan/ScannedRouteView.java
+++ b/webforj-spring/webforj-spring-integration/src/test/java/com/webforj/spring/routescan/ScannedRouteView.java
@@ -1,0 +1,10 @@
+package com.webforj.spring.routescan;
+
+import com.webforj.router.annotation.Route;
+
+/**
+ * Sits alone in this package so a test can scan the package and get exactly one candidate.
+ */
+@Route("/scanned")
+public class ScannedRouteView {
+}


### PR DESCRIPTION
A route class created while the application is running becomes reachable on the next navigation when live reload is enabled, without restarting the application.

Route packages are scanned once per application when live reload is disabled, which remains the behavior outside development.