### PR TITLE
test: use assertDoesNotThrow in component tests #1570

### DIFF
--- a/webforj-components/webforj-accordion/src/test/java/com/webforj/component/accordion/AccordionPanelTest.java
+++ b/webforj-components/webforj-accordion/src/test/java/com/webforj/component/accordion/AccordionPanelTest.java
@@ -1,9 +1,9 @@
 package com.webforj.component.accordion;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -51,13 +51,11 @@ class AccordionPanelTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(AccordionPanel.class, component, descriptor -> {
           return !Arrays.asList("opened", "disabled").contains(descriptor.getName());
         });
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-accordion/src/test/java/com/webforj/component/accordion/AccordionTest.java
+++ b/webforj-components/webforj-accordion/src/test/java/com/webforj/component/accordion/AccordionTest.java
@@ -1,9 +1,9 @@
 package com.webforj.component.accordion;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,11 +41,9 @@ class AccordionTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Accordion.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-alert/src/test/java/com/webforj/component/alert/AlertTest.java
+++ b/webforj-components/webforj-alert/src/test/java/com/webforj/component/alert/AlertTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.alert;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -69,11 +69,9 @@ class AlertTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Alert.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-applayout/src/test/java/com/webforj/component/layout/applayout/AppLayoutTest.java
+++ b/webforj-components/webforj-applayout/src/test/java/com/webforj/component/layout/applayout/AppLayoutTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.layout.applayout;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -31,11 +31,9 @@ class AppLayoutTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(AppLayout.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 

--- a/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavItemTest.java
+++ b/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavItemTest.java
@@ -1,11 +1,11 @@
 package com.webforj.component.layout.appnav;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mockStatic;
 
 import com.webforj.component.Component;
@@ -131,11 +131,9 @@ class AppNavItemTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(AppNavItem.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavTest.java
+++ b/webforj-components/webforj-appnav/src/test/java/com/webforj/component/layout/appnav/AppNavTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.layout.appnav;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import com.webforj.component.icons.IconDefinition;
@@ -31,11 +31,9 @@ class AppNavTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(AppNav.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 

--- a/webforj-components/webforj-avatar/src/test/java/com/webforj/component/avatar/AvatarTest.java
+++ b/webforj-components/webforj-avatar/src/test/java/com/webforj/component/avatar/AvatarTest.java
@@ -1,7 +1,7 @@
 package com.webforj.component.avatar;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -81,11 +81,9 @@ class AvatarTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Avatar.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 }

--- a/webforj-components/webforj-badge/src/test/java/com/webforj/component/badge/BadgeTest.java
+++ b/webforj-components/webforj-badge/src/test/java/com/webforj/component/badge/BadgeTest.java
@@ -1,7 +1,7 @@
 package com.webforj.component.badge;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,11 +67,9 @@ class BadgeTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Badge.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 }

--- a/webforj-components/webforj-columnslayout/src/test/java/com/webforj/component/layout/columnslayout/ColumnsLayoutTest.java
+++ b/webforj-components/webforj-columnslayout/src/test/java/com/webforj/component/layout/columnslayout/ColumnsLayoutTest.java
@@ -1,7 +1,7 @@
 package com.webforj.component.layout.columnslayout;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -28,11 +28,9 @@ class ColumnsLayoutTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(ColumnsLayout.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 

--- a/webforj-components/webforj-dialog/src/test/java/com/webforj/component/dialog/DialogTest.java
+++ b/webforj-components/webforj-dialog/src/test/java/com/webforj/component/dialog/DialogTest.java
@@ -1,9 +1,9 @@
 package com.webforj.component.dialog;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -38,13 +38,11 @@ class DialogTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Dialog.class, component, descriptor -> {
           return !Arrays.asList("opened").contains(descriptor.getName());
         });
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-drawer/src/test/java/com/webforj/component/drawer/DrawerTest.java
+++ b/webforj-components/webforj-drawer/src/test/java/com/webforj/component/drawer/DrawerTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.drawer;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -31,13 +31,11 @@ class DrawerTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Drawer.class, component, descriptor -> {
           return !Arrays.asList("opened").contains(descriptor.getName());
         });
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-googlecharts/src/test/java/com/webforj/component/googlecharts/GoogleChartTest.java
+++ b/webforj-components/webforj-googlecharts/src/test/java/com/webforj/component/googlecharts/GoogleChartTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.googlecharts;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import com.webforj.component.googlecharts.events.GoogleChartReadyEvent;
@@ -29,11 +29,9 @@ class GoogleChartTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(GoogleChart.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 

--- a/webforj-components/webforj-html-elements/src/test/java/com/webforj/component/html/elements/AnchorTest.java
+++ b/webforj-components/webforj-html-elements/src/test/java/com/webforj/component/html/elements/AnchorTest.java
@@ -1,9 +1,9 @@
 package com.webforj.component.html.elements;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import org.junit.jupiter.api.Test;
@@ -51,11 +51,9 @@ class AnchorTest {
   void shouldSetGetProperties() {
     Anchor component = new Anchor();
 
-    try {
+    assertDoesNotThrow(() -> {
       PropertyDescriptorTester.run(Anchor.class, component);
-    } catch (Exception e) {
-      fail("PropertyDescriptor test failed: " + e.getMessage());
-    }
+    });
   }
 
   @Test

--- a/webforj-components/webforj-html-elements/src/test/java/com/webforj/component/html/elements/IframeTest.java
+++ b/webforj-components/webforj-html-elements/src/test/java/com/webforj/component/html/elements/IframeTest.java
@@ -1,9 +1,9 @@
 package com.webforj.component.html.elements;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import java.util.List;
@@ -15,11 +15,9 @@ class IframeTest {
   void shouldSetGetProperties() {
     Iframe component = new Iframe();
 
-    try {
+    assertDoesNotThrow(() -> {
       PropertyDescriptorTester.run(Iframe.class, component);
-    } catch (Exception e) {
-      fail("PropertyDescriptor test failed: " + e.getMessage());
-    }
+    });
   }
 
   @Test

--- a/webforj-components/webforj-html-elements/src/test/java/com/webforj/component/html/elements/ImgTest.java
+++ b/webforj-components/webforj-html-elements/src/test/java/com/webforj/component/html/elements/ImgTest.java
@@ -1,7 +1,7 @@
 package com.webforj.component.html.elements;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import org.junit.jupiter.api.Test;
@@ -30,10 +30,8 @@ class ImgTest {
   void shouldSetGetProperties() {
     Img component = new Img();
 
-    try {
+    assertDoesNotThrow(() -> {
       PropertyDescriptorTester.run(Img.class, component);
-    } catch (Exception e) {
-      fail("PropertyDescriptor test failed: " + e.getMessage());
-    }
+    });
   }
 }

--- a/webforj-components/webforj-icons/src/test/java/com/webforj/component/icons/IconTest.java
+++ b/webforj-components/webforj-icons/src/test/java/com/webforj/component/icons/IconTest.java
@@ -1,6 +1,6 @@
 package com.webforj.component.icons;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,11 +23,9 @@ class IconTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Icon.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 }

--- a/webforj-components/webforj-infinite-scroll/src/test/java/com/webforj/component/infinitescroll/InfiniteScrollTest.java
+++ b/webforj-components/webforj-infinite-scroll/src/test/java/com/webforj/component/infinitescroll/InfiniteScrollTest.java
@@ -1,9 +1,9 @@
 package com.webforj.component.infinitescroll;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -32,11 +32,9 @@ class InfiniteScrollTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(InfiniteScroll.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-loading/src/test/java/com/webforj/component/loading/LoadingTest.java
+++ b/webforj-components/webforj-loading/src/test/java/com/webforj/component/loading/LoadingTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.loading;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -44,11 +44,9 @@ class LoadingTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Loading.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-login/src/test/java/com/webforj/component/login/LoginTest.java
+++ b/webforj-components/webforj-login/src/test/java/com/webforj/component/login/LoginTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.login;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -35,13 +35,11 @@ class LoginTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Login.class, component, descriptor -> {
           return !Arrays.asList("opened", "disabled").contains(descriptor.getName());
         });
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-markdown-viewer/src/test/java/com/webforj/component/markdown/MarkdownViewerTest.java
+++ b/webforj-components/webforj-markdown-viewer/src/test/java/com/webforj/component/markdown/MarkdownViewerTest.java
@@ -1,9 +1,9 @@
 package com.webforj.component.markdown;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.element.PropertyDescriptorTester;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,11 +50,9 @@ class MarkdownViewerTest {
     @Test
     @DisplayName("should set and get properties")
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(MarkdownViewer.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 

--- a/webforj-components/webforj-refresher/src/test/java/com/webforj/component/refresher/RefresherTest.java
+++ b/webforj-components/webforj-refresher/src/test/java/com/webforj/component/refresher/RefresherTest.java
@@ -1,10 +1,10 @@
 package com.webforj.component.refresher;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import com.webforj.component.element.PropertyDescriptorTester;
 import com.webforj.component.icons.IconDefinition;
@@ -31,11 +31,9 @@ class RefresherTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Refresher.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-spinner/src/test/java/com/webforj/component/spinner/SpinnerTest.java
+++ b/webforj-components/webforj-spinner/src/test/java/com/webforj/component/spinner/SpinnerTest.java
@@ -1,7 +1,7 @@
 package com.webforj.component.spinner;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.webforj.component.Theme;
 import com.webforj.component.element.PropertyDescriptorTester;
@@ -61,11 +61,9 @@ class SpinnerTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Spinner.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 }

--- a/webforj-components/webforj-splitter/src/test/java/com/webforj/component/layout/splitter/SplitterTest.java
+++ b/webforj-components/webforj-splitter/src/test/java/com/webforj/component/layout/splitter/SplitterTest.java
@@ -1,10 +1,10 @@
 package com.webforj.component.layout.splitter;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -33,13 +33,11 @@ class SplitterTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Splitter.class, component, descriptor -> {
           return !Arrays.asList("positionRelative").contains(descriptor.getName());
         });
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-table/src/test/java/com/webforj/component/table/TableTest.java
+++ b/webforj-components/webforj-table/src/test/java/com/webforj/component/table/TableTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -61,14 +60,12 @@ class TableTest {
   class Properties {
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Table.class, component, descriptor -> {
           return !Arrays.asList("columnDefinitions", "data", "getRowId", "selected", "columnGroups")
               .contains(descriptor.getName());
         });
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-terminal/src/test/java/com/webforj/component/terminal/TerminalTest.java
+++ b/webforj-components/webforj-terminal/src/test/java/com/webforj/component/terminal/TerminalTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.terminal;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -35,11 +35,9 @@ class TerminalTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Terminal.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 

--- a/webforj-components/webforj-toast/src/test/java/com/webforj/component/toast/ToastTest.java
+++ b/webforj-components/webforj-toast/src/test/java/com/webforj/component/toast/ToastTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.toast;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -149,11 +149,9 @@ class ToastTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Toast.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
 
     @Test

--- a/webforj-components/webforj-toolbar/src/test/java/com/webforj/component/layout/toolbar/ToolbarTest.java
+++ b/webforj-components/webforj-toolbar/src/test/java/com/webforj/component/layout/toolbar/ToolbarTest.java
@@ -1,8 +1,8 @@
 package com.webforj.component.layout.toolbar;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import com.webforj.component.Component;
@@ -27,11 +27,9 @@ class ToolbarTest {
 
     @Test
     void shouldSetGetProperties() {
-      try {
+      assertDoesNotThrow(() -> {
         PropertyDescriptorTester.run(Toolbar.class, component);
-      } catch (Exception e) {
-        fail("PropertyDescriptor test failed: " + e.getMessage());
-      }
+      });
     }
   }
 


### PR DESCRIPTION
I replaced the try/catch + fail() around PropertyDescriptorTester.run in the webforj-components tests with assertDoesNotThrow.

Closes #1570
