### PR TITLE
fix: guard accessor singletons and simplify list binding lookups

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/bridge/ComponentAccessor.java
+++ b/webforj-foundation/src/main/java/com/webforj/bridge/ComponentAccessor.java
@@ -29,6 +29,7 @@ public abstract class ComponentAccessor {
    * necessary by loading the Window class to trigger the static initializer that sets the accessor.
    *
    * @return The singleton instance of the ComponentAccessor.
+   * @throws WebforjRuntimeException if the accessor cannot be initialized.
    */
   public static ComponentAccessor getDefault() {
     ComponentAccessor a = accessor;
@@ -42,7 +43,13 @@ public abstract class ComponentAccessor {
       throw new WebforjRuntimeException("Unable to load Window class.", e);
     }
 
-    return accessor;
+    a = accessor;
+    if (a == null) {
+      throw new WebforjRuntimeException(
+          "ComponentAccessor is not initialized. Loading the Window class did not set an accessor.");
+    }
+
+    return a;
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/bridge/WindowAccessor.java
+++ b/webforj-foundation/src/main/java/com/webforj/bridge/WindowAccessor.java
@@ -24,6 +24,7 @@ public abstract class WindowAccessor {
    * by loading the Window class to trigger the static initializer that sets the accessor.
    *
    * @return The singleton instance of the WindowAccessor.
+   * @throws WebforjRuntimeException if the accessor cannot be initialized.
    */
   public static WindowAccessor getDefault() {
     WindowAccessor a = accessor;
@@ -36,7 +37,13 @@ public abstract class WindowAccessor {
       throw new WebforjRuntimeException("Unable to load Window class.", e);
     }
 
-    return accessor;
+    a = accessor;
+    if (a == null) {
+      throw new WebforjRuntimeException(
+          "WindowAccessor is not initialized. Loading the Window class did not set an accessor.");
+    }
+
+    return a;
   }
 
   /**

--- a/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/DwcSelectDropdown.java
@@ -441,10 +441,11 @@ public abstract class DwcSelectDropdown<T extends DwcList<T, Object>> extends Dw
    */
   @Override
   public <B> void onBind(BindingContext<B> context, Class<B> beanClass, String propertyName) {
-    if (!context.getBinding(propertyName).getTransformer().isPresent()) {
-      @SuppressWarnings("unchecked")
-      Binding<T, Object, B, String> binding =
-          (Binding<T, Object, B, String>) context.getBinding(getSelf());
+    @SuppressWarnings("unchecked")
+    Binding<T, Object, B, String> binding =
+        (Binding<T, Object, B, String>) context.getBinding(propertyName);
+
+    if (!binding.getTransformer().isPresent()) {
       binding.setTransformer(new TypeTransformer<>());
     }
   }

--- a/webforj-foundation/src/main/java/com/webforj/component/list/ListBox.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/list/ListBox.java
@@ -388,9 +388,10 @@ public final class ListBox extends DwcList<ListBox, List<Object>>
    */
   @Override
   public <B> void onBind(BindingContext<B> context, Class<B> beanClass, String propertyName) {
-    if (!context.getBinding(propertyName).getTransformer().isPresent()) {
-      Binding<ListBox, List<Object>, B, List<String>> binding =
-          (Binding<ListBox, List<Object>, B, List<String>>) context.getBinding(this);
+    Binding<ListBox, List<Object>, B, List<String>> binding =
+        (Binding<ListBox, List<Object>, B, List<String>>) context.getBinding(propertyName);
+
+    if (!binding.getTransformer().isPresent()) {
       binding.setTransformer(new TypeTransformer<>());
     }
   }


### PR DESCRIPTION
`ComponentAccessor.getDefault()` and `WindowAccessor.getDefault()` returned the accessor field after the class loading fallback without verifying it was set, so callers dereferenced a possibly null reference. Both now re-read the field and throw `WebforjRuntimeException` with a diagnostic message.

`DwcSelectDropdown.onBind` and `ListBox.onBind` resolved the same binding twice, the second time through the overload that ends in `orElse(null)`. Both now resolve it once by property name.