### PR TITLE
test: extract nested Page mock in DesktopNotificationTest #1573

### DIFF
--- a/webforj-components/webforj-desktop-notification/src/test/java/com/webforj/component/desktopnotification/DesktopNotificationTest.java
+++ b/webforj-components/webforj-desktop-notification/src/test/java/com/webforj/component/desktopnotification/DesktopNotificationTest.java
@@ -37,7 +37,8 @@ class DesktopNotificationTest {
   @BeforeEach
   void setUp() {
     notification = new DesktopNotification("Test Title", "Test Body");
-    mockedPage.when(Page::getCurrent).thenReturn(mock(Page.class));
+    Page page = mock(Page.class);
+    mockedPage.when(Page::getCurrent).thenReturn(page);
   }
 
   @Test


### PR DESCRIPTION
I pulled the nested mock(Page.class) in DesktopNotificationTest into a local variable so it satisfies java:S9016.

Closes #1573