### PR TITLE
feat: reload the browser when JRebel hot swaps a class

### DIFF
--- a/webforj-devtools/src/main/java/com/webforj/devtools/livereload/JRebelReceiver.java
+++ b/webforj-devtools/src/main/java/com/webforj/devtools/livereload/JRebelReceiver.java
@@ -1,0 +1,259 @@
+package com.webforj.devtools.livereload;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Registers a class reload listener with the JRebel agent and pushes a full page reload through the
+ * {@link LiveReloadServer} it is given.
+ *
+ * <p>
+ * The JRebel agent hot swaps Java bytecode in place and never restarts the server, so none of the
+ * webforJ live reload triggers that depend on a restart ever fire for a Java change. This receiver
+ * closes that gap from inside the application virtual machine. When the agent is present, its
+ * software development kit classes are visible to the application classloader, so this receiver
+ * probes for them with reflection and registers a listener without a compile time dependency on the
+ * software development kit and without any new configuration. When the agent is absent the probe
+ * fails and the receiver stays inert.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.02
+ */
+public class JRebelReceiver {
+
+  private static final System.Logger logger = System.getLogger(JRebelReceiver.class.getName());
+  static final String RELOADER_FACTORY_CLASS_NAME = "org.zeroturnaround.javarebel.ReloaderFactory";
+  static final String CLASS_EVENT_LISTENER_CLASS_NAME =
+      "org.zeroturnaround.javarebel.ClassEventListener";
+  private static final long DEBOUNCE_DELAY_MILLIS = 150;
+
+  /**
+   * The agent event type reporting that a class was loaded for the first time, which is not a hot
+   * swap and must never reach the browser.
+   */
+  private static final int EVENT_LOADED = 0;
+
+  private final LiveReloadServer server;
+  private final String reloaderFactoryClassName;
+  private final String classEventListenerClassName;
+  private final AtomicBoolean running = new AtomicBoolean(false);
+  private final AtomicReference<ScheduledFuture<?>> pendingReload = new AtomicReference<>();
+
+  private ScheduledExecutorService executor;
+  private Object reloader;
+  private Object listener;
+
+  /**
+   * Creates a receiver that pushes JRebel class reload events through the given reload server.
+   *
+   * @param server the reload server the reload is pushed through
+   */
+  public JRebelReceiver(LiveReloadServer server) {
+    this(server, RELOADER_FACTORY_CLASS_NAME, CLASS_EVENT_LISTENER_CLASS_NAME);
+  }
+
+  /**
+   * Creates a receiver that discovers the agent under the given type names, so a test can supply
+   * its own stand in types instead of the agent ones.
+   *
+   * @param server the reload server the reload is pushed through
+   * @param reloaderFactoryClassName the binary name of the reloader factory type
+   * @param classEventListenerClassName the binary name of the class event listener interface
+   */
+  JRebelReceiver(LiveReloadServer server, String reloaderFactoryClassName,
+      String classEventListenerClassName) {
+    this.server = server;
+    this.reloaderFactoryClassName = reloaderFactoryClassName;
+    this.classEventListenerClassName = classEventListenerClassName;
+  }
+
+  /**
+   * Probes for the JRebel agent and registers a class reload listener, unless the receiver is
+   * already running or the agent is absent.
+   */
+  public void start() {
+    if (!running.compareAndSet(false, true)) {
+      return;
+    }
+
+    ClassLoader classLoader = resolveClassLoader();
+    ScheduledExecutorService newExecutor = null;
+
+    try {
+      Class<?> reloaderFactoryClass = Class.forName(reloaderFactoryClassName, false, classLoader);
+      Class<?> classEventListenerClass =
+          Class.forName(classEventListenerClassName, true, classLoader);
+
+      Object reloaderInstance = reloaderFactoryClass.getMethod("getInstance").invoke(null);
+      Object listenerProxy = Proxy.newProxyInstance(classLoader,
+          new Class<?>[] {classEventListenerClass}, this::handleInvocation);
+
+      // everything that can fail runs before the registration, so a registration that succeeds is
+      // always followed by the assignments that let stop undo it
+      newExecutor = Executors.newSingleThreadScheduledExecutor(JRebelReceiver::newDaemonThread);
+
+      reloaderInstance.getClass().getMethod("addClassReloadListener", classEventListenerClass)
+          .invoke(reloaderInstance, listenerProxy);
+
+      this.executor = newExecutor;
+      this.reloader = reloaderInstance;
+      this.listener = listenerProxy;
+
+      logger.log(System.Logger.Level.INFO, "JRebel detected, registered for class reload events");
+    } catch (ReflectiveOperationException | RuntimeException e) {
+      if (newExecutor != null) {
+        newExecutor.shutdownNow();
+      }
+
+      logger.log(System.Logger.Level.DEBUG,
+          "JRebel not detected, class reload events will not trigger a browser reload", e);
+      running.set(false);
+    }
+  }
+
+  /**
+   * Deregisters the class reload listener, cancels a pending reload, and stops the receiver.
+   */
+  public void stop() {
+    if (!running.compareAndSet(true, false)) {
+      return;
+    }
+
+    ScheduledFuture<?> scheduled = pendingReload.getAndSet(null);
+    if (scheduled != null) {
+      scheduled.cancel(false);
+    }
+
+    if (reloader != null && listener != null) {
+      try {
+        Method removeListener = findRemoveListenerMethod(reloader, listener);
+        if (removeListener != null) {
+          removeListener.invoke(reloader, listener);
+        }
+      } catch (ReflectiveOperationException | RuntimeException e) {
+        logger.log(System.Logger.Level.DEBUG,
+            "Could not deregister the JRebel class reload listener", e);
+      }
+    }
+
+    if (executor != null) {
+      executor.shutdownNow();
+      executor = null;
+    }
+
+    reloader = null;
+    listener = null;
+  }
+
+  /**
+   * Indicates whether the receiver is running.
+   *
+   * @return {@code true} between a start and a stop
+   */
+  public boolean isRunning() {
+    return running.get();
+  }
+
+  private Object handleInvocation(Object proxy, Method method, Object[] args) {
+    String name = method.getName();
+
+    if ("onClassEvent".equals(name)) {
+      if (isHotSwap(args)) {
+        scheduleReloadSafely();
+      }
+
+      return null;
+    }
+
+    if ("priority".equals(name)) {
+      return 0;
+    }
+
+    if ("equals".equals(name)) {
+      return proxy == (args != null && args.length > 0 ? args[0] : null);
+    }
+
+    if ("hashCode".equals(name)) {
+      return System.identityHashCode(proxy);
+    }
+
+    if ("toString".equals(name)) {
+      return JRebelReceiver.class.getSimpleName() + "$ClassEventListener";
+    }
+
+    return null;
+  }
+
+  private static boolean isHotSwap(Object[] args) {
+    if (args == null || args.length == 0 || !(args[0] instanceof Integer eventType)) {
+      return false;
+    }
+
+    return eventType != EVENT_LOADED;
+  }
+
+  private void scheduleReloadSafely() {
+    try {
+      scheduleReload();
+    } catch (RuntimeException e) {
+      logger.log(System.Logger.Level.DEBUG,
+          "Could not schedule a browser reload for a JRebel class reload", e);
+    }
+  }
+
+  private void scheduleReload() {
+    ScheduledExecutorService currentExecutor = executor;
+    if (currentExecutor == null) {
+      return;
+    }
+
+    ScheduledFuture<?> previous = pendingReload.getAndSet(
+        currentExecutor.schedule(this::sendReload, DEBOUNCE_DELAY_MILLIS, TimeUnit.MILLISECONDS));
+
+    if (previous != null) {
+      previous.cancel(false);
+    }
+  }
+
+  private void sendReload() {
+    pendingReload.set(null);
+
+    if (server == null || !server.isRunning()) {
+      return;
+    }
+
+    logger.log(System.Logger.Level.INFO, "Triggering browser reload for a JRebel class reload");
+    server.sendReloadMessage();
+  }
+
+  private static Method findRemoveListenerMethod(Object reloader, Object listener) {
+    for (Method method : reloader.getClass().getMethods()) {
+      if ("removeClassReloadListener".equals(method.getName()) && method.getParameterCount() == 1
+          && method.getParameterTypes()[0].isInstance(listener)) {
+        return method;
+      }
+    }
+
+    return null;
+  }
+
+  private static Thread newDaemonThread(Runnable task) {
+    Thread thread = new Thread(task, "webforj-jrebel-receiver");
+    thread.setDaemon(true);
+
+    return thread;
+  }
+
+  private static ClassLoader resolveClassLoader() {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+    return classLoader != null ? classLoader : JRebelReceiver.class.getClassLoader();
+  }
+}

--- a/webforj-devtools/src/main/java/com/webforj/devtools/livereload/LiveReloadLifecycle.java
+++ b/webforj-devtools/src/main/java/com/webforj/devtools/livereload/LiveReloadLifecycle.java
@@ -19,6 +19,7 @@ public final class LiveReloadLifecycle {
 
   private LiveReloadServer server;
   private WatchReceiver receiver;
+  private JRebelReceiver jRebelReceiver;
   private boolean notifiedRestarting;
 
   /**
@@ -44,11 +45,25 @@ public final class LiveReloadLifecycle {
         new WatchReceiver(reloadServer, options.isStaticResourcesEnabled());
     watchReceiver.start();
 
+    JRebelReceiver jRebelWatchReceiver = new JRebelReceiver(reloadServer);
+    jRebelWatchReceiver.start();
+
     this.server = reloadServer;
     this.receiver = watchReceiver;
+    this.jRebelReceiver = jRebelWatchReceiver;
     this.notifiedRestarting = false;
     logger.log(System.Logger.Level.INFO,
         "webforJ live reload ready on port " + options.getWebsocketPort());
+  }
+
+  /**
+   * Gets the receiver that listens for hotswap class reload events, so a test can assert that the
+   * lifecycle owns it.
+   *
+   * @return the receiver while the lifecycle is running, {@code null} otherwise
+   */
+  JRebelReceiver getJRebelReceiver() {
+    return jRebelReceiver;
   }
 
   /**
@@ -58,6 +73,11 @@ public final class LiveReloadLifecycle {
     if (receiver != null) {
       receiver.stop();
       receiver = null;
+    }
+
+    if (jRebelReceiver != null) {
+      jRebelReceiver.stop();
+      jRebelReceiver = null;
     }
 
     if (server != null) {

--- a/webforj-devtools/src/test/java/com/webforj/devtools/livereload/JRebelReceiverTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/livereload/JRebelReceiverTest.java
@@ -1,0 +1,254 @@
+package com.webforj.devtools.livereload;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
+
+class JRebelReceiverTest {
+
+  private static final String RELOADER_NAME = ReloaderHolder.class.getName();
+  private static final String LISTENER_NAME = ReloadListener.class.getName();
+
+  private static final int CLASS_LOADED = 0;
+  private static final int CLASS_SWAPPED = 1;
+
+  private Reloader reloader;
+  private ClassLoader previousContextClassLoader;
+
+  @BeforeEach
+  void setUp() {
+    reloader = mock(Reloader.class);
+    ReloaderHolder.current = reloader;
+    previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+  }
+
+  @AfterEach
+  void tearDown() {
+    Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+  }
+
+  @Test
+  @Timeout(10)
+  void shouldRegisterOnceAndDeregisterOnStop() {
+    JRebelReceiver receiver = receiver(runningServer());
+
+    receiver.start();
+    receiver.start();
+
+    assertTrue(receiver.isRunning());
+    ReloadListener listener = registeredListener();
+
+    receiver.stop();
+
+    assertFalse(receiver.isRunning());
+    verify(reloader).removeClassReloadListener(listener);
+  }
+
+  @Test
+  @Timeout(10)
+  void shouldCollapseABurstOfSwapsIntoOneReload() {
+    LiveReloadServer server = runningServer();
+    CountDownLatch secondReload = reloadLatch(server, 2);
+
+    JRebelReceiver receiver = receiver(server);
+    receiver.start();
+    ReloadListener listener = registeredListener();
+
+    for (int i = 0; i < 5; i++) {
+      listener.onClassEvent(CLASS_SWAPPED, JRebelReceiverTest.class);
+    }
+
+    assertFalse(await(secondReload, 500));
+    assertEquals(1, secondReload.getCount());
+
+    receiver.stop();
+  }
+
+  @Test
+  @Timeout(10)
+  void shouldReloadForASwapButNotForAPlainLoad() {
+    LiveReloadServer server = runningServer();
+    JRebelReceiver receiver = receiver(server);
+    receiver.start();
+    ReloadListener listener = registeredListener();
+
+    CountDownLatch load = reloadLatch(server, 1);
+    listener.onClassEvent(CLASS_LOADED, JRebelReceiverTest.class);
+    assertFalse(await(load, 400));
+    verify(server, never()).sendReloadMessage();
+
+    CountDownLatch swap = reloadLatch(server, 1);
+    listener.onClassEvent(CLASS_SWAPPED, JRebelReceiverTest.class);
+    assertTrue(await(swap, 2000));
+
+    receiver.stop();
+  }
+
+  @Test
+  @Timeout(10)
+  void shouldNotReloadThroughAServerThatIsNotRunning() {
+    LiveReloadServer server = mock(LiveReloadServer.class);
+    when(server.isRunning()).thenReturn(false);
+    CountDownLatch latch = reloadLatch(server, 1);
+
+    JRebelReceiver receiver = receiver(server);
+    receiver.start();
+    registeredListener().onClassEvent(CLASS_SWAPPED, JRebelReceiverTest.class);
+
+    assertFalse(await(latch, 400));
+    verify(server, never()).sendReloadMessage();
+
+    receiver.stop();
+  }
+
+  @Test
+  @Timeout(10)
+  void shouldIgnoreEventsArrivingAfterStop() {
+    LiveReloadServer server = runningServer();
+    CountDownLatch latch = reloadLatch(server, 1);
+
+    JRebelReceiver receiver = receiver(server);
+    receiver.start();
+    ReloadListener listener = registeredListener();
+    receiver.stop();
+
+    assertDoesNotThrow(() -> listener.onClassEvent(CLASS_SWAPPED, JRebelReceiverTest.class));
+    assertFalse(await(latch, 400));
+  }
+
+  @Test
+  @Timeout(10)
+  void shouldStayInertWhenTheAgentIsAbsent() {
+    JRebelReceiver receiver = receiver(runningServer());
+
+    Thread.currentThread().setContextClassLoader(new URLClassLoader(new URL[0], null));
+    receiver.start();
+
+    assertFalse(receiver.isRunning());
+    verify(reloader, never()).addClassReloadListener(any());
+  }
+
+  @Test
+  @Timeout(10)
+  void shouldStopHarmlesslyWhenNeverStartedOrWhenDeregistrationFails() {
+    assertDoesNotThrow(receiver(runningServer())::stop);
+
+    doThrow(new IllegalStateException("removal is unavailable")).when(reloader)
+        .removeClassReloadListener(any());
+
+    JRebelReceiver receiver = receiver(runningServer());
+    receiver.start();
+
+    assertDoesNotThrow(receiver::stop);
+    assertFalse(receiver.isRunning());
+  }
+
+  @Test
+  @Timeout(10)
+  void shouldLeaveNoThreadBehindWhenTheRegistrationIsRefused() {
+    long before = receiverThreadCount();
+    doThrow(new IllegalStateException("registration is refused")).when(reloader)
+        .addClassReloadListener(any());
+
+    JRebelReceiver receiver = receiver(runningServer());
+    receiver.start();
+
+    assertFalse(receiver.isRunning());
+    assertEquals(before, receiverThreadCount());
+  }
+
+  /**
+   * The listener interface the receiver builds its proxy against.
+   */
+  interface ReloadListener {
+
+    void onClassEvent(int eventType, Class<?> klass);
+  }
+
+  /**
+   * The registry the receiver registers with, mocked in every test.
+   */
+  interface Reloader {
+
+    void addClassReloadListener(ReloadListener listener);
+
+    void removeClassReloadListener(ReloadListener listener);
+  }
+
+  /**
+   * The type the receiver looks up by name to reach the registry.
+   */
+  static final class ReloaderHolder {
+
+    static Reloader current;
+
+    private ReloaderHolder() {}
+
+    public static Reloader getInstance() {
+      return current;
+    }
+  }
+
+  private ReloadListener registeredListener() {
+    ArgumentCaptor<ReloadListener> captor = ArgumentCaptor.forClass(ReloadListener.class);
+    verify(reloader).addClassReloadListener(captor.capture());
+
+    return captor.getValue();
+  }
+
+  private static long receiverThreadCount() {
+    return Thread.getAllStackTraces().keySet().stream()
+        .filter(thread -> "webforj-jrebel-receiver".equals(thread.getName()))
+        .filter(Thread::isAlive).count();
+  }
+
+  private static boolean await(CountDownLatch latch, long millis) {
+    try {
+      return latch.await(millis, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+
+      return false;
+    }
+  }
+
+  private static JRebelReceiver receiver(LiveReloadServer server) {
+    return new JRebelReceiver(server, RELOADER_NAME, LISTENER_NAME);
+  }
+
+  private static CountDownLatch reloadLatch(LiveReloadServer server, int count) {
+    CountDownLatch latch = new CountDownLatch(count);
+    doAnswer(invocation -> {
+      latch.countDown();
+
+      return null;
+    }).when(server).sendReloadMessage();
+
+    return latch;
+  }
+
+  private static LiveReloadServer runningServer() {
+    LiveReloadServer server = mock(LiveReloadServer.class);
+    when(server.isRunning()).thenReturn(true);
+
+    return server;
+  }
+}

--- a/webforj-devtools/src/test/java/com/webforj/devtools/livereload/LiveReloadLifecycleTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/livereload/LiveReloadLifecycleTest.java
@@ -1,7 +1,11 @@
 package com.webforj.devtools.livereload;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -9,6 +13,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 class LiveReloadLifecycleTest {
+
+  @Test
+  @Timeout(10)
+  void shouldStartAndStopTheJRebelReceiverWithTheLifecycle() throws IOException {
+    LiveReloadLifecycle lifecycle = new LiveReloadLifecycle();
+    try {
+      lifecycle.start(new LiveReloadOptions().setEnabled(true).setWebsocketPort(freePort()));
+
+      assertNotNull(lifecycle.getJRebelReceiver());
+    } finally {
+      lifecycle.stop();
+    }
+
+    assertNull(lifecycle.getJRebelReceiver());
+  }
 
   @Test
   void shouldNotStartWhenDisabled() {


### PR DESCRIPTION
The browser reloads after a Java class is hot swapped while the application runs, so the change reaches the page without restarting the server.

The reload needs no configuration beyond running the application under the JRebel agent.