### PR TITLE
test: static-import Mockito.mock #1571

### DIFF
--- a/webforj-foundation/src/test/java/com/webforj/BusyIndicatorTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/BusyIndicatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,7 +20,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.Mockito;
 
 class BusyIndicatorTest {
 
@@ -28,7 +28,7 @@ class BusyIndicatorTest {
 
   @BeforeEach
   void setUp() {
-    mockIndicator = Mockito.mock(BBjBusyIndicator.class);
+    mockIndicator = mock(BBjBusyIndicator.class);
     busyIndicator = new BusyIndicator(mockIndicator);
   }
 

--- a/webforj-foundation/src/test/java/com/webforj/component/button/event/ButtonClickEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/button/event/ButtonClickEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.button.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjButtonPushEvent;
@@ -9,14 +10,13 @@ import com.webforj.component.button.sink.ButtonClickEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ButtonClickEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjButtonPushEvent eventMock = Mockito.mock(BBjButtonPushEvent.class);
+    BBjButtonPushEvent eventMock = mock(BBjButtonPushEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -31,7 +31,7 @@ class ButtonClickEventTest {
       dispatchedEvent[0] = e;
     });
 
-    Button componentMock = Mockito.mock(Button.class);
+    Button componentMock = mock(Button.class);
     ButtonClickEventSink sink = new ButtonClickEventSink(componentMock, dispatcher);
     // Invoke the event handler
     sink.handleEvent(eventMock);

--- a/webforj-foundation/src/test/java/com/webforj/component/element/sink/ElementDefinedEventSinkTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/sink/ElementDefinedEventSinkTest.java
@@ -10,14 +10,13 @@ import com.webforj.component.element.event.ElementDefinedEvent;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ElementDefinedEventSinkTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() throws BBjException {
-    BBjWebComponentDefinedEvent eventMock = Mockito.mock(BBjWebComponentDefinedEvent.class);
+    BBjWebComponentDefinedEvent eventMock = mock(BBjWebComponentDefinedEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event

--- a/webforj-foundation/src/test/java/com/webforj/component/element/sink/ElementEventSinkTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/element/sink/ElementEventSinkTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Random;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -35,9 +34,9 @@ class ElementEventSinkTest {
   @Test
   @DisplayName("Test the payload of the event")
   void payload() throws BBjException {
-    BBjWebEvent event = Mockito.mock(BBjWebEvent.class);
+    BBjWebEvent event = mock(BBjWebEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
-    Element component = Mockito.mock(Element.class);
+    Element component = mock(Element.class);
     ElementEvent[] dispatchedEvent = new ElementEvent[1];
 
     String eventType = "click";

--- a/webforj-foundation/src/test/java/com/webforj/component/event/ExecuteAsyncScriptEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/event/ExecuteAsyncScriptEventTest.java
@@ -1,7 +1,7 @@
 package com.webforj.component.event;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjExecuteScriptEvent;
@@ -11,14 +11,13 @@ import com.webforj.component.event.sink.ExecuteAsyncScriptEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ExecuteAsyncScriptEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() throws BBjException {
-    BBjExecuteScriptEvent eventMock = Mockito.mock(BBjExecuteScriptEvent.class);
+    BBjExecuteScriptEvent eventMock = mock(BBjExecuteScriptEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event

--- a/webforj-foundation/src/test/java/com/webforj/component/list/event/ListClickEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/event/ListClickEventTest.java
@@ -1,8 +1,9 @@
 package com.webforj.component.list.event;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjListClickEvent;
@@ -13,14 +14,13 @@ import com.webforj.dispatcher.EventDispatcher;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ListClickEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjListClickEvent eventMock = Mockito.mock(BBjListClickEvent.class);
+    BBjListClickEvent eventMock = mock(BBjListClickEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -35,7 +35,7 @@ class ListClickEventTest {
       dispatchedEvent[0] = e;
     });
 
-    ComboBox componentMock = Mockito.spy(ComboBox.class);
+    ComboBox componentMock = spy(ComboBox.class);
     componentMock.insert("Item 1", "Item 2", "Item 3");
     ListClickEventSink sink = new ListClickEventSink(componentMock, dispatcher);
     // Invoke the event handler

--- a/webforj-foundation/src/test/java/com/webforj/component/list/event/ListCloseEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/event/ListCloseEventTest.java
@@ -1,8 +1,9 @@
 package com.webforj.component.list.event;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjListCloseEvent;
@@ -13,14 +14,13 @@ import com.webforj.dispatcher.EventDispatcher;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ListCloseEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjListCloseEvent eventMock = Mockito.mock(BBjListCloseEvent.class);
+    BBjListCloseEvent eventMock = mock(BBjListCloseEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -35,7 +35,7 @@ class ListCloseEventTest {
       dispatchedEvent[0] = e;
     });
 
-    ComboBox componentMock = Mockito.spy(ComboBox.class);
+    ComboBox componentMock = spy(ComboBox.class);
     componentMock.insert("Item 1", "Item 2", "Item 3");
     ListCloseEventSink sink = new ListCloseEventSink(componentMock, dispatcher);
     // Invoke the event handler

--- a/webforj-foundation/src/test/java/com/webforj/component/list/event/ListOpenEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/event/ListOpenEventTest.java
@@ -1,8 +1,9 @@
 package com.webforj.component.list.event;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjListOpenEvent;
@@ -13,14 +14,13 @@ import com.webforj.dispatcher.EventDispatcher;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ListOpenEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjListOpenEvent eventMock = Mockito.mock(BBjListOpenEvent.class);
+    BBjListOpenEvent eventMock = mock(BBjListOpenEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -35,7 +35,7 @@ class ListOpenEventTest {
       dispatchedEvent[0] = e;
     });
 
-    ComboBox componentMock = Mockito.spy(ComboBox.class);
+    ComboBox componentMock = spy(ComboBox.class);
     componentMock.insert("Item 1", "Item 2", "Item 3");
     ListOpenEventSink sink = new ListOpenEventSink(componentMock, dispatcher);
     // Invoke the event handler

--- a/webforj-foundation/src/test/java/com/webforj/component/list/event/ListSelectEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/list/event/ListSelectEventTest.java
@@ -1,8 +1,9 @@
 package com.webforj.component.list.event;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjListClickEvent;
@@ -13,14 +14,13 @@ import com.webforj.dispatcher.EventDispatcher;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ListSelectEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjListClickEvent eventMock = Mockito.mock(BBjListClickEvent.class);
+    BBjListClickEvent eventMock = mock(BBjListClickEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -35,7 +35,7 @@ class ListSelectEventTest {
       dispatchedEvent[0] = e;
     });
 
-    ListBox componentMock = Mockito.spy(ListBox.class);
+    ListBox componentMock = spy(ListBox.class);
     componentMock.insert("Item 1", "Item 2", "Item 3");
     ListSelectEventSink sink = new ListSelectEventSink(componentMock, dispatcher);
     // Invoke the event handler

--- a/webforj-foundation/src/test/java/com/webforj/component/navigator/event/NavigatorMoveFirstEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/navigator/event/NavigatorMoveFirstEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.navigator.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjNavigatorMoveFirstEvent;
@@ -10,14 +11,13 @@ import com.webforj.dispatcher.EventDispatcher;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class NavigatorMoveFirstEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjNavigatorMoveFirstEvent eventMock = Mockito.mock(BBjNavigatorMoveFirstEvent.class);
+    BBjNavigatorMoveFirstEvent eventMock = mock(BBjNavigatorMoveFirstEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -38,7 +38,7 @@ class NavigatorMoveFirstEventTest {
       dispatchedEvent[0] = e;
     });
 
-    Navigator componentMock = Mockito.mock(Navigator.class);
+    Navigator componentMock = mock(Navigator.class);
     NavigatorMoveFirstEventSink sink = new NavigatorMoveFirstEventSink(componentMock, dispatcher);
     // Invoke the event handler
     sink.handleEvent(eventMock);

--- a/webforj-foundation/src/test/java/com/webforj/component/navigator/event/NavigatorMoveLastEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/navigator/event/NavigatorMoveLastEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.navigator.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjNavigatorMoveLastEvent;
@@ -10,14 +11,13 @@ import com.webforj.dispatcher.EventDispatcher;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class NavigatorMoveLastEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjNavigatorMoveLastEvent eventMock = Mockito.mock(BBjNavigatorMoveLastEvent.class);
+    BBjNavigatorMoveLastEvent eventMock = mock(BBjNavigatorMoveLastEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -38,7 +38,7 @@ class NavigatorMoveLastEventTest {
       dispatchedEvent[0] = e;
     });
 
-    Navigator componentMock = Mockito.mock(Navigator.class);
+    Navigator componentMock = mock(Navigator.class);
     NavigatorMoveLastEventSink sink = new NavigatorMoveLastEventSink(componentMock, dispatcher);
     // Invoke the event handler
     sink.handleEvent(eventMock);

--- a/webforj-foundation/src/test/java/com/webforj/component/navigator/event/NavigatorMoveNextEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/navigator/event/NavigatorMoveNextEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.navigator.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjNavigatorMoveNextEvent;
@@ -10,14 +11,13 @@ import com.webforj.dispatcher.EventDispatcher;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class NavigatorMoveNextEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjNavigatorMoveNextEvent eventMock = Mockito.mock(BBjNavigatorMoveNextEvent.class);
+    BBjNavigatorMoveNextEvent eventMock = mock(BBjNavigatorMoveNextEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -38,7 +38,7 @@ class NavigatorMoveNextEventTest {
       dispatchedEvent[0] = e;
     });
 
-    Navigator componentMock = Mockito.mock(Navigator.class);
+    Navigator componentMock = mock(Navigator.class);
     NavigatorMoveNextEventSink sink = new NavigatorMoveNextEventSink(componentMock, dispatcher);
     // Invoke the event handler
     sink.handleEvent(eventMock);

--- a/webforj-foundation/src/test/java/com/webforj/component/navigator/event/NavigatorMovePreviousEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/navigator/event/NavigatorMovePreviousEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.navigator.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjNavigatorMovePreviousEvent;
@@ -10,14 +11,13 @@ import com.webforj.dispatcher.EventDispatcher;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class NavigatorMovePreviousEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjNavigatorMovePreviousEvent eventMock = Mockito.mock(BBjNavigatorMovePreviousEvent.class);
+    BBjNavigatorMovePreviousEvent eventMock = mock(BBjNavigatorMovePreviousEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -38,7 +38,7 @@ class NavigatorMovePreviousEventTest {
       dispatchedEvent[0] = e;
     });
 
-    Navigator componentMock = Mockito.mock(Navigator.class);
+    Navigator componentMock = mock(Navigator.class);
     NavigatorMovePreviousEventSink sink =
         new NavigatorMovePreviousEventSink(componentMock, dispatcher);
     // Invoke the event handler

--- a/webforj-foundation/src/test/java/com/webforj/component/slider/event/SliderSlideEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/slider/event/SliderSlideEventTest.java
@@ -1,8 +1,9 @@
 package com.webforj.component.slider.event;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjControlScrollEvent;
@@ -10,13 +11,12 @@ import com.webforj.component.slider.Slider;
 import com.webforj.component.slider.sink.SliderSlideEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class SliderSlideEventTest {
 
   @Test
   void payload() {
-    BBjControlScrollEvent eventMock = Mockito.mock(BBjControlScrollEvent.class);
+    BBjControlScrollEvent eventMock = mock(BBjControlScrollEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -31,7 +31,7 @@ class SliderSlideEventTest {
       dispatchedEvent[0] = e;
     });
 
-    Slider componentMock = Mockito.spy(Slider.class);
+    Slider componentMock = spy(Slider.class);
     SliderSlideEventSink sink = new SliderSlideEventSink(componentMock, dispatcher);
     // Invoke the event handler
     sink.handleEvent(eventMock);

--- a/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/event/TabCloseEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/event/TabCloseEventTest.java
@@ -1,6 +1,8 @@
 package com.webforj.component.tabbedpane.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjTabCloseEvent;
@@ -10,14 +12,13 @@ import com.webforj.component.tabbedpane.sink.TabCloseEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class TabCloseEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjTabCloseEvent eventMock = Mockito.mock(BBjTabCloseEvent.class);
+    BBjTabCloseEvent eventMock = mock(BBjTabCloseEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -31,7 +32,7 @@ class TabCloseEventTest {
       dispatchedEvent[0] = e;
     });
 
-    TabbedPane componentMock = Mockito.spy(TabbedPane.class);
+    TabbedPane componentMock = spy(TabbedPane.class);
     componentMock.addTab("Tab0");
     componentMock.addTab("Tab1");
     Tab tab2 = componentMock.addTab("Tab2");

--- a/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/event/TabDeselectEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/event/TabDeselectEventTest.java
@@ -1,6 +1,8 @@
 package com.webforj.component.tabbedpane.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjTabDeselectedEvent;
@@ -10,14 +12,13 @@ import com.webforj.component.tabbedpane.sink.TabDeselectEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class TabDeselectEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjTabDeselectedEvent eventMock = Mockito.mock(BBjTabDeselectedEvent.class);
+    BBjTabDeselectedEvent eventMock = mock(BBjTabDeselectedEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -31,7 +32,7 @@ class TabDeselectEventTest {
       dispatchedEvent[0] = e;
     });
 
-    TabbedPane componentMock = Mockito.spy(TabbedPane.class);
+    TabbedPane componentMock = spy(TabbedPane.class);
     componentMock.addTab("Tab0");
     componentMock.addTab("Tab1");
     Tab tab2 = componentMock.addTab("Tab2");

--- a/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/event/TabSelectEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tabbedpane/event/TabSelectEventTest.java
@@ -1,6 +1,8 @@
 package com.webforj.component.tabbedpane.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjTabSelectedEvent;
@@ -10,14 +12,13 @@ import com.webforj.component.tabbedpane.sink.TabSelectEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class TabSelectEventTest {
 
   @Test
   @DisplayName("Test the payload of the event")
   void payload() {
-    BBjTabSelectedEvent eventMock = Mockito.mock(BBjTabSelectedEvent.class);
+    BBjTabSelectedEvent eventMock = mock(BBjTabSelectedEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -31,7 +32,7 @@ class TabSelectEventTest {
       dispatchedEvent[0] = e;
     });
 
-    TabbedPane componentMock = Mockito.spy(TabbedPane.class);
+    TabbedPane componentMock = spy(TabbedPane.class);
     componentMock.addTab("Tab0");
     componentMock.addTab("Tab1");
     Tab tab2 = componentMock.addTab("Tab2");

--- a/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeCollapseEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeCollapseEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.tree.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjTreeNodeCollapsedEvent;
@@ -9,13 +10,12 @@ import com.webforj.component.tree.TreeNode;
 import com.webforj.component.tree.sink.TreeCollapseEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class TreeCollapseEventTest {
 
   @Test
   void payload() {
-    BBjTreeNodeCollapsedEvent eventMock = Mockito.mock(BBjTreeNodeCollapsedEvent.class);
+    BBjTreeNodeCollapsedEvent eventMock = mock(BBjTreeNodeCollapsedEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event

--- a/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeDeselectEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeDeselectEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.tree.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjTreeNodeDeselectedEvent;
@@ -9,13 +10,12 @@ import com.webforj.component.tree.TreeNode;
 import com.webforj.component.tree.sink.TreeDeselectEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class TreeDeselectEventTest {
 
   @Test
   void payload() {
-    BBjTreeNodeDeselectedEvent eventMock = Mockito.mock(BBjTreeNodeDeselectedEvent.class);
+    BBjTreeNodeDeselectedEvent eventMock = mock(BBjTreeNodeDeselectedEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event

--- a/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeExpandEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeExpandEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.tree.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjTreeNodeExpandedEvent;
@@ -9,13 +10,12 @@ import com.webforj.component.tree.TreeNode;
 import com.webforj.component.tree.sink.TreeExpandEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class TreeExpandEventTest {
 
   @Test
   void payload() {
-    BBjTreeNodeExpandedEvent eventMock = Mockito.mock(BBjTreeNodeExpandedEvent.class);
+    BBjTreeNodeExpandedEvent eventMock = mock(BBjTreeNodeExpandedEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event

--- a/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeMouseEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeMouseEventTest.java
@@ -1,6 +1,7 @@
 package com.webforj.component.tree.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjTreeMouseDoubleClickEvent;
@@ -9,13 +10,12 @@ import com.webforj.component.tree.TreeNode;
 import com.webforj.component.tree.sink.TreeDoubleClickEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class TreeMouseEventTest {
 
   @Test
   void payload() {
-    BBjTreeMouseDoubleClickEvent eventMock = Mockito.mock(BBjTreeMouseDoubleClickEvent.class);
+    BBjTreeMouseDoubleClickEvent eventMock = mock(BBjTreeMouseDoubleClickEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event
@@ -37,7 +37,6 @@ class TreeMouseEventTest {
     when(eventMock.isCmdDown()).thenReturn(false);
     when(eventMock.isControlDown()).thenReturn(true);
     when(eventMock.isShiftDown()).thenReturn(false);
-
 
     TreeDoubleClickEventSink sink = new TreeDoubleClickEventSink(tree, dispatcher);
     // Invoke the event handler

--- a/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeSelectEventTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/component/tree/event/TreeSelectEventTest.java
@@ -1,7 +1,7 @@
 package com.webforj.component.tree.event;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.basis.bbj.proxies.event.BBjTreeNodeSelectedEvent;
@@ -10,13 +10,12 @@ import com.webforj.component.tree.TreeNode;
 import com.webforj.component.tree.sink.TreeSelectEventSink;
 import com.webforj.dispatcher.EventDispatcher;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class TreeSelectEventTest {
 
   @Test
   void payload() {
-    BBjTreeNodeSelectedEvent eventMock = Mockito.mock(BBjTreeNodeSelectedEvent.class);
+    BBjTreeNodeSelectedEvent eventMock = mock(BBjTreeNodeSelectedEvent.class);
     EventDispatcher dispatcher = new EventDispatcher();
 
     // Capture the dispatched event

--- a/webforj-foundation/src/test/java/com/webforj/sink/page/PageEventSinkTest.java
+++ b/webforj-foundation/src/test/java/com/webforj/sink/page/PageEventSinkTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -93,7 +92,7 @@ class PageEventSinkTest {
       BBjWebEventOptions optionsMock = mock(BBjWebEventOptions.class);
       when(webManager.newEventOptions()).thenReturn(optionsMock);
 
-      BBjWebEvent event = Mockito.mock(BBjWebEvent.class);
+      BBjWebEvent event = mock(BBjWebEvent.class);
       PageEvent[] dispatchedEvent = new PageEvent[1];
 
       String eventType = "click";


### PR DESCRIPTION
Use a static import for mock and spy in the listed foundation tests.

Fixes #1571
