### PR TITLE
feat: add AppNavLabel component

### DIFF
--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNavItem.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNavItem.java
@@ -37,8 +37,8 @@ public class AppNavItem extends NavigationContainer<AppNavItem> implements HasSt
     HasText<AppNavItem>, HasPrefixAndSuffix<AppNavItem>, HasEnablement<AppNavItem> {
   private String path;
   private ParametersBag queryParameters;
-  private Component prefix;
-  private Component suffix;
+  private final SlottedComponent prefix = new SlottedComponent();
+  private final SlottedComponent suffix = new SlottedComponent();
 
   private static final String SLOT_PREFIX = "prefix";
   private static final String SLOT_SUFFIX = "suffix";
@@ -366,16 +366,7 @@ public class AppNavItem extends NavigationContainer<AppNavItem> implements HasSt
    */
   @Override
   public AppNavItem setPrefixComponent(Component prefix) {
-    if (prefix.equals(this.prefix)) {
-      return this;
-    }
-
-    if (this.prefix != null) {
-      this.prefix.destroy();
-    }
-
-    this.prefix = prefix;
-    getElement().add(SLOT_PREFIX, prefix);
+    this.prefix.set(getElement(), SLOT_PREFIX, prefix);
     return this;
   }
 
@@ -384,7 +375,7 @@ public class AppNavItem extends NavigationContainer<AppNavItem> implements HasSt
    */
   @Override
   public Component getPrefixComponent() {
-    return prefix;
+    return prefix.get();
   }
 
   /**
@@ -392,16 +383,7 @@ public class AppNavItem extends NavigationContainer<AppNavItem> implements HasSt
    */
   @Override
   public AppNavItem setSuffixComponent(Component suffix) {
-    if (suffix.equals(this.suffix)) {
-      return this;
-    }
-
-    if (this.suffix != null) {
-      this.suffix.destroy();
-    }
-
-    this.suffix = suffix;
-    getElement().add(SLOT_SUFFIX, suffix);
+    this.suffix.set(getElement(), SLOT_SUFFIX, suffix);
     return this;
   }
 
@@ -410,7 +392,7 @@ public class AppNavItem extends NavigationContainer<AppNavItem> implements HasSt
    */
   @Override
   public Component getSuffixComponent() {
-    return suffix;
+    return suffix.get();
   }
 
   /**

--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNavLabel.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNavLabel.java
@@ -35,8 +35,8 @@ import com.webforj.concern.HasVisibility;
 public class AppNavLabel extends ElementComposite
     implements HasText<AppNavLabel>, HasStyle<AppNavLabel>, HasClassName<AppNavLabel>,
     HasAttribute<AppNavLabel>, HasVisibility<AppNavLabel>, HasPrefixAndSuffix<AppNavLabel> {
-  private Component prefix;
-  private Component suffix;
+  private final SlottedComponent prefix = new SlottedComponent();
+  private final SlottedComponent suffix = new SlottedComponent();
 
   private static final String SLOT_PREFIX = "prefix";
   private static final String SLOT_SUFFIX = "suffix";
@@ -77,16 +77,7 @@ public class AppNavLabel extends ElementComposite
    */
   @Override
   public AppNavLabel setPrefixComponent(Component prefix) {
-    if (prefix.equals(this.prefix)) {
-      return this;
-    }
-
-    if (this.prefix != null) {
-      this.prefix.destroy();
-    }
-
-    this.prefix = prefix;
-    getElement().add(SLOT_PREFIX, prefix);
+    this.prefix.set(getElement(), SLOT_PREFIX, prefix);
     return this;
   }
 
@@ -95,7 +86,7 @@ public class AppNavLabel extends ElementComposite
    */
   @Override
   public Component getPrefixComponent() {
-    return prefix;
+    return prefix.get();
   }
 
   /**
@@ -103,16 +94,7 @@ public class AppNavLabel extends ElementComposite
    */
   @Override
   public AppNavLabel setSuffixComponent(Component suffix) {
-    if (suffix.equals(this.suffix)) {
-      return this;
-    }
-
-    if (this.suffix != null) {
-      this.suffix.destroy();
-    }
-
-    this.suffix = suffix;
-    getElement().add(SLOT_SUFFIX, suffix);
+    this.suffix.set(getElement(), SLOT_SUFFIX, suffix);
     return this;
   }
 
@@ -121,6 +103,6 @@ public class AppNavLabel extends ElementComposite
    */
   @Override
   public Component getSuffixComponent() {
-    return suffix;
+    return suffix.get();
   }
 }

--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNavLabel.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/AppNavLabel.java
@@ -1,0 +1,126 @@
+package com.webforj.component.layout.appnav;
+
+import com.webforj.component.Component;
+import com.webforj.component.element.ElementComposite;
+import com.webforj.component.element.annotation.NodeName;
+import com.webforj.concern.HasAttribute;
+import com.webforj.concern.HasClassName;
+import com.webforj.concern.HasPrefixAndSuffix;
+import com.webforj.concern.HasStyle;
+import com.webforj.concern.HasText;
+import com.webforj.concern.HasVisibility;
+
+/**
+ * A non interactive section label for the application navigator {@link AppNav}.
+ *
+ * <p>
+ * A label is placed between the top level items of the navigator and titles the run of following
+ * items up to the next label or the end of the menu. The navigator hides a label automatically when
+ * its section has no visible items, for example when a search filters them all out or when all of
+ * them are pinned away.
+ * </p>
+ *
+ * <p>
+ * A label is composed into the navigator like any other component, the order of the calls defines
+ * the sections. For example {@code nav.add(new AppNavLabel("Management"))} followed by
+ * {@code nav.addItem(users)}.
+ * </p>
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.02
+ *
+ * @see AppNav
+ */
+@NodeName("dwc-app-nav-label")
+public class AppNavLabel extends ElementComposite
+    implements HasText<AppNavLabel>, HasStyle<AppNavLabel>, HasClassName<AppNavLabel>,
+    HasAttribute<AppNavLabel>, HasVisibility<AppNavLabel>, HasPrefixAndSuffix<AppNavLabel> {
+  private Component prefix;
+  private Component suffix;
+
+  private static final String SLOT_PREFIX = "prefix";
+  private static final String SLOT_SUFFIX = "suffix";
+
+  /**
+   * Constructs a new label.
+   */
+  public AppNavLabel() {
+    super();
+  }
+
+  /**
+   * Constructs a new label with the given text.
+   *
+   * @param text the text of the label
+   */
+  public AppNavLabel(String text) {
+    this();
+    setText(text);
+  }
+
+  /**
+   * Constructs a new label with the given text and prefix.
+   *
+   * @param text the text of the label
+   * @param prefix the prefix component of the label
+   */
+  public AppNavLabel(String text, Component prefix) {
+    this(text);
+
+    if (prefix != null) {
+      setPrefixComponent(prefix);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public AppNavLabel setPrefixComponent(Component prefix) {
+    if (prefix.equals(this.prefix)) {
+      return this;
+    }
+
+    if (this.prefix != null) {
+      this.prefix.destroy();
+    }
+
+    this.prefix = prefix;
+    getElement().add(SLOT_PREFIX, prefix);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Component getPrefixComponent() {
+    return prefix;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public AppNavLabel setSuffixComponent(Component suffix) {
+    if (suffix.equals(this.suffix)) {
+      return this;
+    }
+
+    if (this.suffix != null) {
+      this.suffix.destroy();
+    }
+
+    this.suffix = suffix;
+    getElement().add(SLOT_SUFFIX, suffix);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Component getSuffixComponent() {
+    return suffix;
+  }
+}

--- a/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/SlottedComponent.java
+++ b/webforj-components/webforj-appnav/src/main/java/com/webforj/component/layout/appnav/SlottedComponent.java
@@ -1,0 +1,43 @@
+package com.webforj.component.layout.appnav;
+
+import com.webforj.component.Component;
+import com.webforj.component.element.Element;
+
+/**
+ * Holds the single component of a named slot.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 26.02
+ */
+final class SlottedComponent {
+  private Component component;
+
+  /**
+   * Returns the component currently held by the slot.
+   *
+   * @return the slot component, or {@code null} when none was set
+   */
+  Component get() {
+    return component;
+  }
+
+  /**
+   * Places the given component in the slot.
+   *
+   * @param element the element owning the slot
+   * @param slot the name of the slot
+   * @param value the component to place
+   */
+  void set(Element element, String slot, Component value) {
+    if (value.equals(component)) {
+      return;
+    }
+
+    if (component != null) {
+      component.destroy();
+    }
+
+    component = value;
+    element.add(slot, value);
+  }
+}

--- a/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavLabelTest.java
+++ b/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavLabelTest.java
@@ -1,0 +1,97 @@
+package com.webforj.component.layout.appnav;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.webforj.component.Component;
+import com.webforj.component.element.Element;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AppNavLabelTest {
+
+  AppNavLabel component;
+
+  @BeforeEach
+  void setUp() {
+    component = new AppNavLabel();
+  }
+
+  @Nested
+  class ConstructorsTest {
+
+    @Test
+    void shouldCreateLabelWithText() {
+      String text = "Management";
+
+      AppNavLabel label = new AppNavLabel(text);
+
+      assertEquals(text, label.getText());
+    }
+
+    @Test
+    void shouldCreateLabelWithTextAndPrefix() {
+      String text = "Management";
+      Component prefix = new Element("div");
+
+      AppNavLabel label = new AppNavLabel(text, prefix);
+
+      assertEquals(text, label.getText());
+      assertEquals(prefix, label.getPrefixComponent());
+    }
+  }
+
+  @Nested
+  class PrefixSuffixApi {
+
+    @Test
+    void shouldSetPrefixAndSuffix() {
+      Element prefix = new Element("span");
+      Element suffix = new Element("span");
+      component.setPrefixComponent(prefix);
+      component.setSuffixComponent(suffix);
+
+      assertSame(prefix, component.getPrefixComponent());
+      assertSame(suffix, component.getSuffixComponent());
+    }
+
+    @Test
+    void shouldDestroyPreviousPrefixAndSuffix() {
+      Element oldPrefix = new Element("span");
+      Element oldSuffix = new Element("span");
+      component.setPrefixComponent(oldPrefix);
+      component.setSuffixComponent(oldSuffix);
+
+      Element newPrefix = new Element("span");
+      Element newSuffix = new Element("span");
+      component.setPrefixComponent(newPrefix);
+      component.setSuffixComponent(newSuffix);
+
+      assertTrue(oldPrefix.isDestroyed());
+      assertTrue(oldSuffix.isDestroyed());
+
+      assertSame(newPrefix, component.getPrefixComponent());
+      assertSame(newSuffix, component.getSuffixComponent());
+    }
+
+    @Test
+    void shouldIgnoreSamePrefixAndSuffix() {
+      Element prefix = new Element("span");
+      Element suffix = new Element("span");
+      component.setPrefixComponent(prefix);
+      component.setSuffixComponent(suffix);
+
+      component.setPrefixComponent(prefix);
+      component.setSuffixComponent(suffix);
+
+      assertFalse(prefix.isDestroyed());
+      assertFalse(suffix.isDestroyed());
+
+      assertSame(prefix, component.getPrefixComponent());
+      assertSame(suffix, component.getSuffixComponent());
+    }
+  }
+}

--- a/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNav.kt
+++ b/webforj-kotlin/src/main/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNav.kt
@@ -3,6 +3,7 @@ package com.webforj.kotlin.dsl.component.layout.appnav
 import com.webforj.component.Component
 import com.webforj.component.layout.appnav.AppNav
 import com.webforj.component.layout.appnav.AppNavItem
+import com.webforj.component.layout.appnav.AppNavLabel
 import com.webforj.concern.HasComponents
 import com.webforj.kotlin.dsl.WebforjDsl
 import com.webforj.kotlin.dsl.init
@@ -107,6 +108,34 @@ fun @WebforjDsl AppNavItem.appNavItem(
   addItem(item)
   return item
 }
+
+/**
+ * Adds an `AppNavLabel` to the `AppNav`, a non interactive section label that titles the run of
+ * items that follow it, up to the next label or the end of the menu.
+ * ```
+ * appNav {
+ *   appNavItem("Home", "/home")
+ *   appNavLabel("Analytics") {
+ *     prefixSlot { icon("chart-pie") }
+ *     suffixSlot { badge("2") }
+ *   }
+ *   appNavItem("Overview", OverviewView::class)
+ * }
+ * ```
+ *
+ * To configure the slots of the `AppNavLabel` see:
+ * - [prefixSlot], and
+ * - [suffixSlot]
+ *
+ * @param text The display text of the label.
+ * @param block The initialization steps of the `AppNavLabel`.
+ * @return The configured `AppNavLabel`.
+ * @see AppNavLabel
+ */
+fun @WebforjDsl AppNav.appNavLabel(
+  text: String,
+  block: @WebforjDsl AppNavLabel.() -> Unit = {}
+): AppNavLabel = init(AppNavLabel(text), block)
 
 /**
  * Configures the `AppNav`'s embedded search field.

--- a/webforj-kotlin/src/test/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNavTest.kt
+++ b/webforj-kotlin/src/test/kotlin/com/webforj/kotlin/dsl/component/layout/appnav/AppNavTest.kt
@@ -184,4 +184,36 @@ class AppNavTest {
       }
     }
   }
+
+  @Test
+  fun shouldCreateAppNavLabel() {
+    val appNav = root.appNav {
+      val label = appNavLabel("Analytics")
+      assertTrue { hasComponent(label) }
+      assertEquals("Analytics", label.text)
+    }
+
+    assertTrue(root.hasComponent(appNav))
+  }
+
+  @Test
+  fun shouldCreateAppNavLabelWithPrefixAndSuffix() {
+    val appNav = root.appNav {
+      val navLabel = appNavLabel("Analytics") {
+        prefixSlot {
+          label("pie")
+        }
+        suffixSlot {
+          label("2")
+        }
+        val prefixComponent = prefix as Label
+        val suffixComponent = suffix as Label
+        assertEquals("pie", prefixComponent.text)
+        assertEquals("2", suffixComponent.text)
+      }
+      assertEquals("Analytics", navLabel.text)
+    }
+
+    assertTrue(root.hasComponent(appNav))
+  }
 }


### PR DESCRIPTION
Adds `AppNavLabel`, a non interactive section label for `AppNav`. A label is composed into the navigator like any other component and titles the run of items that follow it, up to the next label or the end of the menu.

```java
AppNav nav = new AppNav();
nav.addItem(new AppNavItem("Dashboard", DashboardView.class, TablerIcon.create("layout-dashboard")));

AppNavLabel analytics = new AppNavLabel("Analytics", TablerIcon.create("chart-pie"));
analytics.setSuffixComponent(new Badge("2", BadgeTheme.WARNING));
nav.add(analytics);

nav.addItem(new AppNavItem("Overview", OverviewView.class));
nav.addItem(new AppNavItem("Reports", ReportsView.class));

nav.add(new AppNavLabel("Other"));
nav.addItem(new AppNavItem("Settings", SettingsView.class));
```
