### PR TITLE
test: extract nested WatchSession mocks #1577

### DIFF
--- a/webforj-plugins/webforj-plugin/webforj-gradle-plugin/src/test/java/com/webforj/plugin/gradle/WatchTaskTest.java
+++ b/webforj-plugins/webforj-plugin/webforj-gradle-plugin/src/test/java/com/webforj/plugin/gradle/WatchTaskTest.java
@@ -71,7 +71,8 @@ class WatchTaskTest {
   @Test
   void shouldOpenTheSocketAndWriteThePortFile(@TempDir Path tmp) throws Exception {
     BundlerExecution execution = mock(BundlerExecution.class);
-    when(execution.watch(any(), any(), any())).thenReturn(mock(WatchSession.class));
+    WatchSession session = mock(WatchSession.class);
+    when(execution.watch(any(), any(), any())).thenReturn(session);
     Project project = ProjectBuilder.builder().withProjectDir(tmp.toFile()).build();
     TestableWatchTask task = task(project, tmp, tmp.toFile());
     task.setExecution(execution);

--- a/webforj-plugins/webforj-plugin/webforj-maven-plugin/src/test/java/com/webforj/plugin/maven/WatchMojoTest.java
+++ b/webforj-plugins/webforj-plugin/webforj-maven-plugin/src/test/java/com/webforj/plugin/maven/WatchMojoTest.java
@@ -36,7 +36,8 @@ class WatchMojoTest {
   @Test
   void shouldOpenTheSocketAndWriteThePortFile(@TempDir Path tmp) throws Exception {
     BundlerExecution execution = mock(BundlerExecution.class);
-    when(execution.watch(any(), any(), any())).thenReturn(mock(WatchSession.class));
+    WatchSession session = mock(WatchSession.class);
+    when(execution.watch(any(), any(), any())).thenReturn(session);
     WatchMojo mojo = newMojo(execution, tmp);
     Path portFile = WatchPortFile.resolve(tmp.toAbsolutePath().toString());
 


### PR DESCRIPTION
I pulled the nested `mock(WatchSession.class)` calls in WatchTaskTest and WatchMojoTest into local variables so they satisfy java:S9016.

Closes #1577