### PR TITLE
fix(craftforj): handle null ColumnsLayout breakpoints

### DIFF
--- a/webforj-devtools/src/main/java/com/webforj/devtools/craftforj/inspector/contribution/layout/columnslayout/ColumnsLayoutBreakpointsContribution.java
+++ b/webforj-devtools/src/main/java/com/webforj/devtools/craftforj/inspector/contribution/layout/columnslayout/ColumnsLayoutBreakpointsContribution.java
@@ -59,9 +59,14 @@ public class ColumnsLayoutBreakpointsContribution extends ConcernContribution<Co
   }
 
   private static List<Map<String, Object>> readBreakpoints(ColumnsLayout layout) {
+    List<Breakpoint> breakpoints = layout.getBreakpoints();
+    if (breakpoints == null) {
+      return List.of();
+    }
+
     List<Map<String, Object>> result = new ArrayList<>();
 
-    for (Breakpoint breakpoint : layout.getBreakpoints()) {
+    for (Breakpoint breakpoint : breakpoints) {
       Map<String, Object> entry = new LinkedHashMap<>();
       entry.put(KEY_NAME, breakpoint.name());
       entry.put(KEY_MIN_WIDTH, breakpoint.minWidth());

--- a/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/inspector/contribution/layout/columnslayout/ColumnsLayoutBreakpointsContributionTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/inspector/contribution/layout/columnslayout/ColumnsLayoutBreakpointsContributionTest.java
@@ -69,6 +69,17 @@ class ColumnsLayoutBreakpointsContributionTest {
   }
 
   @Test
+  void shouldReturnEmptyBreakpointsWhenGetterReturnsNull() {
+    ColumnsLayout layout = mock(ColumnsLayout.class);
+    when(layout.getBreakpoints()).thenReturn(null);
+
+    var result = contribution.get(layout);
+
+    assertTrue(result.isPresent());
+    assertEquals(List.of(), result.get().getValue());
+  }
+
+  @Test
   void shouldSetBreakpointsFromListOfMaps() {
     ColumnsLayout layout = mock(ColumnsLayout.class);
     List<Map<String, Object>> value =


### PR DESCRIPTION
Return an empty list when ColumnsLayout.getBreakpoints() returns null and add regression coverage for the null case.

Fixes #1501
SonarQube: https://sonarcloud.io/project/issues?id=webforj&open=AaBrZ7gwEeFUPdCmXSsb