### PR TITLE
test: extract nested SessionCookieConfig mock #1576

### DIFF
--- a/webforj-mcp-apps/src/test/java/com/webforj/mcp/McpAppContributionTest.java
+++ b/webforj-mcp-apps/src/test/java/com/webforj/mcp/McpAppContributionTest.java
@@ -97,7 +97,8 @@ class McpAppContributionTest {
     @Test
     @DisplayName("Should declare the configured domains on every resource")
     void shouldDeclareDomainsOnResources() {
-      when(context.getSessionCookieConfig()).thenReturn(mock(SessionCookieConfig.class));
+      SessionCookieConfig cookies = mock(SessionCookieConfig.class);
+      when(context.getSessionCookieConfig()).thenReturn(cookies);
       contribution.getOrigin().configure("https://app.example.com");
 
       contribution.install(context,


### PR DESCRIPTION
I pulled the nested mock(SessionCookieConfig.class) in McpAppContributionTest into a local variable so it satisfies java:S9016.

Closes #1576