### PR TITLE
feat: use spotless to enforce Java & Kotlin coding standards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,16 @@
                 <style>GOOGLE</style>
               </googleJavaFormat>
             </java>
+            <kotlin>
+              <includes>
+                <include>src/main/kotlin/**/*.kt</include>
+                <include>src/test/kotlin/**/*.kt</include>
+              </includes>
+              <ktfmt>
+                <version>0.64</version>
+                <style>KOTLINLANG</style>
+              </ktfmt>
+            </kotlin>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,24 @@
         </plugin>
 
         <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>3.10.0</version>
+          <configuration>
+            <java>
+              <includes>
+                <include>src/main/java/**/*.java</include>
+                <include>src/test/java/**/*.java</include>
+              </includes>
+              <googleJavaFormat>
+                <version>1.36.1</version>
+                <style>GOOGLE</style>
+              </googleJavaFormat>
+            </java>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <groupId>org.sonatype.central</groupId>
           <artifactId>central-publishing-maven-plugin</artifactId>
           <version>0.11.0</version>
@@ -248,6 +266,20 @@
           <execution>
             <goals>
               <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>spotless-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -221,8 +221,8 @@
           <configuration>
             <java>
               <includes>
-                <include>src/main/java/**/*.java</include>
-                <include>src/test/java/**/*.java</include>
+                <include>**/src/main/java/**/*.java</include>
+                <include>**/src/test/java/**/*.java</include>
               </includes>
               <googleJavaFormat>
                 <version>1.36.1</version>
@@ -231,8 +231,8 @@
             </java>
             <kotlin>
               <includes>
-                <include>src/main/kotlin/**/*.kt</include>
-                <include>src/test/kotlin/**/*.kt</include>
+                <include>**/src/main/kotlin/**/*.kt</include>
+                <include>**/src/test/kotlin/**/*.kt</include>
               </includes>
               <ktfmt>
                 <version>0.64</version>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
               </includes>
               <ktfmt>
                 <version>0.64</version>
-                <style>KOTLINLANG</style>
+                <style>GOOGLE</style>
               </ktfmt>
             </kotlin>
           </configuration>


### PR DESCRIPTION
Closes #1479 

The formatting of the Java and Kotlin files are not modified by his PR. 

This still has to be done by running `mvn spotless:apply`