### PR TITLE
test: extract nested mocks in webforj-devtools #1574

### DIFF
--- a/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/CraftforjLifecycleListenerTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/CraftforjLifecycleListenerTest.java
@@ -165,7 +165,8 @@ class CraftforjLifecycleListenerTest {
       when(env.getBBjAPI()).thenReturn(mock(BBjAPI.class));
       envMock.when(Environment::getCurrent).thenReturn(env);
       allowLoopback(requestMock);
-      pageMock.when(Page::getCurrent).thenReturn(mock(Page.class));
+      Page page = mock(Page.class);
+      pageMock.when(Page::getCurrent).thenReturn(page);
       routerMock.when(Router::getCurrent).thenReturn(null);
 
       listener.onWillRun(mock(App.class));
@@ -197,7 +198,8 @@ class CraftforjLifecycleListenerTest {
       when(env.getBBjAPI()).thenReturn(mock(BBjAPI.class));
       envMock.when(Environment::getCurrent).thenReturn(env);
       allowLoopback(requestMock);
-      pageMock.when(Page::getCurrent).thenReturn(mock(Page.class));
+      Page page = mock(Page.class);
+      pageMock.when(Page::getCurrent).thenReturn(page);
       routerMock.when(Router::getCurrent).thenReturn(null);
 
       listener.onWillRun(mock(App.class));
@@ -258,7 +260,8 @@ class CraftforjLifecycleListenerTest {
       envMock.when(Environment::getCurrent).thenReturn(env);
       allowLoopback(requestMock);
 
-      pageMock.when(Page::getCurrent).thenReturn(mock(Page.class));
+      Page page = mock(Page.class);
+      pageMock.when(Page::getCurrent).thenReturn(page);
       routerMock.when(Router::getCurrent).thenReturn(null);
 
       listener.onWillRun(mock(App.class));
@@ -343,7 +346,8 @@ class CraftforjLifecycleListenerTest {
 
       Page page = mock(Page.class);
       pageMock.when(Page::getCurrent).thenReturn(page);
-      routerMock.when(Router::getCurrent).thenReturn(mock(Router.class));
+      Router router = mock(Router.class);
+      routerMock.when(Router::getCurrent).thenReturn(router);
 
       listener.onWillRun(mock(App.class));
 

--- a/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/module/ModuleStoreTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/module/ModuleStoreTest.java
@@ -29,7 +29,8 @@ class ModuleStoreTest {
   @BeforeEach
   void setUp() {
     environment = mockStatic(Environment.class);
-    environment.when(Environment::getCurrent).thenReturn(mock(Environment.class));
+    Environment current = mock(Environment.class);
+    environment.when(Environment::getCurrent).thenReturn(current);
   }
 
   @AfterEach

--- a/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/module/action/GetModuleActionTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/craftforj/module/action/GetModuleActionTest.java
@@ -29,7 +29,8 @@ class GetModuleActionTest {
   @BeforeEach
   void setUp() {
     environment = mockStatic(Environment.class);
-    environment.when(Environment::getCurrent).thenReturn(mock(Environment.class));
+    Environment current = mock(Environment.class);
+    environment.when(Environment::getCurrent).thenReturn(current);
   }
 
   @AfterEach

--- a/webforj-devtools/src/test/java/com/webforj/devtools/livereload/ClassUpdateListenerTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/livereload/ClassUpdateListenerTest.java
@@ -67,7 +67,8 @@ class ClassUpdateListenerTest {
     mockedPage.when(Page::getCurrent).thenReturn(page);
 
     mockedEnvironment = mockStatic(Environment.class);
-    mockedEnvironment.when(Environment::getCurrent).thenReturn(mock(Environment.class));
+    Environment current = mock(Environment.class);
+    mockedEnvironment.when(Environment::getCurrent).thenReturn(current);
     BBjSysGui sysGui = mock(BBjSysGui.class);
     when(Environment.getCurrent().getSysGui()).thenReturn(sysGui);
 

--- a/webforj-devtools/src/test/java/com/webforj/devtools/livereload/LiveReloadServletContainerInitializerTest.java
+++ b/webforj-devtools/src/test/java/com/webforj/devtools/livereload/LiveReloadServletContainerInitializerTest.java
@@ -19,8 +19,9 @@ class LiveReloadServletContainerInitializerTest {
   @Test
   void shouldRegisterTheContextListenerOnStartup() {
     ServletContext context = mock(ServletContext.class);
+    FilterRegistration.Dynamic registration = mock(FilterRegistration.Dynamic.class);
     when(context.addFilter(anyString(), any(LiveReloadRestartFilter.class)))
-        .thenReturn(mock(FilterRegistration.Dynamic.class));
+        .thenReturn(registration);
 
     new LiveReloadServletContainerInitializer().onStartup(Set.of(), context);
 


### PR DESCRIPTION
I pulled the nested mock(...) calls in the webforj-devtools tests into local variables so they satisfy java:S9016.

Closes #1574
