### PR TITLE
test: extract nested mocks in foundation tests #1575

### DIFF
--- a/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/TabbedPaneTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/TabbedPaneTest.java
@@ -113,8 +113,7 @@ class TabbedPaneTest {
         ComponentAccessor accessor = mock(ComponentAccessor.class);
         BBjControl prefixControl = mock(BBjControl.class);
         BBjControl suffixControl = mock(BBjControl.class);
-        componentAccessor.when(ComponentAccessor::getDefault)
-            .thenReturn(accessor);
+        componentAccessor.when(ComponentAccessor::getDefault).thenReturn(accessor);
         componentAccessor.when(() -> ComponentAccessor.getDefault().getControl(spy))
             .thenReturn(control);
         componentAccessor.when(() -> ComponentAccessor.getDefault().getControl(prefix))
@@ -186,8 +185,7 @@ class TabbedPaneTest {
       try (
           MockedStatic<ComponentAccessor> componentAccessor = mockStatic(ComponentAccessor.class)) {
         ComponentAccessor accessor = mock(ComponentAccessor.class);
-        componentAccessor.when(ComponentAccessor::getDefault)
-            .thenReturn(accessor);
+        componentAccessor.when(ComponentAccessor::getDefault).thenReturn(accessor);
         componentAccessor.when(() -> ComponentAccessor.getDefault().getControl(spy))
             .thenReturn(control);
 

--- a/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/TabbedPaneTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/TabbedPaneTest.java
@@ -110,14 +110,17 @@ class TabbedPaneTest {
 
       try (
           MockedStatic<ComponentAccessor> componentAccessor = mockStatic(ComponentAccessor.class)) {
+        ComponentAccessor accessor = mock(ComponentAccessor.class);
+        BBjControl prefixControl = mock(BBjControl.class);
+        BBjControl suffixControl = mock(BBjControl.class);
         componentAccessor.when(ComponentAccessor::getDefault)
-            .thenReturn(mock(ComponentAccessor.class));
+            .thenReturn(accessor);
         componentAccessor.when(() -> ComponentAccessor.getDefault().getControl(spy))
             .thenReturn(control);
         componentAccessor.when(() -> ComponentAccessor.getDefault().getControl(prefix))
-            .thenReturn(mock(BBjControl.class));
+            .thenReturn(prefixControl);
         componentAccessor.when(() -> ComponentAccessor.getDefault().getControl(suffix))
-            .thenReturn(mock(BBjControl.class));
+            .thenReturn(suffixControl);
 
         addedTab.setEnabled(false);
         addedTab.setClosable(true);
@@ -182,8 +185,9 @@ class TabbedPaneTest {
 
       try (
           MockedStatic<ComponentAccessor> componentAccessor = mockStatic(ComponentAccessor.class)) {
+        ComponentAccessor accessor = mock(ComponentAccessor.class);
         componentAccessor.when(ComponentAccessor::getDefault)
-            .thenReturn(mock(ComponentAccessor.class));
+            .thenReturn(accessor);
         componentAccessor.when(() -> ComponentAccessor.getDefault().getControl(spy))
             .thenReturn(control);
 

--- a/webforj-foundation/src/test/java/com/webforj/router/RouteRendererScenariosTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/router/RouteRendererScenariosTest.java
@@ -47,7 +47,8 @@ class RouteRendererScenariosTest {
     routeRenderer = spy(new RouteRenderer(routeRegistry));
 
     mockedEnvironment = mockStatic(Environment.class);
-    mockedEnvironment.when(Environment::getCurrent).thenReturn(mock(Environment.class));
+    Environment environment = mock(Environment.class);
+    mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
     BBjSysGui sysGui = mock(BBjSysGui.class);
     when(Environment.getCurrent().getSysGui()).thenReturn(sysGui);
 

--- a/webforj-foundation/src/test/java/com/webforj/router/RouteRendererTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/router/RouteRendererTest.java
@@ -57,7 +57,8 @@ class RouteRendererTest {
     routeRenderer = spy(new RouteRenderer(routeRegistry));
 
     mockedEnvironment = mockStatic(Environment.class);
-    mockedEnvironment.when(Environment::getCurrent).thenReturn(mock(Environment.class));
+    Environment environment = mock(Environment.class);
+    mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
     BBjSysGui sysGui = mock(BBjSysGui.class);
     when(Environment.getCurrent().getSysGui()).thenReturn(sysGui);
 

--- a/webforj-foundation/src/test/java/com/webforj/router/RouterTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/router/RouterTest.java
@@ -80,10 +80,12 @@ class RouterTest {
     router = new Router(registry, history);
 
     mockedPage = mockStatic(Page.class);
-    mockedPage.when(Page::getCurrent).thenReturn(mock(Page.class));
+    Page page = mock(Page.class);
+    mockedPage.when(Page::getCurrent).thenReturn(page);
 
     mockedEnvironment = mockStatic(Environment.class);
-    mockedEnvironment.when(Environment::getCurrent).thenReturn(mock(Environment.class));
+    Environment environment = mock(Environment.class);
+    mockedEnvironment.when(Environment::getCurrent).thenReturn(environment);
     BBjSysGui sysGui = mock(BBjSysGui.class);
     when(Environment.getCurrent().getSysGui()).thenReturn(sysGui);
 


### PR DESCRIPTION
I pulled the nested mock() calls in TabbedPaneTest, RouteRendererScenariosTest, RouteRendererTest, and RouterTest into local variables so they satisfy java:S9016.

Closes #1575
