### PR TITLE
fix: safely handle missing navigation options in router

### DIFF
--- a/webforj-foundation/src/main/java/com/webforj/router/RouteRenderer.java
+++ b/webforj-foundation/src/main/java/com/webforj/router/RouteRenderer.java
@@ -329,14 +329,10 @@ public class RouteRenderer {
    */
   protected void detachNode(Class<? extends Component> componentClass,
       Component componentInstance) {
-    Optional<Class<? extends Component>> outletClass = registry.getOutlet(componentClass);
-    if (!outletClass.isPresent()) {
-      outletClass = Optional.ofNullable(Frame.class);
-    }
-
-    boolean isFrame = Frame.class.isAssignableFrom(outletClass.get());
+    Class<? extends Component> outletClass = registry.getOutlet(componentClass).orElse(Frame.class);
+    boolean isFrame = Frame.class.isAssignableFrom(outletClass);
     Component outletInstance =
-        isFrame ? getFrameComponent(componentClass) : componentsCache.get(outletClass.get());
+        isFrame ? getFrameComponent(componentClass) : componentsCache.get(outletClass);
 
     if (isFrame) {
       context.setActiveFrame((Frame) outletInstance);
@@ -420,12 +416,8 @@ public class RouteRenderer {
   protected void attachNode(Class<? extends Component> componentClass, Component componentInstance,
       Consumer<Boolean> onComplete) {
 
-    Optional<Class<? extends Component>> outletClass = registry.getOutlet(componentClass);
-    if (!outletClass.isPresent()) {
-      outletClass = Optional.of(Frame.class);
-    }
-
-    final Class<? extends Component> outletClassFinal = outletClass.get();
+    Class<? extends Component> outletClassFinal =
+        registry.getOutlet(componentClass).orElse(Frame.class);
     boolean isFrame = Frame.class.isAssignableFrom(outletClassFinal);
 
     if (isFrame) {

--- a/webforj-foundation/src/main/java/com/webforj/router/RouterDevUtils.java
+++ b/webforj-foundation/src/main/java/com/webforj/router/RouterDevUtils.java
@@ -78,7 +78,7 @@ public final class RouterDevUtils {
     }
 
     Location location = context.getLocation();
-    NavigationOptions options = context.getOptions().get();
+    NavigationOptions options = context.getOptions().orElseGet(NavigationOptions::new);
     ParametersBag routeParameters = context.getRouteParameters();
 
     StringBuilder js = new StringBuilder();

--- a/webforj-foundation/src/test/java/com/webforj/router/RouterDevUtilsTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/router/RouterDevUtilsTest.java
@@ -1,0 +1,39 @@
+package com.webforj.router;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.webforj.Environment;
+import com.webforj.Page;
+import com.webforj.component.Component;
+import com.webforj.router.history.Location;
+import com.webforj.router.history.ParametersBag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class RouterDevUtilsTest {
+
+  @Test
+  void shouldLogNavigationWithoutOptions() {
+    Environment environment = mock(Environment.class);
+    Page page = mock(Page.class);
+
+    try (MockedStatic<Environment> mockedEnvironment = mockStatic(Environment.class);
+        MockedStatic<Page> mockedPage = mockStatic(Page.class)) {
+      mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
+      mockedPage.when(Page::getCurrent).thenReturn(page);
+      when(environment.isDebug()).thenReturn(true);
+
+      NavigationContext context = new NavigationContext();
+      context.setLocation(new Location("/test"));
+      context.setRouteParameters(new ParametersBag());
+
+      assertDoesNotThrow(() -> RouterDevUtils.logNavigationAction(context, Component.class));
+      verify(page).executeJsVoidAsync(anyString());
+    }
+  }
+}


### PR DESCRIPTION
Use explicit fallbacks when router optionals are empty to prevent `NoSuchElementException` during route rendering and development logging.

Fixes #1502
Fixes #1503