### PR TITLE
docs: align DateTimeField and TimeField with minute-based format #1497

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/component/field/DateTimeField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/DateTimeField.java
@@ -211,7 +211,7 @@ public final class DateTimeField extends DwcFieldInitializer<DateTimeField, Loca
   public DateTimeField setText(String text) {
     if (text != null && !text.isEmpty() && !DateTimeField.isValidDateTime(text)) {
       throw new IllegalArgumentException(
-          "Text must be a valid date and time in yyyy-MM-ddTHH:mm:ss format");
+          "Text must be a valid date and time in yyyy-MM-ddTHH:mm format (seconds are truncated)");
     }
 
     if (min != null && text != null && compareDateTime(LocalDateTime.parse(text), min) < 0) {
@@ -249,20 +249,29 @@ public final class DateTimeField extends DwcFieldInitializer<DateTimeField, Loca
   }
 
   /**
-   * Convert a date and time string in yyyy-MM-ddTHH:mm:ss format to a LocalDateTime.
+   * Convert a date and time string to a LocalDateTime truncated to minutes.
    *
-   * @param dateTimeAsString the date and time string in yyyy-MM-ddTHH:mm:ss format
-   * @return the LocalDateTime
+   * <p>
+   * Seconds in the input are accepted and then dropped. The effective format is
+   * {@code yyyy-MM-ddTHH:mm}.
+   * </p>
+   *
+   * @param dateTimeAsString the date and time string, optionally including seconds
+   * @return the LocalDateTime truncated to minutes
    */
   public static LocalDateTime fromDateTime(String dateTimeAsString) {
     return LocalDateTime.parse(dateTimeAsString).truncatedTo(ChronoUnit.MINUTES);
   }
 
   /**
-   * Convert a LocalDateTime to a date and time string in yyyy-MM-ddTHH:mm:ss format.
+   * Convert a LocalDateTime to a date and time string in {@code yyyy-MM-ddTHH:mm} format.
+   *
+   * <p>
+   * Seconds are dropped. The returned string is minute based.
+   * </p>
    *
    * @param dateTime the LocalDateTime
-   * @return the date and time string in yyyy-MM-ddTHH:mm:ss format
+   * @return the date and time string in yyyy-MM-ddTHH:mm format
    */
   public static String toDateTime(LocalDateTime dateTime) {
     return dateTime.truncatedTo(ChronoUnit.MINUTES)
@@ -270,7 +279,12 @@ public final class DateTimeField extends DwcFieldInitializer<DateTimeField, Loca
   }
 
   /**
-   * Check if the given string is a valid yyyy-MM-ddTHH:mm:ss date and time.
+   * Check if the given string is a valid date and time.
+   *
+   * <p>
+   * Seconds are accepted; {@link #fromDateTime(String)} and {@link #toDateTime(LocalDateTime)}
+   * truncate them so the stored value is minute based ({@code yyyy-MM-ddTHH:mm}).
+   * </p>
    *
    * @param dateTimeAsString the date and time string
    * @return true if the string is a valid date and time, false otherwise

--- a/webforj-foundation/src/main/java/com/webforj/component/field/TimeField.java
+++ b/webforj-foundation/src/main/java/com/webforj/component/field/TimeField.java
@@ -15,8 +15,8 @@ import com.webforj.dispatcher.EventListener;
  * <p>
  * The control's user interface varies from browser to browser. The value of the time field is
  * always in 24-hour format that includes leading zeros: HH:mm, regardless of the field format,
- * which is likely to be selected based on the user's locale (or by the user agent). If the time
- * includes seconds, the format is always HH:mm:ss
+ * which is likely to be selected based on the user's locale (or by the user agent). Seconds in
+ * input are truncated; the stored value is always minute based.
  * </p>
  *
  * @author Hyyan Abo Fakher
@@ -180,7 +180,8 @@ public final class TimeField extends DwcFieldInitializer<TimeField, LocalTime>
   @Override
   public TimeField setText(String text) {
     if (text != null && !text.isEmpty() && !TimeField.isValidTime(text)) {
-      throw new IllegalArgumentException("Text must be a valid time in HH:mm:ss format");
+      throw new IllegalArgumentException(
+          "Text must be a valid time in HH:mm format (seconds are truncated)");
     }
 
     if (min != null && text != null && compareTime(min, LocalTime.parse(text)) > 0) {
@@ -215,10 +216,14 @@ public final class TimeField extends DwcFieldInitializer<TimeField, LocalTime>
   }
 
   /**
-   * Convert a time string in HH:mm:ss format to a LocalTime.
+   * Convert a time string to a LocalTime truncated to minutes.
    *
-   * @param timeAsString the time string in HH:mm:ss format
-   * @return the LocalTime
+   * <p>
+   * Seconds in the input are accepted and then dropped. The effective format is {@code HH:mm}.
+   * </p>
+   *
+   * @param timeAsString the time string, optionally including seconds
+   * @return the LocalTime truncated to minutes
    */
   public static LocalTime fromTime(String timeAsString) {
     return LocalTime.parse(timeAsString).truncatedTo(ChronoUnit.MINUTES);
@@ -235,7 +240,12 @@ public final class TimeField extends DwcFieldInitializer<TimeField, LocalTime>
   }
 
   /**
-   * Check if the given string is a valid HH:mm:ss time.
+   * Check if the given string is a valid time.
+   *
+   * <p>
+   * Seconds are accepted; {@link #fromTime(String)} and {@link #toTime(LocalTime)} truncate them so
+   * the stored value is minute based ({@code HH:mm}).
+   * </p>
    *
    * @param timeAsString the time string
    * @return true if the string is a valid time, false otherwise


### PR DESCRIPTION
Since #861, DateTimeField and TimeField truncate to minutes. I updated the leftover javadoc and setText messages so they describe that minute-based format instead of HH:mm:ss / yyyy-MM-ddTHH:mm:ss.

Seconds in input are still accepted and then dropped.

Closes #1497
