### PR TITLE
fix: omit frame domains from the MCP app resource policy

### DIFF
--- a/webforj-mcp-apps/src/main/java/com/webforj/mcp/McpAppResource.java
+++ b/webforj-mcp-apps/src/main/java/com/webforj/mcp/McpAppResource.java
@@ -149,8 +149,7 @@ public class McpAppResource {
     String socketOrigin = origin.replaceFirst("^http", "ws");
 
     return Map.of("resourceDomains",
-        merge(List.of(origin), FRAMEWORK_RESOURCE_DOMAINS, resourceDomains.get()), "frameDomains",
-        List.of(origin), "connectDomains",
+        merge(List.of(origin), FRAMEWORK_RESOURCE_DOMAINS, resourceDomains.get()), "connectDomains",
         merge(List.of(origin, socketOrigin), FRAMEWORK_CONNECT_DOMAINS, connectDomains.get()));
   }
 
@@ -158,8 +157,8 @@ public class McpAppResource {
     String socketOrigin = origin.replaceFirst("^http", "ws");
 
     return Map.of("resource_domains",
-        merge(List.of(origin), FRAMEWORK_RESOURCE_DOMAINS, resourceDomains.get()), "frame_domains",
-        List.of(origin), "connect_domains",
+        merge(List.of(origin), FRAMEWORK_RESOURCE_DOMAINS, resourceDomains.get()),
+        "connect_domains",
         merge(List.of(origin, socketOrigin), FRAMEWORK_CONNECT_DOMAINS, connectDomains.get()));
   }
 

--- a/webforj-mcp-apps/src/test/java/com/webforj/mcp/McpAppResourceTest.java
+++ b/webforj-mcp-apps/src/test/java/com/webforj/mcp/McpAppResourceTest.java
@@ -155,7 +155,8 @@ class McpAppResourceTest {
     assertEquals(
         List.of("https://app.example.com", "https://cdn.jsdelivr.net", "https://www.gstatic.com"),
         csp.get("resourceDomains"));
-    assertEquals(List.of("https://app.example.com"), csp.get("frameDomains"));
+    assertFalse(csp.containsKey("frameDomains"),
+        "an application that embeds no frames must not ask hosts for frame permissions");
     assertEquals(List.of("https://app.example.com", "wss://app.example.com",
         "https://cdn.jsdelivr.net", "https://www.gstatic.com", "data:"), csp.get("connectDomains"));
   }
@@ -174,7 +175,8 @@ class McpAppResourceTest {
     assertEquals(
         List.of("https://app.example.com", "https://cdn.jsdelivr.net", "https://www.gstatic.com"),
         widgetCsp.get("resource_domains"));
-    assertEquals(List.of("https://app.example.com"), widgetCsp.get("frame_domains"));
+    assertFalse(widgetCsp.containsKey("frame_domains"),
+        "an application that embeds no frames must not ask hosts for frame permissions");
     assertEquals(List.of("https://app.example.com", "wss://app.example.com",
         "https://cdn.jsdelivr.net", "https://www.gstatic.com", "data:"),
         widgetCsp.get("connect_domains"));


### PR DESCRIPTION
The published policy declared the application origin under frameDomains and under the legacy frame_domains key although the served page never embeds an iframe. Hosts read a declared frame domain as a request to embed external content and route the connector into a stricter review. With the keys omitted the specification default applies and the application requests no frame permissions at all.