### PR TITLE
build: use spotless to format Java and Kotlin files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,8 @@
           <artifactId>spotless-maven-plugin</artifactId>
           <version>3.10.0</version>
           <configuration>
+            <lineEndings>UNIX</lineEndings>
+            <encoding>UTF-8</encoding>
             <java>
               <includes>
                 <include>**/src/main/java/**/*.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -275,25 +275,6 @@
       </plugin>
 
       <plugin>
-        <groupId>net.revelc.code.formatter</groupId>
-        <artifactId>formatter-maven-plugin</artifactId>
-        <version>2.29.0</version>
-        <configuration>
-          <configFile>
-            https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml</configFile>
-          <lineEnding>LF</lineEnding>
-          <encoding>UTF-8</encoding>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.6.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,44 @@
         </plugin>
 
         <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>3.10.0</version>
+          <configuration>
+            <java>
+              <includes>
+                <include>**/src/main/java/**/*.java</include>
+                <include>**/src/test/java/**/*.java</include>
+              </includes>
+              <eclipse>
+                <file>
+                  https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml
+                </file>
+              </eclipse>
+            </java>
+            <kotlin>
+              <includes>
+                <include>**/src/main/kotlin/**/*.kt</include>
+                <include>**/src/test/kotlin/**/*.kt</include>
+              </includes>
+              <ktfmt>
+                <version>0.64</version>
+                <style>GOOGLE</style>
+              </ktfmt>
+            </kotlin>
+          </configuration>
+          <executions>
+            <execution>
+              <id>spotless-check</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
           <groupId>org.sonatype.central</groupId>
           <artifactId>central-publishing-maven-plugin</artifactId>
           <version>0.11.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -238,20 +238,10 @@
                 <include>**/src/test/kotlin/**/*.kt</include>
               </includes>
               <ktfmt>
-                <version>0.64</version>
                 <style>GOOGLE</style>
               </ktfmt>
             </kotlin>
           </configuration>
-          <executions>
-            <execution>
-              <id>spotless-check</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
 
         <plugin>
@@ -272,6 +262,20 @@
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
         <extensions>true</extensions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>spotless-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Updated PR that uses the Eclipse formatter with Google styleguide to format Java code delivering identical results to the current formatter. Kotlin source files are formatted according to the Google styleguide.

New maven commands:

* mvn spotless:check
* mvn spotless:apply

The `formatter-maven-plugin` was removed, because it is no longer needed:

```
      <plugin>
        <groupId>net.revelc.code.formatter</groupId>
        <artifactId>formatter-maven-plugin</artifactId>
        <version>2.29.0</version>
        <configuration>
          <configFile>
            https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml</configFile>
          <lineEnding>LF</lineEnding>
          <encoding>UTF-8</encoding>
        </configuration>
        <executions>
          <execution>
            <goals>
              <goal>format</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
  ```
