### PR TITLE
feat: Add support for complete callbacks in `ViewTransition`. 

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/ViewTransition.java
+++ b/webforj-foundation/src/main/java/com/webforj/ViewTransition.java
@@ -193,6 +193,8 @@ public final class ViewTransition {
    *
    * @param callback the callback to execute when the transition completes
    * @return this builder for chaining
+   *
+   * @since 26.01
    */
   public ViewTransition onComplete(Runnable callback) {
     this.completeCallback = callback;

--- a/webforj-foundation/src/main/java/com/webforj/ViewTransition.java
+++ b/webforj-foundation/src/main/java/com/webforj/ViewTransition.java
@@ -122,6 +122,7 @@ public final class ViewTransition {
   private final String transitionId;
   private Consumer<Runnable> updateCallback;
   private Runnable readyCallback;
+  private Runnable completeCallback;
   private String defaultType;
   private final Map<Component, String> exitComponents = new LinkedHashMap<>();
   private final Map<Component, String> enterComponents = new LinkedHashMap<>();
@@ -178,6 +179,23 @@ public final class ViewTransition {
    */
   public ViewTransition onReady(Runnable callback) {
     this.readyCallback = callback;
+    return this;
+  }
+
+  /**
+   * Sets a callback to execute when the transition fully completes.
+   *
+   * <p>
+   * This callback is invoked after the browser reports that the transition has finished animating.
+   * Use it for follow-up work that should only run after the update phase and transition lifecycle
+   * are fully complete.
+   * </p>
+   *
+   * @param callback the callback to execute when the transition completes
+   * @return this builder for chaining
+   */
+  public ViewTransition onComplete(Runnable callback) {
+    this.completeCallback = callback;
     return this;
   }
 
@@ -338,6 +356,15 @@ public final class ViewTransition {
   void executeReady() {
     if (readyCallback != null) {
       readyCallback.run();
+    }
+  }
+
+  /**
+   * Executes the complete callback. Called by the JS coordination code.
+   */
+  void executeComplete() {
+    if (completeCallback != null) {
+      completeCallback.run();
     }
   }
 

--- a/webforj-foundation/src/main/java/com/webforj/ViewTransitionManager.java
+++ b/webforj-foundation/src/main/java/com/webforj/ViewTransitionManager.java
@@ -135,11 +135,14 @@ final class ViewTransitionManager {
   }
 
   /**
-   * Completes a view transition and removes it from tracking.
+   * Completes a view transition, executes its completion callback, and removes it from tracking.
    *
    * @param transitionId the transition ID
    */
   void executeComplete(String transitionId) {
-    pendingTransitions.remove(transitionId);
+    ViewTransition transition = pendingTransitions.remove(transitionId);
+    if (transition != null) {
+      transition.executeComplete();
+    }
   }
 }

--- a/webforj-foundation/src/test/java/com/webforj/ViewTransitionManagerTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/ViewTransitionManagerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.webforj.utilities.Assets;
@@ -93,6 +94,11 @@ class ViewTransitionManagerTest {
 
       manager.register("test-id", transition);
       assertDoesNotThrow(() -> manager.executeComplete("test-id"));
+
+      verify(transition).executeComplete();
+
+      manager.executeReady("test-id");
+      verify(transition, never()).executeReady();
     }
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/ViewTransitionTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/ViewTransitionTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.webforj.component.element.Element;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -115,11 +117,39 @@ class ViewTransitionTest {
     }
 
     @Test
+    @DisplayName("should execute complete callback")
+    void shouldRunCompleteCallback() {
+      AtomicBoolean called = new AtomicBoolean(false);
+      viewTransition.onComplete(() -> called.set(true));
+      viewTransition.executeComplete();
+      assertTrue(called.get());
+    }
+
+    @Test
+    @DisplayName("should run complete after update finishes")
+    void shouldRunCompleteAfterUpdateFinishes() {
+      List<String> events = new ArrayList<>();
+
+      viewTransition.onUpdate(done -> {
+        events.add("update");
+        done.run();
+        events.add("after-done");
+      });
+      viewTransition.onComplete(() -> events.add("complete"));
+
+      viewTransition.executeUpdate(() -> events.add("done"));
+      viewTransition.executeComplete();
+
+      assertEquals(List.of("update", "done", "after-done", "complete"), events);
+    }
+
+    @Test
     @DisplayName("should handle null callbacks gracefully")
     void shouldHandleNullCallbacks() {
       assertDoesNotThrow(() -> viewTransition.executeUpdate(() -> {
       }));
       assertDoesNotThrow(() -> viewTransition.executeReady());
+      assertDoesNotThrow(() -> viewTransition.executeComplete());
     }
   }
 


### PR DESCRIPTION
Extend `ViewTransitionManager` to handle and execute these callbacks during transition completion. 

closes #1275 