### PR TITLE
feat: add disable on click support to all button components

### DIFF
--- a/webforj-components/webforj-html-elements/src/main/java/com/webforj/component/html/elements/NativeButton.java
+++ b/webforj-components/webforj-html-elements/src/main/java/com/webforj/component/html/elements/NativeButton.java
@@ -3,6 +3,7 @@ package com.webforj.component.html.elements;
 import com.webforj.component.Component;
 import com.webforj.component.element.annotation.NodeName;
 import com.webforj.component.html.HtmlComponentContainer;
+import com.webforj.concern.HasDisableOnClick;
 
 /**
  * Component representing a {@code button} element.
@@ -18,7 +19,8 @@ import com.webforj.component.html.HtmlComponentContainer;
 // framework's needs. The current structure is essential for meeting those needs.
 @SuppressWarnings("squid:S110")
 @NodeName("button")
-public class NativeButton extends HtmlComponentContainer<NativeButton> {
+public class NativeButton extends HtmlComponentContainer<NativeButton>
+    implements HasDisableOnClick<NativeButton> {
 
   /**
    * Creates a new empty button.

--- a/webforj-components/webforj-html-elements/src/test/java/com/webforj/component/html/elements/NativeButtonTest.java
+++ b/webforj-components/webforj-html-elements/src/test/java/com/webforj/component/html/elements/NativeButtonTest.java
@@ -1,0 +1,30 @@
+package com.webforj.component.html.elements;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NativeButtonTest {
+
+  NativeButton component;
+
+  @BeforeEach
+  void setUp() {
+    component = new NativeButton();
+  }
+
+  @Test
+  void shouldSetGetDisableOnClick() {
+    assertFalse(component.isDisableOnClick());
+
+    assertSame(component, component.setDisableOnClick(true));
+    assertTrue(component.isDisableOnClick());
+    assertTrue(component.getElement().isDisableOnClick());
+
+    component.setDisableOnClick(false);
+    assertFalse(component.isDisableOnClick());
+  }
+}

--- a/webforj-components/webforj-icons/src/main/java/com/webforj/component/icons/IconButton.java
+++ b/webforj-components/webforj-icons/src/main/java/com/webforj/component/icons/IconButton.java
@@ -5,6 +5,7 @@ import com.webforj.component.element.PropertyDescriptor;
 import com.webforj.component.element.annotation.NodeName;
 import com.webforj.component.event.BlurEvent;
 import com.webforj.component.event.FocusEvent;
+import com.webforj.concern.HasDisableOnClick;
 import com.webforj.concern.HasEnablement;
 import com.webforj.concern.HasFocus;
 import com.webforj.dispatcher.EventListener;
@@ -29,7 +30,8 @@ import com.webforj.dispatcher.ListenerRegistration;
  * @see TablerIcon
  */
 @NodeName("dwc-icon-button")
-public class IconButton extends Icon implements HasEnablement<Icon>, HasFocus<IconButton> {
+public class IconButton extends Icon
+    implements HasEnablement<Icon>, HasFocus<IconButton>, HasDisableOnClick<IconButton> {
 
   // Properties
   private final PropertyDescriptor<Boolean> disabledProp =

--- a/webforj-components/webforj-icons/src/test/java/com/webforj/component/icons/IconButtonTest.java
+++ b/webforj-components/webforj-icons/src/test/java/com/webforj/component/icons/IconButtonTest.java
@@ -69,6 +69,18 @@ class IconButtonTest {
     }
 
     @Test
+    void shouldSetGetDisableOnClick() {
+      assertTrue(!component.isDisableOnClick());
+
+      assertEquals(component, component.setDisableOnClick(true));
+      assertTrue(component.isDisableOnClick());
+      assertTrue(component.getOriginalElement().isDisableOnClick());
+
+      component.setDisableOnClick(false);
+      assertTrue(!component.isDisableOnClick());
+    }
+
+    @Test
     void shouldFocus() {
       IconButton spy = spy(component);
       Element element = spy(spy.getOriginalElement());

--- a/webforj-devtools/src/main/java/com/webforj/devtools/craftforj/inspector/contribution/state/HasDisableOnClickContribution.java
+++ b/webforj-devtools/src/main/java/com/webforj/devtools/craftforj/inspector/contribution/state/HasDisableOnClickContribution.java
@@ -1,29 +1,28 @@
-package com.webforj.devtools.craftforj.inspector.contribution.state.button;
+package com.webforj.devtools.craftforj.inspector.contribution.state;
 
 import com.google.auto.service.AutoService;
-import com.webforj.component.button.DwcButton;
+import com.webforj.concern.HasDisableOnClick;
 import com.webforj.devtools.craftforj.inspector.contribution.ConcernContribution;
 import com.webforj.devtools.craftforj.inspector.contribution.FeatureHandler;
 import com.webforj.devtools.craftforj.inspector.model.FeatureCategory;
 import com.webforj.devtools.craftforj.inspector.model.FeatureProperty;
 
 /**
- * Contribution for the Button disableOnClick property.
+ * Contribution for the HasDisableOnClick concern.
  *
  * @author Hyyan Abo Fakher
  * @since 26.02
  */
 @AutoService(FeatureHandler.class)
-public class ButtonDisableOnClickContribution extends ConcernContribution<DwcButton<?>> {
+public class HasDisableOnClickContribution extends ConcernContribution<HasDisableOnClick<?>> {
 
   /**
-   * Creates the Button disableOnClick contribution.
+   * Creates the HasDisableOnClick contribution.
    */
-  public ButtonDisableOnClickContribution() {
-    super(DwcButton.class, "DisableOnClick", FeatureCategory.STATE);
+  public HasDisableOnClickContribution() {
+    super(HasDisableOnClick.class, "DisableOnClick", FeatureCategory.STATE);
     setBuilderConfig(FeatureProperty.Builder::bool);
-    setGetter(DwcButton::isDisableOnClick);
+    setGetter(HasDisableOnClick::isDisableOnClick);
     setSetter((c, v) -> c.setDisableOnClick(Boolean.TRUE.equals(v)));
   }
-
 }

--- a/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector.properties
+++ b/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector.properties
@@ -39,7 +39,6 @@ props.AvatarShape.desc=Sets the outline shape of the avatar.
 
 props.BadgeLabel.desc=Sets the text displayed inside the badge.
 
-props.ButtonDisableOnClick.desc=Disables the button automatically right after it is clicked.
 props.ButtonName.desc=Sets the accessible name used for the button when its label is icon-only.
 
 props.CardBorderless.desc=Removes the frame ring drawn around the card.
@@ -90,6 +89,7 @@ props.FlexLayoutSpacing.desc=Sets the gap between items in the flex layout.
 props.FlexLayoutWrap.desc=Controls whether items wrap onto multiple lines when they run out of space.
 
 props.HasClassName.desc=Adds CSS class names to the component's root element.
+props.HasDisableOnClick.desc=Disables the component automatically right after it is clicked.
 props.HasEnablement.desc=Enables or disables user interaction with the component.
 props.HasExpanse.desc=Sets the size scale of the component, from smaller to larger.
 props.HasFileChooserFiltersVisible.desc=Shows the file type filter menu in the file chooser.

--- a/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector_de.properties
+++ b/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector_de.properties
@@ -39,7 +39,6 @@ props.AvatarShape.desc=Legt die Umrissform des Avatars fest.
 
 props.BadgeLabel.desc=Legt den Text fest, der im Badge angezeigt wird.
 
-props.ButtonDisableOnClick.desc=Deaktiviert die Schaltfläche automatisch direkt nach dem Klick.
 props.ButtonName.desc=Legt den barrierefreien Namen der Schaltfläche fest, wenn ihre Beschriftung nur aus einem Icon besteht.
 
 props.CardBorderless.desc=Entfernt den Rahmen, der um die Karte gezeichnet wird.
@@ -90,6 +89,7 @@ props.FlexLayoutSpacing.desc=Legt den Abstand zwischen den Elementen im Flex-Lay
 props.FlexLayoutWrap.desc=Steuert, ob Elemente auf mehrere Zeilen umbrechen, wenn der Platz ausgeht.
 
 props.HasClassName.desc=Fügt dem Wurzelelement der Komponente CSS-Klassennamen hinzu.
+props.HasDisableOnClick.desc=Deaktiviert die Komponente automatisch direkt nach dem Klick.
 props.HasEnablement.desc=Aktiviert oder deaktiviert die Interaktion mit der Komponente.
 props.HasExpanse.desc=Legt die Größenstufe der Komponente fest, von kleiner bis größer.
 props.HasFileChooserFiltersVisible.desc=Zeigt das Menü der Dateityp-Filter im Dateiauswahldialog.

--- a/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector_es.properties
+++ b/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector_es.properties
@@ -39,7 +39,6 @@ props.AvatarShape.desc=Define la forma del contorno del avatar.
 
 props.BadgeLabel.desc=Define el texto que se muestra dentro del badge.
 
-props.ButtonDisableOnClick.desc=Desactiva el botón automáticamente justo después de hacer clic en él.
 props.ButtonName.desc=Define el nombre accesible que se usa para el botón cuando su etiqueta es solo un icono.
 
 props.CardBorderless.desc=Elimina el marco dibujado alrededor de la tarjeta.
@@ -90,6 +89,7 @@ props.FlexLayoutSpacing.desc=Define el espacio entre los elementos del layout fl
 props.FlexLayoutWrap.desc=Controla si los elementos pasan a varias líneas cuando se quedan sin espacio.
 
 props.HasClassName.desc=Añade nombres de clase CSS al elemento raíz del componente.
+props.HasDisableOnClick.desc=Desactiva el componente automáticamente justo después de hacer clic en él.
 props.HasEnablement.desc=Activa o desactiva la interacción del usuario con el componente.
 props.HasExpanse.desc=Define la escala de tamaño del componente, de menor a mayor.
 props.HasFileChooserFiltersVisible.desc=Muestra el menú de filtros por tipo de archivo en el selector de archivos.

--- a/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector_fr.properties
+++ b/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector_fr.properties
@@ -39,7 +39,6 @@ props.AvatarShape.desc=Définit la forme du contour de l'avatar.
 
 props.BadgeLabel.desc=Définit le texte affiché à l'intérieur du badge.
 
-props.ButtonDisableOnClick.desc=Désactive automatiquement le bouton juste après un clic.
 props.ButtonName.desc=Définit le nom accessible utilisé pour le bouton lorsque son libellé se réduit à une icône.
 
 props.CardBorderless.desc=Supprime le cadre dessiné autour de la carte.
@@ -90,6 +89,7 @@ props.FlexLayoutSpacing.desc=Définit l'espacement entre les éléments de la mi
 props.FlexLayoutWrap.desc=Contrôle si les éléments passent sur plusieurs lignes lorsqu'ils manquent de place.
 
 props.HasClassName.desc=Ajoute des noms de classes CSS à l'élément racine du composant.
+props.HasDisableOnClick.desc=Désactive automatiquement le composant juste après un clic.
 props.HasEnablement.desc=Active ou désactive l'interaction de l'utilisateur avec le composant.
 props.HasExpanse.desc=Définit l'échelle de taille du composant, du plus petit au plus grand.
 props.HasFileChooserFiltersVisible.desc=Affiche le menu de filtres de types de fichiers dans le sélecteur de fichiers.

--- a/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector_nl.properties
+++ b/webforj-devtools/src/main/resources/com/webforj/devtools/craftforj/inspector/i18n/craftforj-inspector_nl.properties
@@ -39,7 +39,6 @@ props.AvatarShape.desc=Stelt de omtrekvorm van de avatar in.
 
 props.BadgeLabel.desc=Stelt de tekst in die in de badge wordt getoond.
 
-props.ButtonDisableOnClick.desc=Schakelt de knop automatisch uit direct nadat erop is geklikt.
 props.ButtonName.desc=Stelt de toegankelijke naam in die voor de knop wordt gebruikt wanneer het label alleen een icoon is.
 
 props.CardBorderless.desc=Verwijdert de rand die rond de kaart wordt getekend.
@@ -90,6 +89,7 @@ props.FlexLayoutSpacing.desc=Stelt de ruimte tussen items in de flex-layout in.
 props.FlexLayoutWrap.desc=Bepaalt of items over meerdere regels wrappen wanneer de ruimte opraakt.
 
 props.HasClassName.desc=Voegt CSS-klassenamen toe aan het root-element van het component.
+props.HasDisableOnClick.desc=Schakelt het component automatisch uit direct nadat erop is geklikt.
 props.HasEnablement.desc=Schakelt gebruikersinteractie met het component in of uit.
 props.HasExpanse.desc=Stelt de grootteschaal van het component in, van kleiner naar groter.
 props.HasFileChooserFiltersVisible.desc=Toont het menu met bestandstypefilters in de bestandskiezer.

--- a/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/inspector/contribution/state/HasDisableOnClickContributionTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/inspector/contribution/state/HasDisableOnClickContributionTest.java
@@ -1,4 +1,4 @@
-package com.webforj.devtools.craftforj.inspector.contribution.state.button;
+package com.webforj.devtools.craftforj.inspector.contribution.state;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -6,20 +6,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.webforj.component.button.Button;
+import com.webforj.component.Component;
+import com.webforj.concern.HasDisableOnClick;
 import com.webforj.devtools.craftforj.inspector.model.PropertyType;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class ButtonDisableOnClickContributionTest {
+class HasDisableOnClickContributionTest {
 
-  private final ButtonDisableOnClickContribution contribution =
-      new ButtonDisableOnClickContribution();
+  private final HasDisableOnClickContribution contribution = new HasDisableOnClickContribution();
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void shouldGet(boolean value) {
-    Button component = mock(Button.class);
+    TestComponent component = mock(TestComponent.class);
     when(component.isDisableOnClick()).thenReturn(value);
 
     var result = contribution.get(component);
@@ -33,9 +33,12 @@ class ButtonDisableOnClickContributionTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void shouldSet(boolean value) {
-    Button component = mock(Button.class);
+    TestComponent component = mock(TestComponent.class);
 
     assertTrue(contribution.set(component, value));
     verify(component).setDisableOnClick(value);
+  }
+
+  abstract static class TestComponent extends Component implements HasDisableOnClick<Component> {
   }
 }

--- a/webforj-foundation/src/main/java/com/webforj/component/button/DwcButton.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/button/DwcButton.java
@@ -10,6 +10,7 @@ import com.webforj.component.Expanse;
 import com.webforj.component.button.event.ButtonClickEvent;
 import com.webforj.component.button.sink.ButtonClickEventSink;
 import com.webforj.component.event.ComponentEventSinkRegistry;
+import com.webforj.concern.HasDisableOnClick;
 import com.webforj.concern.HasExpanse;
 import com.webforj.concern.HasFocusStatus;
 import com.webforj.concern.HasHorizontalAlignment;
@@ -35,13 +36,14 @@ import java.util.List;
  * @see HasExpanse
  * @see HasTheme
  * @see HasHorizontalAlignment
+ * @see HasDisableOnClick
  *
  * @author Hyyan Abo Fakher
  * @since 23.05
  */
 public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcFocusableComponent<T>
     implements HasExpanse<T, Expanse>, HasTheme<T, ButtonTheme>, HasHorizontalAlignment<T>,
-    HasFocusStatus, HasPrefixAndSuffix<T> {
+    HasFocusStatus, HasPrefixAndSuffix<T>, HasDisableOnClick<T> {
   private static final String BADGE_SLOT = "badge";
   private boolean disableOnClick = false;
 
@@ -121,12 +123,9 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
   }
 
   /**
-   * Sets whether the button should be immediately disabled when the user clicks it.
-   *
-   * @param disableOnClick {@code true} to disable the button when the user clicks it
-   *
-   * @return the component itself
+   * {@inheritDoc}
    */
+  @Override
   public T setDisableOnClick(boolean disableOnClick) {
     BBjButton control = inferControl();
 
@@ -143,16 +142,15 @@ public abstract class DwcButton<T extends DwcFocusableComponent<T>> extends DwcF
   }
 
   /**
-   * Returns whether the button is disabled when the user clicks it.
-   *
-   * @return {@code true} if the button is disabled when the user clicks it
+   * {@inheritDoc}
    */
+  @Override
   public boolean isDisableOnClick() {
     BBjButton control = inferControl();
 
     if (control != null) {
       try {
-        control.getDisableOnClick();
+        return control.getDisableOnClick();
       } catch (BBjException e) {
         throw new WebforjRuntimeException(e);
       }

--- a/webforj-foundation/src/main/java/com/webforj/component/element/Element.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/element/Element.java
@@ -30,6 +30,7 @@ import com.webforj.component.event.FocusEvent;
 import com.webforj.component.event.sink.ExecuteAsyncScriptEventSink;
 import com.webforj.component.optioninput.RadioButtonGroup;
 import com.webforj.component.window.Window;
+import com.webforj.concern.HasDisableOnClick;
 import com.webforj.concern.HasEnablement;
 import com.webforj.concern.HasFocus;
 import com.webforj.concern.HasJsExecution;
@@ -57,8 +58,8 @@ import java.util.Optional;
  * @author Hyyan Abo Fakher
  * @since 23.06
  */
-public final class Element extends DwcContainer<Element>
-    implements HasFocus<Element>, HasEnablement<Element>, HasJsExecution {
+public final class Element extends DwcContainer<Element> implements HasFocus<Element>,
+    HasEnablement<Element>, HasJsExecution, HasDisableOnClick<Element> {
 
   private final String nodeName;
   private final Map<String, ComponentEventSinkRegistry<ElementEvent>> registries = new HashMap<>();
@@ -74,6 +75,7 @@ public final class Element extends DwcContainer<Element>
           ExecuteAsyncScriptEvent.class);
   private final List<PendingResult<Element>> whenDefinedResults = new ArrayList<>();
   private boolean isDefined = false;
+  private boolean disableOnClick = false;
   private String html;
 
   /**
@@ -184,6 +186,47 @@ public final class Element extends DwcContainer<Element>
     }
 
     return html;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 26.02
+   */
+  @Override
+  public Element setDisableOnClick(boolean disableOnClick) {
+    BBjWebComponent control = inferControl();
+
+    if (control != null) {
+      try {
+        control.setDisableOnClick(disableOnClick);
+      } catch (BBjException e) {
+        throw new WebforjRuntimeException(e);
+      }
+    }
+
+    this.disableOnClick = disableOnClick;
+    return getSelf();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 26.02
+   */
+  @Override
+  public boolean isDisableOnClick() {
+    BBjWebComponent control = inferControl();
+
+    if (control != null) {
+      try {
+        return control.getDisableOnClick();
+      } catch (BBjException e) {
+        throw new WebforjRuntimeException(e);
+      }
+    }
+
+    return disableOnClick;
   }
 
   /**
@@ -663,6 +706,10 @@ public final class Element extends DwcContainer<Element>
 
     super.onAttach();
     focusableMixin.onAttach();
+
+    if (disableOnClick) {
+      setDisableOnClick(disableOnClick);
+    }
 
     if (!properties.isEmpty()) {
       for (Map.Entry<String, Object> entry : properties.entrySet()) {

--- a/webforj-foundation/src/main/java/com/webforj/concern/HasDisableOnClick.java
+++ b/webforj-foundation/src/main/java/com/webforj/concern/HasDisableOnClick.java
@@ -1,0 +1,48 @@
+package com.webforj.concern;
+
+import com.webforj.component.Component;
+import com.webforj.component.ComponentUtil;
+
+/**
+ * An interface for components which disable themselves as soon as the user clicks them.
+ *
+ * @param <T> the type of the component that implements this interface.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.02
+ */
+public interface HasDisableOnClick<T extends Component> {
+
+  /**
+   * Checks whether the component is disabled when the user clicks it.
+   *
+   * @return true if the component is disabled when the user clicks it
+   */
+  public default boolean isDisableOnClick() {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasDisableOnClick) {
+      return ((HasDisableOnClick<?>) component).isDisableOnClick();
+    }
+
+    throw new UnsupportedOperationException("The component does not support disable on click");
+  }
+
+  /**
+   * Sets whether the component is disabled as soon as the user clicks it.
+   *
+   * @param disableOnClick true to disable the component when the user clicks it
+   * @return the component itself
+   */
+  @SuppressWarnings("unchecked")
+  public default T setDisableOnClick(boolean disableOnClick) {
+    Component component = ComponentUtil.getBoundComponent(this);
+
+    if (component instanceof HasDisableOnClick) {
+      ((HasDisableOnClick<?>) component).setDisableOnClick(disableOnClick);
+      return (T) this;
+    }
+
+    throw new UnsupportedOperationException("The component does not support disable on click");
+  }
+}

--- a/webforj-foundation/src/test/java/com/webforj/component/element/ElementTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/ElementTest.java
@@ -182,6 +182,57 @@ class ElementTest {
   }
 
   @Nested
+  @DisplayName("DisableOnClick API")
+  class DisableOnClickApi {
+
+    @Test
+    @DisplayName("Setting/getting disableOnClick when control is null")
+    void settingGettingDisableOnClickWhenControlIsNull()
+        throws IllegalAccessException, BBjException {
+      ReflectionUtils.nullifyControl(component);
+      component.setDisableOnClick(true);
+      assertTrue(component.isDisableOnClick());
+
+      verify(control, times(0)).setDisableOnClick(true);
+      verify(control, times(0)).getDisableOnClick();
+    }
+
+    @Test
+    @DisplayName("Setting/getting disableOnClick when control is not null")
+    void settingGettingDisableOnClickWhenControlIsNotNull() throws BBjException {
+      when(control.getDisableOnClick()).thenReturn(true);
+      component.setDisableOnClick(true);
+
+      assertTrue(component.isDisableOnClick());
+
+      verify(control, times(1)).setDisableOnClick(true);
+      verify(control, times(1)).getDisableOnClick();
+    }
+
+    @Test
+    @DisplayName("When control throws BBjException a DwcjRuntimeException is thrown")
+    void shouldThrowDwcjRuntimeException() throws BBjException {
+      doThrow(BBjException.class).when(control).setDisableOnClick(true);
+      assertThrows(WebforjRuntimeException.class, () -> component.setDisableOnClick(true));
+
+      doThrow(BBjException.class).when(control).getDisableOnClick();
+      assertThrows(WebforjRuntimeException.class, () -> component.isDisableOnClick());
+    }
+
+    @Test
+    @DisplayName("onAttach will re-apply disableOnClick changes")
+    void onAttachWillReapplyDisableOnClickChanges() throws BBjException, IllegalAccessException {
+      ReflectionUtils.nullifyControl(component);
+      component.setDisableOnClick(true);
+
+      ReflectionUtils.unNullifyControl(component, control);
+      component.onAttach();
+
+      verify(control, times(1)).setDisableOnClick(true);
+    }
+  }
+
+  @Nested
   @DisplayName("Events API")
   class EventsApi {
 

--- a/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/ConcernComponentMock.java
@@ -29,7 +29,7 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
     HasRestoreValue<ConcernComponentMock, Double>, HasLocale<ConcernComponentMock>,
     HasStep<ConcernComponentMock, Double>, HasPredictedText<ConcernComponentMock>,
     HasSize<ConcernComponentMock>, HasPrefixAndSuffix<ConcernComponentMock>,
-    HasAutoFocus<ConcernComponentMock> {
+    HasAutoFocus<ConcernComponentMock>, HasDisableOnClick<ConcernComponentMock> {
 
   private Map<String, String> attributes = new HashMap<>();
   private Map<String, Object> properties = new HashMap<>();
@@ -74,6 +74,7 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
   private Component prefixComponent;
   private Component suffixComponent;
   private boolean autofocus = false;
+  private boolean disableOnClick = false;
 
   @Override
   public String getAttribute(String attribute) {
@@ -623,6 +624,17 @@ class ConcernComponentMock extends Component implements HasAttribute<ConcernComp
   @Override
   public boolean isAutoFocus() {
     return this.autofocus;
+  }
+
+  @Override
+  public ConcernComponentMock setDisableOnClick(boolean disableOnClick) {
+    this.disableOnClick = disableOnClick;
+    return this;
+  }
+
+  @Override
+  public boolean isDisableOnClick() {
+    return this.disableOnClick;
   }
 
   @Override

--- a/webforj-foundation/src/test/java/com/webforj/concern/HasDisableOnClickTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/concern/HasDisableOnClickTest.java
@@ -1,0 +1,61 @@
+package com.webforj.concern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.webforj.component.Component;
+import com.webforj.component.Composite;
+import com.webforj.component.window.Window;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HasDisableOnClickTest {
+
+  private CompositeMock component;
+
+  @BeforeEach
+  void setup() {
+    component = new CompositeMock();
+  }
+
+  @Test
+  void shouldSetGetDisableOnClick() {
+    assertFalse(component.isDisableOnClick());
+
+    assertSame(component, component.setDisableOnClick(true));
+    assertTrue(component.isDisableOnClick());
+
+    component.setDisableOnClick(false);
+    assertFalse(component.isDisableOnClick());
+  }
+
+  @Test
+  void shouldThrowWhenBoundComponentDoesNotSupportDisableOnClick() {
+    UnsupportedCompositeMock unsupported = new UnsupportedCompositeMock();
+
+    assertThrows(UnsupportedOperationException.class, () -> unsupported.setDisableOnClick(true));
+    assertThrows(UnsupportedOperationException.class, unsupported::isDisableOnClick);
+  }
+
+  class CompositeMock extends Composite<ConcernComponentMock>
+      implements HasDisableOnClick<CompositeMock> {
+  }
+
+  class UnsupportedCompositeMock extends Composite<PlainComponentMock>
+      implements HasDisableOnClick<UnsupportedCompositeMock> {
+  }
+
+  static class PlainComponentMock extends Component {
+    @Override
+    protected void onCreate(Window window) {
+      // pass
+    }
+
+    @Override
+    protected void onDestroy() {
+      // pass
+    }
+  }
+}


### PR DESCRIPTION
A component that implements `HasDisableOnClick` disables itself as soon as the user clicks it, and stays disabled until it is enabled again. `Button` already supported this behavior, and it is now available on `IconButton`, `NativeButton` and `Element`.

Any component backed by an `Element` supports the concern by declaring it.

```java
@NodeName("my-button")
public class MyButton extends ElementComposite 
      implements HasDisableOnClick<MyButton> {
      // ....
}
```

Closes #1273